### PR TITLE
Add description to community, and other fixes

### DIFF
--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -38,7 +38,7 @@ class CollectionsController < ApplicationController
     @collection.unlock_and_fetch_ldp_object do |unlocked_collection|
       unlocked_collection.update!(permitted_attributes(Collection))
     end
-    flash[:notice] = I18n.t('application.collections.updated')
+    flash[:notice] = t('.updated')
     redirect_to admin_communities_and_collections_path
   end
 
@@ -47,9 +47,9 @@ class CollectionsController < ApplicationController
     authorize collection
     collection.unlock_and_fetch_ldp_object do |uo|
       if uo.destroy
-        flash[:notice] = I18n.t('application.collections.deleted')
+        flash[:notice] = t('.deleted')
       else
-        flash[:alert] = I18n.t('application.collections.not_empty_error')
+        flash[:alert] = t('.not_empty_error')
       end
 
       redirect_to admin_communities_and_collections_path

--- a/app/controllers/communities_controller.rb
+++ b/app/controllers/communities_controller.rb
@@ -42,7 +42,7 @@ class CommunitiesController < ApplicationController
     @community.unlock_and_fetch_ldp_object do |unlocked_community|
       unlocked_community.update!(permitted_attributes(Community))
     end
-    flash[:notice] = I18n.t('application.communities.updated')
+    flash[:notice] = t('.updated')
     redirect_to @community
   end
 
@@ -51,9 +51,9 @@ class CommunitiesController < ApplicationController
     authorize community
     community.unlock_and_fetch_ldp_object do |uo|
       if uo.destroy
-        flash[:notice] = I18n.t('application.communities.deleted')
+        flash[:notice] = t('.deleted')
       else
-        flash[:alert] = I18n.t('application.communities.not_empty_error')
+        flash[:alert] = t('.not_empty_error')
       end
 
       redirect_to admin_communities_and_collections_path

--- a/app/models/community.rb
+++ b/app/models/community.rb
@@ -1,6 +1,7 @@
 class Community < JupiterCore::LockedLdpObject
 
   has_attribute :title, ::RDF::Vocab::DC.title, solrize_for: [:search, :facet]
+  has_attribute :description, ::RDF::Vocab::DC.description, solrize_for: [:search]
 
   # this method can be used on the SolrCached object OR the ActiveFedora object
   def member_collections
@@ -9,6 +10,8 @@ class Community < JupiterCore::LockedLdpObject
 
   unlocked do
     before_destroy :can_be_destroyed?
+
+    validates :title, presence: true
 
     before_validation do
       self.visibility = JupiterCore::VISIBILITY_PUBLIC

--- a/app/views/communities/_form.html.erb
+++ b/app/views/communities/_form.html.erb
@@ -1,6 +1,7 @@
 <%= simple_form_for @community do |f| %>
   <div class="form-group">
     <%= f.input :title %>
+    <%= f.input :description %>
     <%= f.button :submit, class: 'btn btn-primary' %>
   </div>
 <% end %>

--- a/app/views/communities/show.html.erb
+++ b/app/views/communities/show.html.erb
@@ -1,6 +1,6 @@
 <h2 class="mt-3"><%= t('communities.title', title: @community.title) %></h2>
 
-<% if policy(@community).edit? || policy(@community).delete? %>
+<% if policy(@community).edit? || policy(@community).destroy? %>
   <div class="row mt-3" >
     <div class="col text-right" >
       <% if policy(@community).edit? %>
@@ -25,7 +25,7 @@
 
 <div class="row mt-3">
   <div class="col">
-    <h4>
+    <h4 class="collections-header">
       <% if @community.member_collections.count > 0 %>
         <%= t('.collections_list_header') %>
       <% else %>
@@ -33,10 +33,12 @@
       <% end %>
     </h4>
   </div>
-  <div class="col text-right">
-    <%= link_to t('.create_new_collection'), new_community_collection_path(@community),
-        class: 'btn btn-primary' %>
-  </div>
+  <% if policy(:collection).create? %>
+    <div class="col text-right">
+      <%= link_to t('.create_new_collection'), new_community_collection_path(@community),
+          class: 'btn btn-primary' %>
+    </div>
+  <% end %>
 </div>
 <% if @community.member_collections.count > 0 %>
   <div class="row mt-3">

--- a/app/views/communities/show.html.erb
+++ b/app/views/communities/show.html.erb
@@ -1,25 +1,52 @@
 <h2 class="mt-3"><%= t('communities.title', title: @community.title) %></h2>
+
+<% if policy(@community).edit? || policy(@community).delete? %>
+  <div class="row mt-3" >
+    <div class="col text-right" >
+      <% if policy(@community).edit? %>
+        <%= link_to t('.edit'), edit_community_path(@community), class:'btn btn-secondary' %>
+      <% end %>
+      <% if policy(@community).destroy? %>
+        <%= link_to t('.delete'), community_path(@community), method: :delete,
+            class:'btn btn-danger',
+            data: { confirm: t('.delete_confirm', title: @community.title) } %>
+        <% end %>
+    </div>
+  </div>
+<% end %>
+
+<div class="row mt-3">
+  <div class="col" >
+    <p>
+      <%= @community.description %>
+    </p>
+  </div>
+</div>
+
 <div class="row mt-3">
   <div class="col">
