### PR TITLE
Issue #119, remove redundant word from headers

### DIFF
--- a/app/views/collections/show.html.erb
+++ b/app/views/collections/show.html.erb
@@ -10,9 +10,7 @@
 </div>
 
 <div class="d-flex justify-content-between mt-3">
-  <h1>
-    <%= t('.header', title: @collection.title) %>
-  </h1>
+  <h1><%= @collection.title %></h1>
 
   <%# "align-self-center" stops buttons from growing to size of H1 in this flexbox %>
   <div class="btn-group align-self-center">
@@ -30,7 +28,7 @@
   </div>
 </div>
 
-<h5 class="items-header">
+<h5 class="items-header p-3">
   <%= t('.items_list_header') %>
 </h5>
 

--- a/app/views/communities/show.html.erb
+++ b/app/views/communities/show.html.erb
@@ -1,4 +1,4 @@
-<% page_title(t('communities.title', title: @community.title)) %>
+<% page_title(@community.title) %>
 
 <h1 class="mt-3"><%= @community.title %></h1>
 

--- a/app/views/communities/show.html.erb
+++ b/app/views/communities/show.html.erb
@@ -1,6 +1,6 @@
 <% page_title(t('communities.title', title: @community.title)) %>
 
-<h1 class="mt-3"><%= t('communities.title', title: @community.title) %></h1>
+<h1 class="mt-3"><%= @community.title %></h1>
 
 <% if policy(@community).edit? || policy(@community).destroy? %>
   <div class="row mt-3" >
@@ -20,12 +20,12 @@
   </div>
 <% end %>
 
-<div class="row mt-3">
-  <div class="col-md-2" >
+<div class="d-flex justify-content-between m-3">
+  <div class="p-3 align-self-center">
     <%= render partial: 'logo' %>
   </div>
 
-  <div class="col" >
+  <div class="p-3 align-self-center">
     <p>
       <%= @community.description %>
     </p>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -1,8 +1,7 @@
 <% page_title( t('.header', title: @item.title)) %>
 
-<h1 class="mt-3">
-  <%= t('.header', title: @item.title) %>
-</h1>
+<h1 class="mt-3"><%= @item.title %></h1>
+
 <div class="row mt-3">
   <div class="col">
     <div class="list-group">

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -1,4 +1,4 @@
-<% page_title( t('.header', title: @item.title)) %>
+<% page_title(@item.title) %>
 
 <h1 class="mt-3"><%= @item.title %></h1>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -178,7 +178,6 @@ en:
       header: 'Create Collection'
     show:
       delete_confirm: 'Are you sure you want to delete collection "%{title}"?'
-      header: "Collection: %{title}"
       parent_community: "Parent Community: %{title}"
       items_list_header: 'Items in this Collection'
       no_items_in_collection: 'There are no items in this Collection'
@@ -222,7 +221,6 @@ en:
     edit:
       header: 'Edit Item'
     show:
-      header: "Item: %{title}"
       member_of: 'Member of'
       contain_files: 'Contains files'
       fileset: 'FileSet'


### PR DESCRIPTION
The labels "Community:", "Collection:" and "Item:" are removed from page headers (but not page titles).
Also did a bit of spacing/indenting tweaks on Collection/Community pages (e.g., community logo). Here are before/after screenshots showing tweaks:

![community-tweak](https://user-images.githubusercontent.com/672104/30392721-deab485e-987a-11e7-8073-d470458a070c.png)

![collection-tweak](https://user-images.githubusercontent.com/672104/30392737-e4ea4e68-987a-11e7-94c7-e6806eb7d06a.png)
