### PR TITLE
Use all the same headings for page headers (and fix broken system tests)

### DIFF
--- a/app/views/admin/communities_and_collections/index.html.erb
+++ b/app/views/admin/communities_and_collections/index.html.erb
@@ -5,7 +5,7 @@
   <li class="breadcrumb-item active"><%= t('.header') %></li>
 </ol>
 
-<h2><%= t('.header') %></h2>
+<h1><%= t('.header') %></h1>
 
 <div class="my-4" >
   <ul id="admin-collection-list" class="list-group">

--- a/app/views/admin/dashboard/index.html.erb
+++ b/app/views/admin/dashboard/index.html.erb
@@ -1,5 +1,5 @@
 <div class='admin-dashboard'>
-  <h2><%= t('.header') %></h2>
+  <h1><%= t('.header') %></h1>
 
   <hr/>
 

--- a/app/views/admin/site_notifications/new.html.erb
+++ b/app/views/admin/site_notifications/new.html.erb
@@ -6,7 +6,7 @@
 </ol>
 
 
-<h2><%= t('.header') %></h2>
+<h1><%= t('.header') %></h1>
   <%= simple_form_for [:admin, @new_notification] do |f| %>
     <%= f.input :message %>
     <%= f.button :submit, t('.new_button_text') %>

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -6,7 +6,7 @@
   <li class="breadcrumb-item active"><%= t('.header') %></li>
 </ol>
 
-<h2 class="my-3"><%= t('.header') %></h2>
+<h1 class="my-3"><%= t('.header') %></h1>
 
 <%= form_tag admin_users_path, method:'get' do %>
   <%# preserve previous sort params when submitting form %>

--- a/app/views/collections/show.html.erb
+++ b/app/views/collections/show.html.erb
@@ -1,8 +1,8 @@
 <% page_title(@collection.title) %>
 
-<h2 class="mt-3">
+<h1 class="mt-3">
     <%= t('.header', title: @collection.title) %>
-</h2>
+</h1>
 
 <% if policy(@collection).edit? %>
   <div class="d-flex justify-content-between mt-3">

--- a/app/views/communities/edit.html.erb
+++ b/app/views/communities/edit.html.erb
@@ -1,4 +1,4 @@
 <% page_title(t('communities.title', title: @community.title)) %>
 
-<h2 class="mt-3"><%= t('communities.title', title: @community.title) %></h2>
+<h1 class="mt-3"><%= t('communities.title', title: @community.title) %></h1>
 <%= render partial: 'form' %>

--- a/app/views/communities/index.html.erb
+++ b/app/views/communities/index.html.erb
@@ -1,6 +1,6 @@
 <% page_title(t('.header')) %>
 
-<h2 class="mt-3"><%= t('.header') %></h2>
+<h1 class="mt-3"><%= t('.header') %></h1>
 
 <div class="row mt-3">
   <div class="col">

--- a/app/views/communities/new.html.erb
+++ b/app/views/communities/new.html.erb
@@ -1,4 +1,4 @@
 <% page_title(t('.header')) %>
 
-<h2 class="mt-3"><%= t('.header') %></h2>
+<h1 class="mt-3"><%= t('.header') %></h1>
 <%= render partial: 'form' %>

--- a/app/views/communities/show.html.erb
+++ b/app/views/communities/show.html.erb
@@ -1,6 +1,6 @@
 <% page_title(t('communities.title', title: @community.title)) %>
 
-<h2 class="mt-3"><%= t('communities.title', title: @community.title) %></h2>
+<h1 class="mt-3"><%= t('communities.title', title: @community.title) %></h1>
 
 <% if policy(@community).edit? || policy(@community).destroy? %>
   <div class="row mt-3" >

--- a/app/views/works/edit.html.erb
+++ b/app/views/works/edit.html.erb
@@ -1,4 +1,4 @@
 <% page_title( t('.header')) %>
 
-<h2 class="mt-3"><%= t('.header') %></h2>
+<h1 class="mt-3"><%= t('.header') %></h1>
 <%= render partial: 'form', locals: {work: @work} %>