-    <div class="list-group">
+    <h4>
       <% if @community.member_collections.count > 0 %>
+        <%= t('.collections_list_header') %>
+      <% else %>
+        <%= t('.no_collections') %>
+      <% end %>
+    </h4>
+  </div>
+  <div class="col text-right">
+    <%= link_to t('.create_new_collection'), new_community_collection_path(@community),
+        class: 'btn btn-primary' %>
+  </div>
+</div>
+<% if @community.member_collections.count > 0 %>
+  <div class="row mt-3">
+    <div class="col">
+      <div class="list-group">
         <% @community.member_collections.each do |c| %>
           <%= link_to c.title, community_collection_path(@community.id, c),
               class: 'list-group-item list-group-item-action' %>
         <% end %>
-      <% else %>
-        <%= t('.no_collections') %>
-      <% end %>
-    </div>
-  </div>
-</div>
-
-<% if policy(:collection).create? %>
-  <div class="row mt-3" >
-    <div class="col" >
-      <%= link_to t('.create_new_collection'), new_community_collection_path(@community),
-          class: 'btn btn-primary' %>
-      <%= link_to t('.edit'), edit_community_path(@community), class:'btn btn-secondary' %>
+      </div>
     </div>
   </div>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -47,14 +47,6 @@ en:
         stop_impersonating: 'Stop Impersonating'
       user_dropdown:
         heading_html: "Signed in as <strong>%{name}</strong>"
-      communities:
-        updated: 'Community updated'
-        deleted: 'Community deleted'
-        not_empty_error: 'Cannot delete a non-empty Community'
-      collections:
-        updated: 'Collection updated'
-        deleted: 'Collection deleted'
-        not_empty_error: 'Cannot delete a non-empty Collection'
   sessions:
     new:
       header: 'Login to ERA'
@@ -105,14 +97,28 @@ en:
         search_placeholder: 'Search by email or name...'
         search_button: 'Search Users'
         header: 'Users'
+  collections:
+    destroy:
+      deleted: 'Collection deleted'
+      not_empty_error: 'Cannot delete a non-empty Collection'
+    update:
+      updated: 'Collection updated'
   communities:
+    destroy:
+      deleted: 'Community deleted'
+      not_empty_error: 'Cannot delete a non-empty Community'
     index:
       header: 'Communities'
       create_new_community: 'Create New Community'
     new:
-      header: 'Create Community'
+      header: 'Add New Community'
     show:
-      create_new_collection: 'Create New Collection'
+      collections_list_header: 'Collections in this Community'
+      create_new_collection: 'Add Collection'
+      delete: 'Delete'
+      delete_confirm: 'Are you sure you want to delete the community %{title}'
       edit: 'Edit'
       no_collections: 'There are no Collections in this Community'
+    update:
+      updated: 'Community updated'
     title: 'Community: %{title}'

--- a/test/integration/community_show_test.rb
+++ b/test/integration/community_show_test.rb
@@ -2,32 +2,28 @@ require 'test_helper'
 
 class CommunityShowTest < ActionDispatch::IntegrationTest
 
-  setup do
-    admin = users(:admin_user)
+  def before_all
+    super
 
     # TODO: setup proper fixtures for LockedLdpObjects
 
     # A community with two collections
-    @community1 = Community.new_locked_ldp_object(title: 'Two collection community',
-                                                  owner: admin.id)
-    @community1.unlock_and_fetch_ldp_object(&:save!)
-    @collection1 = Collection.new_locked_ldp_object(community_id: @community1.id,
-                                                    title: 'Nice collection',
-                                                    owner: admin.id)
-    @collection1.unlock_and_fetch_ldp_object(&:save!)
-    @collection2 = Collection.new_locked_ldp_object(community_id: @community1.id,
-                                                    title: 'Another collection',
-                                                    owner: admin.id)
-    @collection2.unlock_and_fetch_ldp_object(&:save!)
+    @community1 = Community
+                  .new_locked_ldp_object(title: 'Two collection community', owner: 1)
+                  .unlock_and_fetch_ldp_object(&:save!)
+    @collection1 = Collection
+                   .new_locked_ldp_object(community_id: @community1.id,
+                                          title: 'Nice collection', owner: 1)
+                   .unlock_and_fetch_ldp_object(&:save!)
+    @collection2 = Collection
+                   .new_locked_ldp_object(community_id: @community1.id,
+                                          title: 'Another collection', owner: 1)
+                   .unlock_and_fetch_ldp_object(&:save!)
 
     # A community with no collections
