### PR TITLE
Fix a11y errors on wrong markup being nested in <ul> elements

### DIFF
--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -41,6 +41,12 @@ class CollectionsController < ApplicationController
       unlocked_collection.update!(permitted_attributes(Collection))
     end
     flash[:notice] = t('.updated')
+
+    # TODO: Needs to be rethinked (and destroy action for both communties and collections)
+    # You can access this from both admin communties and collections index as well as communities show page
+    # When your in communities show page and go to edit the collection this shouldn't be redirecting to
+    # the admin communities and collections index page, it should go back to the communities show page...no?
+    # Perhaps better to only allow this behaviour from admin communities and collections?
     redirect_to admin_communities_and_collections_path
   end
 

--- a/app/views/admin/communities_and_collections/index.html.erb
+++ b/app/views/admin/communities_and_collections/index.html.erb
@@ -33,9 +33,10 @@
             <%= link_to t('delete'), community_path(community), class: 'btn btn-danger', method: :delete, data: {confirm: t('.delete_confirm', title: community.title) } %>
           </div>
         </div>
+
+        <ul class="list-group mt-3" id="<%=community.id%>"></ul>
       </li>
 
-      <ul class="list-group" id="<%=community.id%>"></ul>
 
     <% end %>
   </ul>

--- a/app/views/admin/dashboard/index.html.erb
+++ b/app/views/admin/dashboard/index.html.erb
@@ -89,7 +89,7 @@
   <div class="row">
     <div class="col-md-6">
       <h4><%= t('.latest_works') %></h4>
-      <ul class="list-group">
+      <div class="list-group">
         <% @works.each do |work| %>
          <%# TODO: FIX links when work CRUD is completed %>
           <%= link_to work, class: "list-group-item list-group-item-action d-flex justify-content-between" do %>
@@ -101,7 +101,7 @@
             <% end %>
           <% end %>
         <% end %>
-      </ul>
+      </div>
     </div>
     <div class="col-md-6">
       <h4><%= t('.latest_users') %></h4>


### PR DESCRIPTION
Found small issue when playing around with a11y tools

Only `<li>` elements should be nested within `<ul> or <ol>` elements.

Also `TODO` a weird behavior in communties/collections and admin community and collection pages when editing/deleting stuff