--- a/app/views/works/new.html.erb
+++ b/app/views/works/new.html.erb
@@ -1,4 +1,4 @@
 <% page_title( t('.header')) %>
 
-<h2 class="mt-3"><%= t('.header') %></h2>
+<h1 class="mt-3"><%= t('.header') %></h1>
 <%= render partial: 'form', locals: {work: @work} %>

--- a/app/views/works/search.html.erb
+++ b/app/views/works/search.html.erb
@@ -1,7 +1,7 @@
 <% page_title( t('.header')) %>
 
 <% if @results.count > 0 %>
-  <h2 class="mt-3"><%= t('.found_results', count: @results.count) %></h2>
+  <h1 class="mt-3"><%= t('.found_results', count: @results.count) %></h1>
   <div class="row mt-3">
     <div class="col-sm-2">
       <%= t('.refine_your_search') %>
@@ -33,5 +33,5 @@
     </div>
   </div>
 <% else %>
-  <h2 class="mt-3"><%= t('.no_results_found') %></h2>
+  <h1 class="mt-3"><%= t('.no_results_found') %></h1>
 <% end %>

--- a/app/views/works/show.html.erb
+++ b/app/views/works/show.html.erb
@@ -1,8 +1,8 @@
 <% page_title( t('.header', title: @work.title)) %>
 
-<h2 class="mt-3">
+<h1 class="mt-3">
   <%= t('.header', title: @work.title) %>
-</h2>
+</h1>
 <div class="row mt-3">
   <div class="col">
     <div class="list-group">

--- a/test/system/admin_users_test.rb
+++ b/test/system/admin_users_test.rb
@@ -11,7 +11,7 @@ class AdminUsersTest < ApplicationSystemTestCase
       click_link admin.name # opens user dropdown which has the admin link
       click_link I18n.t('application.navbar.links.admin')
 
-      assert_selector 'h1', text: I18n.t('admin.header')
+      assert_selector 'h1', text: I18n.t('admin.dashboard.index.header')
 
       click_link I18n.t('admin.users.index.header')
       assert_selector 'h1', text: I18n.t('admin.users.index.header')
@@ -39,7 +39,7 @@ class AdminUsersTest < ApplicationSystemTestCase
       click_link admin.name # opens user dropdown which has the admin link
       click_link I18n.t('application.navbar.links.admin')
 
-      assert_selector 'h1', text: I18n.t('admin.header')
+      assert_selector 'h1', text: I18n.t('admin.dashboard.index.header')
 
       click_link I18n.t('admin.users.index.header')
       assert_selector 'h1', text: I18n.t('admin.users.index.header')
@@ -67,7 +67,7 @@ class AdminUsersTest < ApplicationSystemTestCase
       click_link admin.name # opens user dropdown which has the admin link
       click_link I18n.t('application.navbar.links.admin')
 
-      assert_selector 'h1', text: I18n.t('admin.header')
+      assert_selector 'h1', text: I18n.t('admin.dashboard.index.header')
 
       click_link I18n.t('admin.users.index.header')
       assert_selector 'h1', text: I18n.t('admin.users.index.header')
@@ -138,7 +138,7 @@ class AdminUsersTest < ApplicationSystemTestCase
       click_link admin.name # opens user dropdown which has the admin link
       click_link I18n.t('application.navbar.links.admin')
 
-      assert_selector 'h1', text: I18n.t('admin.header')
+      assert_selector 'h1', text: I18n.t('admin.dashboard.index.header')
 
       click_link I18n.t('admin.users.index.header')
       assert_selector 'h1', text: I18n.t('admin.users.index.header')


### PR DESCRIPTION
We using h1's in some places and h2's in other places. Lets use the same everywhere.

Top heading of the page should be an H1 lesser headers should be h2-h4. (Why? Good for SEO and good for accessibility, etc)

If theses are too big we can change the base font to a smaller size or do something smarter like responsive fonts (or use some css to change it, etc.)