-    @community2 = Community.new_locked_ldp_object(title: 'Empty community',
-                                                  owner: admin.id)
-    @community2.unlock_and_fetch_ldp_object(&:save!)
-  end
-
-  teardown do
-    ActiveFedora::Cleaner.clean!
+    @community2 = Community
+                  .new_locked_ldp_object(title: 'Empty community', owner: 1)
+                  .unlock_and_fetch_ldp_object(&:save!)
   end
 
   test 'visiting the show page for a community with two collections as an admin' do

--- a/test/integration/community_show_test.rb
+++ b/test/integration/community_show_test.rb
@@ -1,0 +1,105 @@
+require 'test_helper'
+
+class CommunityShowTest < ActionDispatch::IntegrationTest
+
+  setup do
+    admin = users(:admin_user)
+
+    # TODO: setup proper fixtures for LockedLdpObjects
+
+    # A community with two collections
+    @community1 = Community.new_locked_ldp_object(title: 'Two collection community',
+                                                  owner: admin.id)
+    @community1.unlock_and_fetch_ldp_object(&:save!)
+    @collection1 = Collection.new_locked_ldp_object(community_id: @community1.id,
+                                                    title: 'Nice collection',
+                                                    owner: admin.id)
+    @collection1.unlock_and_fetch_ldp_object(&:save!)
+    @collection2 = Collection.new_locked_ldp_object(community_id: @community1.id,
+                                                    title: 'Another collection',
+                                                    owner: admin.id)
+    @collection2.unlock_and_fetch_ldp_object(&:save!)
+
+    # A community with no collections
+    @community2 = Community.new_locked_ldp_object(title: 'Empty community',
+                                                  owner: admin.id)
+    @community2.unlock_and_fetch_ldp_object(&:save!)
+  end
+
+  teardown do
+    ActiveFedora::Cleaner.clean!
+  end
+
+  test 'visiting the show page for a community with two collections as an admin' do
+    user = users(:admin)
+    sign_in_as user
+    get community_url(@community1)
+
+    # Community delete and edit should be shown
+    test_admin_links(true)
+
+    # Links to collections should be shown
+    test_collections_header(true)
+    test_no_collections_message(false)
+    test_collection_links(true)
+  end
+
+  test 'visiting the show page for a community with two collections as a regular user' do
+    user = users(:regular_user)
+    sign_in_as user
+    get community_url(@community1)
+
+    # Community delete and edit should not be shown
+    test_admin_links(false)
+
+    # Links to collections should be shown
+    test_collections_header(true)
+    test_no_collections_message(false)
+    test_collection_links(true)
+  end
+
+  test 'visiting a community with no collections' do
+    user = users(:admin)
+    sign_in_as user
+    get community_url(@community2)
+
+    # Links to collections should no be shown
+    test_collections_header(false)
+    test_no_collections_message(true)
+    test_collection_links(false)
+  end
+
+  private
+
+  def test_admin_links(true_false)
+    count = true_false ? 1 : 0
+    assert_select 'a[href=?]', community_path(@community1),
+                  text: 'Delete', count: count
+    assert_select 'a[href=?]', edit_community_path(@community1),
+                  text: 'Edit', count: count
+    assert_select 'a[href=?]', new_community_collection_path(@community1),
+                  text: 'Add Collection', count: count
+  end
+
+  def test_collections_header(true_false)
+    assert_select 'h4.collections-header',
+                  text: 'Collections in this Community', count: true_false ? 1 : 0
+  end
+
+  def test_no_collections_message(true_false)
+    assert_select 'h4.collections-header',
+                  text: 'There are no Collections in this Community',
+                  count: true_false ? 1 : 0
+  end
+
+  def test_collection_links(true_false)
+    assert_select 'div.list-group', true_false do
+      assert_select 'a[href=?]',
+                    community_collection_path(@community1, @collection1),
+                    text: @collection1.title
+      assert_select 'a[href=?]', community_collection_path(@community1, @collection2),
+                    text: @collection2.title
+    end
+  end
+
+end

--- a/test/models/community_test.rb
+++ b/test/models/community_test.rb
@@ -8,4 +8,9 @@ class CommunityTest < ActiveSupport::TestCase
     assert_equal c.visibility, JupiterCore::VISIBILITY_PUBLIC
   end
 
+  test 'needs title' do
+    c = Community.new_locked_ldp_object(owner: users(:admin).id)
+    assert !c.valid?
+  end
+
 end

--- a/test/models/community_test.rb
+++ b/test/models/community_test.rb
@@ -10,7 +10,7 @@ class CommunityTest < ActiveSupport::TestCase
 
   test 'needs title' do
     c = Community.new_locked_ldp_object(owner: users(:admin).id)
-    assert !c.valid?
+    refute c.valid?
   end
 
 end


### PR DESCRIPTION
This PR is part of issue #38. The community logo will be a separate PR.

Also within this PR:

* Add validation for presence of community title
* Make community#show view more closely resemble the mockup:
  https://jupiter.mybalsamiq.com/projects/jupiter/Admin%20-%20community%20detail%20page
* Fix for incorrectly-nested translations (also use lazy lookup)