### PR TITLE
Issue #127, many seeds.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,8 +40,8 @@ gem 'omniauth-saml'
 gem 'pundit'
 
 # Misc Utilities
-gem 'kaminari'
 gem 'faker'
+gem 'kaminari'
 
 group :development, :test do
   gem 'sdoc', require: false

--- a/Gemfile
+++ b/Gemfile
@@ -44,7 +44,6 @@ gem 'sidekiq', '~> 5.0'
 gem 'sinatra' # used by sidekiq/web
 
 # Misc Utilities
-gem 'faker'
 gem 'kaminari'
 
 group :development, :test do
@@ -57,6 +56,9 @@ group :development, :test do
   gem 'pry-rails'
 
   gem 'rubocop', require: false
+
+  # Seeds
+  gem 'faker', require: false
 end
 
 group :development do

--- a/Gemfile
+++ b/Gemfile
@@ -41,6 +41,7 @@ gem 'pundit'
 
 # Misc Utilities
 gem 'kaminari'
+gem 'faker'
 
 group :development, :test do
   gem 'sdoc', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -118,6 +118,8 @@ GEM
       sxp (~> 1.0)
     erubi (1.6.1)
     execjs (2.7.0)
+    faker (1.8.4)
+      i18n (~> 0.5)
     faraday (0.12.2)
       multipart-post (>= 1.2, < 3)
     faraday-encoding (0.0.4)
@@ -365,6 +367,7 @@ DEPENDENCIES
   binding_of_caller
   bootstrap (~> 4.0.0.beta)
   capybara (~> 2.13)
+  faker
   font-awesome-rails
   haikunator
   hydra-works

--- a/README.md
+++ b/README.md
@@ -23,6 +23,14 @@ By default, `rails test` will not run the system tests. To run them use:
 
 `$ bundle exec rails test:system`
 
+# Seed your development database
+
+`$ bundle exec rake db:seed`
+
+Please note that by default the seeding process will download community logos
+from the web. If you are not on a network, or otherwise wish to prevent this
+behaviour, please set the enviroment variable `SKIP_DOWNLOAD_COMMUNITY_LOGOS`.
+
 ***Note***: You may need chromedriver and perhaps a few other dependencies installed to run these system tests in selenium.
 
 # REGenerate Documentation

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -40,7 +40,7 @@ if Rails.env.development?
     # Attach logos, if possible
     filename = File.expand_path(Rails.root + "tmp/#{thing}.png")
     unless File.exist?(filename)
-      if ENV['DOWNLOAD_COMMUNITY_LOGOS'].present?
+      unless ENV['SKIP_DOWNLOAD_COMMUNITY_LOGOS'].present?
         set = (thing == 'cat') ? 'set4' : 'set1'
         url = Faker::Avatar.image(thing, "100x100", "png", set)
         File.open(filename, 'wb') do |fo|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -13,7 +13,7 @@ if Rails.env.development?
   puts 'Starting seeding of dev database...'
 
   # start fresh
-  User.destroy_all
+  [ SiteNotification, ActiveStorage::Blob, ActiveStorage::Attachment, Identity, User ].each(&:destroy_all)
   ActiveFedora::Cleaner.clean!
 
   # Seed an admin user
@@ -38,10 +38,8 @@ if Rails.env.development?
       if ENV['DOWNLOAD_COMMUNITY_LOGOS'].present?
         set = (thing == 'cat') ? 'set4' : 'set1'
         url = Faker::Avatar.image(thing, "100x100", "png", set)
-        unless File.exist?(filename)
-          File.open(filename, 'wb') do |fo|
-            fo.write open(url).read 
-          end
+        File.open(filename, 'wb') do |fo|
+          fo.write open(url).read
         end
       end
     end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -21,7 +21,7 @@ if Rails.env.development?
   admin.identities.create(provider: 'developer', uid: 'admin@ualberta.ca')
 
   # Seed a non-admin user
-  non_admin = User.create(name: 'Admin', email: 'non_admin@ualberta.ca', admin: false)
+  non_admin = User.create(name: 'Non-admin', email: 'non_admin@ualberta.ca', admin: false)
   non_admin.identities.create(provider: 'developer', uid: 'non_admin@ualberta.ca')
 
   [ "cat", "dog", "unicorn", "hamburger", "librarian"].each_with_index do |thing, idx|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -19,34 +19,60 @@ if Rails.env.development?
   admin = User.create(name: 'Admin', email: 'admin@ualberta.ca', admin: true)
   admin.identities.create(provider: 'developer', uid: 'admin@ualberta.ca')
 
