### PR TITLE
A few hiccups and modifications to make development work via docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@
 .byebug_history
 .ruby-version
 .ruby-gemset
+
+/docker-compose.*custom*.yml
+vendor/bundle

--- a/README.md
+++ b/README.md
@@ -119,6 +119,8 @@ And everything else is how you would normally develop in a rails project.
   ```
 - If your switching between docker-compose and local development on your machine, you may encounter in weird permissions on files that docker has created (logs/tmp/etc.). Simply just `sudo rm` them.
 
+- If you would like to run MySQL in a container, but docker-compose reports that port 3306 is already in use, you likely have a MySQL instance already running on the host. You will need to shutdown MySQL before you can start the container. On Ubuntu, `sudo service mysql stop` on the host will do the trick. Another option is to configure docker and the rails app to look for MySQL using a different port.
+
 ## Configuring SAML
 
 * Update `secrets.yml` (and maybe `omniauth.rb`) for the SAML implementation (you may need to generate a certificate/key for certain environments)

--- a/config/database.yml
+++ b/config/database.yml
@@ -14,8 +14,8 @@ default: &default
   encoding: utf8
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   username: root
-  password: password
-  host: localhost
+  password: mysecretpassword
+  host: 127.0.0.1
 
 development:
   <<: *default

--- a/docker-compose.lightweight.yml
+++ b/docker-compose.lightweight.yml
@@ -22,7 +22,7 @@ services:
   #     MYSQL_ROOT_PASSWORD: mysecretpassword
   #   volumes:
   #     - mysql:/var/lib/mysql
-  #   port:
+  #   ports:
   #     - "3306:3306"
 
   solr:
@@ -46,6 +46,6 @@ services:
   #   image: redis:alpine
   #   volumes:
   #     - redis:/data
-  #   port:
+  #   ports:
   #     - "6379:6379"
 


### PR DESCRIPTION
These work better for me:

* Have git ignore vendor/bundle.
* Have git ignore any file matching docker-compose.*custom*.yml
  (I'd rather not modify the lightweight file directly as it's under
  revision control, so I copy it to match the pattern above).
* Change password in config/database.yml so that it matches the one
  in the docker-compose files (this lets it work better out of the box).
* Have rails look for the database on 127.0.0.1 instead of localhost.
  Using 127.0.0.1 will prevent MySQL from using a socket file, which
  it tries to do if you point it to localhost (causing a failure if
  MySQL is running in a container). This is a documented feature:
  https://dev.mysql.com/doc/refman/5.5/en/connecting.html
* Correct some commented-out typos in the docker-compose (should be
  "ports" not "port"
* Update the documentation about a potential issue when you are
  trying to run MySQL in a container, but you are already running
  MySQL on the host.