### PR TITLE
updated readme, and added deploy.sh for ssh deployment of jupiter master

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,11 @@ By default, `rails test` will not run the system tests. To run them use:
 
 `$ bundle exec rake rerdoc`
 
+# UAT Environment 
 
+The UAT server is accessible on all library staff workstation, and through VPN on any external IP address.  More details regarding access and deployment can be found:
+[Jupiter UAT Setup](https://github.com/ualbertalib/di_internal/blob/master/System-Adminstration/UAT-Environment.md) 
+ 
 # Docker
 This project comes with a docker setup to easily setup your own local development environment for jupiter in just a few steps.
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,5 +1,8 @@
 cd /home/deploy/jupiter && git fetch --all && git reset --hard origin/master
-docker-compose -f /home/deploy/jupiter/docker-compose.deployment.yml stop web
+docker-compose -f /home/deploy/jupiter/docker-compose.deployment.yml down web
 docker rmi $(docker images -f "dangling=true" -q)
 docker-compose -f /home/deploy/jupiter/docker-compose.deployment.yml build web
 docker-compose -f /home/deploy/jupiter/docker-compose.deployment.yml up -d
+docker-compose -f /home/deploy/jupiter/docker-compose.deployment.yml run --rm web rake db:migrate
+#Recompile assets is optional, and can be commented out if not needed
+docker-compose -f /home/deploy/jupiter/docker-compose.deployment.yml run --rm web rake assets:precompile

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,5 +1,5 @@
-cd /home/deploy/jupiter && git pull origin master
-docker-compose -f /home/deploy/jupiter/docker-compose.deployment.yml rm -f -s -v
+cd /home/deploy/jupiter && git fetch --all && git reset --hard origin/master
+docker-compose -f /home/deploy/jupiter/docker-compose.deployment.yml stop web
 docker rmi $(docker images -f "dangling=true" -q)
 docker-compose -f /home/deploy/jupiter/docker-compose.deployment.yml build web
 docker-compose -f /home/deploy/jupiter/docker-compose.deployment.yml up -d

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,5 @@
+cd /home/deploy/jupiter && git pull origin master
+docker-compose -f /home/deploy/jupiter/docker-compose.deployment.yml rm -f -s -v
+docker rmi $(docker images -f "dangling=true" -q)
+docker-compose -f /home/deploy/jupiter/docker-compose.deployment.yml build web
+docker-compose -f /home/deploy/jupiter/docker-compose.deployment.yml up -d


### PR DESCRIPTION
The deploy.sh allows devs to do 
`ssh deploy@uatserver /home/deploy/jupiter/deploy.sh`