-  # seed items for admin user
-  Item.new_locked_ldp_object(
-    owner: admin.id,
-    visibility: JupiterCore::VISIBILITY_PUBLIC,
-    title: 'Thesis about cats',
-    date_created: Time.zone.now.to_s # will not be required in future, probably will have a created_at field
-  ).unlock_and_fetch_ldp_object(&:save!)
+  [ "cat", "dog", "unicorn", "hamburger"].each_with_index do |thing, idx|
+    if idx % 2 == 0
+      title = "The department of #{thing.capitalize}"
+    else
+      title = "Special reports about #{thing.pluralize}"
+    end
+    community = Community.new_locked_ldp_object(
+      owner: admin.id,
+      title: title,
+      description: Faker::Lorem.sentence(20, false, 0).chop
+    ).unlock_and_fetch_ldp_object(&:save!)
 
-  Item.new_locked_ldp_object(
-    owner: admin.id,
-    visibility: JupiterCore::VISIBILITY_PUBLIC,
-    title: 'Thesis about dogs',
-    date_created: Time.zone.now.to_s
-  ).unlock_and_fetch_ldp_object(&:save!)
+    collection_first = collection_last = nil
+    [ "Theses about #{thing.pluralize}",
+      "The annals of '#{thing.capitalize} International'"].each do |title|
+      collection = Collection.new_locked_ldp_object(
+        owner: admin.id,
+        title: title,
+        community_id: community.id
+      ).unlock_and_fetch_ldp_object(&:save!)
 
-  Item.new_locked_ldp_object(
-    owner: admin.id,
-    visibility: JupiterCore::VISIBILITY_PUBLIC,
-    title: 'Report about stock markets',
-    date_created: Time.zone.now.to_s
-  ).unlock_and_fetch_ldp_object(&:save!)
+      collection_first ||= collection
+      collection_last = collection
 
-  Item.new_locked_ldp_object(
-    owner: admin.id,
-    visibility: JupiterCore::VISIBILITY_PUBLIC,
-    title: 'Random images',
-    date_created: Time.zone.now.to_s
-  ).unlock_and_fetch_ldp_object(&:save!)
+      (0..20).each do
+        Item.new_locked_ldp_object(
+          owner: admin.id,
+          visibility: JupiterCore::VISIBILITY_PUBLIC,
+          title: "The effects of #{Faker::Beer.name} on #{thing.pluralize}",
+          description: Faker::Lorem.sentence(20, false, 0).chop,
+          # will not be required in future, probably will have a created_at field
+          date_created: Time.zone.now.to_s
+        ).unlock_and_fetch_ldp_object do |uo|
+          uo.add_to_path(community.id, collection.id)
+          uo.save!
+        end
+      end
+    end
+
+    # Want one multi-collection item per community
+    Item.new_locked_ldp_object(
+      owner: admin.id,
+      visibility: JupiterCore::VISIBILITY_PUBLIC,
+      title: "Multi-collection random images of #{thing.pluralize}",
+      description: Faker::Lorem.sentence(20, false, 0).chop,
+      # will not be required in future, probably will have a created_at field
+      date_created: Time.zone.now.to_s
+    ).unlock_and_fetch_ldp_object do |uo|
+      uo.add_to_path(community.id, collection_first.id)
+      uo.add_to_path(community.id, collection_last.id)
+      uo.save!
+    end
+  end
 
   puts 'Database seeded successfully!'
 end
+

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -19,7 +19,7 @@ if Rails.env.development?
   admin = User.create(name: 'Admin', email: 'admin@ualberta.ca', admin: true)
   admin.identities.create(provider: 'developer', uid: 'admin@ualberta.ca')
 
-  [ "cat", "dog", "unicorn", "hamburger"].each_with_index do |thing, idx|
+  [ "cat", "dog", "unicorn", "hamburger", "librarian"].each_with_index do |thing, idx|
     if idx % 2 == 0
       title = "The department of #{thing.capitalize}"
     else

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -58,7 +58,8 @@ if Rails.env.development?
       collection = Collection.new_locked_ldp_object(
         owner: admin.id,
         title: title,
-        community_id: community.id
+        community_id: community.id,
+        description: Faker::Lorem.sentence(40, false, 0).chop
       ).unlock_and_fetch_ldp_object(&:save!)
 
       collection_first ||= collection

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -9,6 +9,7 @@
 if Rails.env.development?
   require 'active_fedora/cleaner'
   require "open-uri"
+  require 'faker'
 
   puts 'Starting seeding of dev database...'
 


### PR DESCRIPTION
Adds 5 communities, 2 collections per community, and about 25 items per collection:

Each collection has:

* A Multi-collection item
* A private item
* An item owned by non-admin
* A currently embargoed item
* A formerly embargoed item
* 20 regular, public, admin-owned items

These have obvious names:

![seeds1](https://user-images.githubusercontent.com/672104/30454187-aba537ec-9958-11e7-8eb4-0987f7e976ea.png)

Setting env variable `DOWNLOAD_COMMUNITY_LOGOS` will grab some logos off the web using Faker gem (if they don't exist already in the `tmp` folder):

![seeds2](https://user-images.githubusercontent.com/672104/30454314-167384ca-9959-11e7-9237-9f2c27909405.png)
