### PR TITLE
Fix cleaning up server pids on container stops

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,4 +42,3 @@ RUN bundle install
 ADD . /app
 
 EXPOSE 3000
-CMD bundle exec rails s -p 3000 -b '0.0.0.0'

--- a/README.md
+++ b/README.md
@@ -107,15 +107,3 @@ And everything else is how you would normally develop in a rails project.
   docker-compose logs web
   ```
 - If your switching between docker-compose and local development on your machine, you may encounter in weird permissions on files that docker has created (logs/tmp/etc.). Simply just `sudo rm` them.
-
-- One common issue could be the webpage is not rendering when you go to [localhost:3000](http://localhost:3000). This probably a result of the server not being started due to a bad stop and exiting of the container from a previous run. This causes the server to leave a pid file in the tmp directory. To fix this, cleanup the pid file via:
-
-  ```shell
-  sudo rm -rf /tmp/pids/server.pid
-  ```
-
-  Then restart the server:
-    ```shell
-    docker-compose restart web
-    ```
-  (NOTE: we could add this pid removal to before the rails start command if this is a common issue? `command: bash -c "rm -f tmp/pids/* && bundle exec rails s -p 3000 -b '0.0.0.0'"`)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,6 +44,7 @@ services:
   web:
     build: .
     image: ualbertalib/jupiter
+    command: bash -c 'rm -f tmp/pids/server.pid && bundle exec rails s'
     environment:
       RAILS_ENV: development
       DATABASE_URL: 'mysql2://root:mysecretpassword@mysql/'
@@ -55,7 +56,7 @@ services:
       - .:/app
     ports:
       - "3000:3000"
-    links:
+    depends_on:
       - mysql
       - fcrepo
       - redis
@@ -65,16 +66,19 @@ services:
   # worker:
   #   build: .
   #   image: ualbertalib/jupiter
-  #   command: bundle exec rake environment resque:work QUEUE=*
+  #   command: bundle exec sidekiq
   #   environment:
   #     RAILS_ENV: development
-  #     DATABASE_URL: 'mysql2://:mysecretpassword@mysql/'
+  #     DATABASE_URL: 'mysql2://root:mysecretpassword@mysql/'
   #     FCREPO_URL: http://fcrepo:8080/fcrepo/rest
-  #     SOLR_URL: http://solr:8983/solr/jupiter
+  #     SOLR_URL: http://solr:8983/solr/development
+  #     SOLR_TEST_URL: http://solr:8983/solr/test
   #     REDIS_URL: 'redis://redis/1'
   #   volumes:
   #     - .:/app
-  #   links:
+  #   ports:
+  #     - "3000:3000"
+  #   depends_on:
   #     - mysql
   #     - fcrepo
   #     - redis

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,7 +44,7 @@ services:
   web:
     build: .
     image: ualbertalib/jupiter
-    command: bash -c 'rm -f tmp/pids/server.pid && bundle exec rails s'
+    command: bash -c 'rm -f tmp/pids/server.pid && bundle exec rails s -p 3000 -b "0.0.0.0"'
     environment:
       RAILS_ENV: development
       DATABASE_URL: 'mysql2://root:mysecretpassword@mysql/'


### PR DESCRIPTION
When stopping containers rails doesn't cleanup properly and leaves a pid file. This prevents docker from starting back up cleanly.

Uses solution from here: https://github.com/docker/compose/issues/1393#issuecomment-99988242
