### PR TITLE
Fix collections and communities forms

### DIFF
--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -1,6 +1,6 @@
 class CollectionsController < ApplicationController
 
-  before_action -> { authorize :application, :admin? }, except: [:index, :show]
+  before_action -> { authorize :application, :admin? }, except: [:show]
 
   def show
     @collection = Collection.find(params[:id])
@@ -25,7 +25,7 @@ class CollectionsController < ApplicationController
       if unlocked_collection.save
         redirect_to community_collection_path(@community, @collection), notice: t('.created')
       else
-        render :new
+        render :new, status: :bad_request
       end
     end
   end
@@ -52,7 +52,7 @@ class CollectionsController < ApplicationController
         # Perhaps better to only allow this behaviour from admin communities and collections?
         redirect_to admin_communities_and_collections_path, notice: t('.updated')
       else
-        render :edit
+        render :edit, status: :bad_request
       end
     end
   end

--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -16,15 +16,18 @@ class CollectionsController < ApplicationController
 
   def create
     @collection =
-      Collection.new_locked_ldp_object(permitted_attributes(Collection)
-                                        .merge(owner: current_user&.id))
-    authorize @collection
-    @collection.unlock_and_fetch_ldp_object(&:save!)
+      Collection.new_locked_ldp_object(permitted_attributes(Collection).merge(owner: current_user&.id))
 
+    authorize @collection
     @community = Community.find(params[:community_id])
 
-    # TODO: success flash message?
-    redirect_to community_collection_path(@community, @collection)
+    @collection.unlock_and_fetch_ldp_object do |unlocked_collection|
+      if unlocked_collection.save
+        redirect_to community_collection_path(@community, @collection), notice: t('.created')
+      else
+        render :new
+      end
+    end
   end
 
   def edit
@@ -37,24 +40,28 @@ class CollectionsController < ApplicationController
   def update
     @collection = Collection.find(params[:id])
     authorize @collection
-    @collection.unlock_and_fetch_ldp_object do |unlocked_collection|
-      unlocked_collection.update!(permitted_attributes(Collection))
-    end
-    flash[:notice] = t('.updated')
 
-    # TODO: Needs to be rethinked (and destroy action for both communties and collections)
-    # You can access this from both admin communties and collections index as well as communities show page
-    # When your in communities show page and go to edit the collection this shouldn't be redirecting to
-    # the admin communities and collections index page, it should go back to the communities show page...no?
-    # Perhaps better to only allow this behaviour from admin communities and collections?
-    redirect_to admin_communities_and_collections_path
+    @community = Community.find(params[:community_id])
+    @collection.unlock_and_fetch_ldp_object do |unlocked_collection|
+      if unlocked_collection.update(permitted_attributes(Collection))
+
+        # TODO: Needs to be rethinked (and destroy action for both communties and collections)
+        # You can access this from both admin communties and collections index as well as communities show page
+        # When your in communities show page and go to edit the collection this shouldn't be redirecting to
+        # the admin communities and collections index page, it should go back to the communities show page...no?
+        # Perhaps better to only allow this behaviour from admin communities and collections?
+        redirect_to admin_communities_and_collections_path, notice: t('.updated')
+      else
+        render :edit
+      end
+    end
   end
 
   def destroy
     collection = Collection.find(params[:id])
     authorize collection
-    collection.unlock_and_fetch_ldp_object do |uo|
-      if uo.destroy
+    collection.unlock_and_fetch_ldp_object do |unlocked_collection|
+      if unlocked_collection.destroy
         flash[:notice] = t('.deleted')
       else
         flash[:alert] = t('.not_empty_error')

--- a/app/controllers/communities_controller.rb
+++ b/app/controllers/communities_controller.rb
@@ -31,35 +31,41 @@ class CommunitiesController < ApplicationController
       Community.new_locked_ldp_object(permitted_attributes(Community)
                                        .merge(owner: current_user&.id))
     authorize @community
-    @community.unlock_and_fetch_ldp_object(&:save!)
     if params[:community][:logo].present?
       @community.logo.attach(params[:community][:logo])
     end
-
-    # TODO: success flash message?
-    redirect_to @community
+    @community.unlock_and_fetch_ldp_object do |unlocked_community|
+      if unlocked_community.save
+        redirect_to @community, notice: t('.created')
+      else
+        render :new
+      end
+    end
   end
 
   def update
     @community = Community.find(params[:id])
     authorize @community
-    @community.unlock_and_fetch_ldp_object do |unlocked_community|
-      unlocked_community.update!(permitted_attributes(Community))
-    end
+
     if params[:community][:logo].present?
       # Note: monkey patch to ActiveStorage removes any previous versions
       @community.logo.attach(params[:community][:logo])
     end
 
-    flash[:notice] = t('.updated')
-    redirect_to @community
+    @community.unlock_and_fetch_ldp_object do |unlocked_community|
+      if unlocked_community.update(permitted_attributes(Community))
+        redirect_to @community, notice: t('.updated')
+      else
+        render :edit
+      end
+    end
   end
 
   def destroy
     community = Community.find(params[:id])
     authorize community
-    community.unlock_and_fetch_ldp_object do |uo|
-      if uo.destroy
+    community.unlock_and_fetch_ldp_object do |unlocked_community|
+      if unlocked_community.destroy
         flash[:notice] = t('.deleted')
       else
         flash[:alert] = t('.not_empty_error')

--- a/app/controllers/communities_controller.rb
+++ b/app/controllers/communities_controller.rb
@@ -38,7 +38,7 @@ class CommunitiesController < ApplicationController
       if unlocked_community.save
         redirect_to @community, notice: t('.created')
       else
-        render :new
+        render :new, status: :bad_request
       end
     end
   end
@@ -56,7 +56,7 @@ class CommunitiesController < ApplicationController
       if unlocked_community.update(permitted_attributes(Community))
         redirect_to @community, notice: t('.updated')
       else
-        render :edit
+        render :edit, status: :bad_request
       end
     end
   end

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -26,6 +26,8 @@ class Collection < JupiterCore::LockedLdpObject
   unlocked do
     before_destroy :can_be_destroyed?
 
+    validates :title, presence: true
+
     before_validation do
       self.visibility = JupiterCore::VISIBILITY_PUBLIC
     end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -170,14 +170,16 @@ en:
     index:
       header: 'Collections'
     destroy:
-      deleted: 'Collection deleted'
+      deleted: 'Collection was successfully deleted!'
       not_empty_error: 'Cannot delete a non-empty Collection'
     update:
-      updated: 'Collection updated'
+      updated: 'Collection was successfully updated!'
     edit:
       header: 'Edit Collection'
     new:
       header: 'Create Collection'
+    create:
+      created: 'Collection was successfully created!'
     show:
       header: "Collection: %{title}"
       parent_community: "Parent Community: %{title}"
@@ -198,6 +200,8 @@ en:
       has_no_logo: 'Community has no logo'
     new:
       header: 'Add New Community'
+    create:
+      created: 'Community was successfully created!'
     show:
       collections_list_header: 'Collections in this Community'
       create_new_collection: 'Add Collection'
@@ -206,7 +210,7 @@ en:
       edit: 'Edit'
       no_collections: 'There are no Collections in this Community'
     update:
-      updated: 'Community updated'
+      updated: 'Community was successfully updated!'
     title: 'Community: %{title}'
     errors:
       member_collections_must_be_empty: "must be empty. Currently: %{list_of_collections}"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,7 @@ Rails.application.routes.draw do
   end
 
   resources :communities do
-    resources :collections
+    resources :collections, except: [:index]
   end
 
   namespace :admin, constraints: AdminConstraint.new do

--- a/test/controllers/collections_controller_test.rb
+++ b/test/controllers/collections_controller_test.rb
@@ -20,22 +20,35 @@ class CollectionsControllerTest < ActionDispatch::IntegrationTest
 
   # Note: this controller has no #index action
 
+  test 'should show collection' do
+    get community_collection_url(@community, @collection)
+    assert_response :success
+  end
+
   test 'should get new' do
     get new_community_collection_url(@community)
     assert_response :success
   end
 
-  test 'should create collection' do
-    assert_difference('Collection.count') do
-      post community_collections_url(@community),
-           params: { collection: { title: 'New collection' } }
-    end
-    assert_redirected_to community_collection_url(@community, Collection.last)
-  end
+  context '#create' do
+    should 'create collection when given valid information' do
+      assert_difference('Collection.count', +1) do
+        post community_collections_url(@community),
+             params: { collection: { title: 'New collection' } }
+      end
 
-  test 'should show collection' do
-    get community_collection_url(@community, @collection)
-    assert_response :success
+      assert_redirected_to community_collection_url(@community, Collection.last)
+      assert_equal I18n.t('collections.create.created'), flash[:notice]
+    end
+
+    should 'not create collection when given invalid information' do
+      assert_no_difference('Collection.count') do
+        post community_collections_url(@community),
+             params: { collection: { title: '' } }
+      end
+
+      assert_response :bad_request
+    end
   end
 
   test 'should get edit' do
@@ -43,25 +56,61 @@ class CollectionsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
-  test 'should update collection' do
-    patch community_collection_url(@community, @collection),
-          params: { collection: { title: 'Updated collection' } }
-    # TODO: do smart routing based on the path that got us here
-    # assert_redirected_to collection_url(@collection)
-    assert_redirected_to admin_communities_and_collections_url
-  end
+  context '#update' do
+    should 'update collection when given valid information' do
+      patch community_collection_url(@community, @collection),
+            params: { collection: { title: 'Updated collection' } }
 
-  test 'should destroy collection' do
-    community = Community.new_locked_ldp_object(title: 'Nice community',
-                                                owner: 1).unlock_and_fetch_ldp_object(&:save!)
-    collection = Collection.new_locked_ldp_object(community_id: @community.id,
-                                                  title: 'Nice collection',
-                                                  owner: 1).unlock_and_fetch_ldp_object(&:save!)
-    assert_difference('Collection.count', -1) do
-      delete community_collection_url(community, collection)
+      assert_redirected_to admin_communities_and_collections_url
+      assert_equal I18n.t('collections.update.updated'), flash[:notice]
     end
 
-    assert_redirected_to admin_communities_and_collections_url
+    should 'not update collection when given invalid information' do
+      patch community_collection_url(@community, @collection),
+            params: { collection: { title: '' } }
+
+      assert_response :bad_request
+    end
+  end
+
+  context '#destroy' do
+    should 'destroy collection if has no items' do
+      community = Community.new_locked_ldp_object(
+        title: 'Nice community',
+        owner: 1
+      ).unlock_and_fetch_ldp_object(&:save!)
+
+      collection = Collection.new_locked_ldp_object(
+        community_id: @community.id,
+        title: 'Nice collection',
+        owner: 1
+      ).unlock_and_fetch_ldp_object(&:save!)
+
+      assert_difference('Collection.count', -1) do
+        delete community_collection_url(community, collection)
+      end
+
+      assert_redirected_to admin_communities_and_collections_url
+      assert_equal I18n.t('collections.destroy.deleted'), flash[:notice]
+    end
+
+    should 'not destroy collection if has items' do
+      # Give the collection an item
+      Item.new_locked_ldp_object(
+        owner: 1,
+        visibility: JupiterCore::VISIBILITY_PRIVATE
+      ).unlock_and_fetch_ldp_object do |unlocked_item|
+        unlocked_item.add_to_path(@community.id, @collection.id)
+        unlocked_item.save!
+      end
+
+      assert_no_difference('Collection.count') do
+        delete community_collection_url(@community, @collection)
+      end
+
+      assert_redirected_to admin_communities_and_collections_url
+      assert_equal I18n.t('collections.destroy.not_empty_error'), flash[:alert]
+    end
   end
 
 end

--- a/test/controllers/communities_controller_test.rb
+++ b/test/controllers/communities_controller_test.rb
@@ -103,6 +103,4 @@ class CommunitiesControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
-
-
 end

--- a/test/controllers/communities_controller_test.rb
+++ b/test/controllers/communities_controller_test.rb
@@ -18,22 +18,35 @@ class CommunitiesControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  test 'should show community' do
+    get community_url(@community)
+    assert_response :success
+  end
+
   test 'should get new' do
     get new_community_url
     assert_response :success
   end
 
-  test 'should create community' do
-    assert_difference('Community.count') do
-      post communities_url, params: { community: { title: 'New community' } }
+  context '#create' do
+    should 'create community when given valid information' do
+      assert_difference('Community.count', +1) do
+        post communities_url,
+             params: { community: { title: 'New community' } }
+      end
+
+      assert_redirected_to community_url(Community.last)
+      assert_equal I18n.t('communities.create.created'), flash[:notice]
     end
 
-    assert_redirected_to community_url(Community.last)
-  end
+    should 'not create community when given invalid information' do
+      assert_no_difference('Community.count') do
+        post communities_url,
+             params: { community: { title: '' } }
+      end
 
-  test 'should show community' do
-    get community_url(@community)
-    assert_response :success
+      assert_response :bad_request
+    end
   end
 
   test 'should get edit' do
@@ -41,19 +54,55 @@ class CommunitiesControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
-  test 'should update community' do
-    patch community_url(@community), params: { community: { title: 'Updated community' } }
-    assert_redirected_to community_url(@community)
-  end
+  context '#update' do
+    should 'update community when given valid information' do
+      patch community_url(@community),
+            params: { community: { title: 'Updated community' } }
 
-  test 'should destroy community' do
-    community = Community.new_locked_ldp_object(title: 'Delete me',
-                                                owner: users(:admin).id).unlock_and_fetch_ldp_object(&:save!)
-    assert_difference('Community.count', -1) do
-      delete community_url(community)
+      assert_redirected_to community_url(@community)
+      assert_equal I18n.t('communities.update.updated'), flash[:notice]
     end
 
-    assert_redirected_to admin_communities_and_collections_url
+    should 'not update community when given invalid information' do
+      patch community_url(@community),
+            params: { community: { title: '' } }
+
+      assert_response :bad_request
+    end
   end
+
+  context '#destroy' do
+    should 'destroy collection if has no items' do
+      community = Community.new_locked_ldp_object(
+        title: 'Nice community',
+        owner: 1
+      ).unlock_and_fetch_ldp_object(&:save!)
+
+      assert_difference('Community.count', -1) do
+        delete community_url(community)
+      end
+
+      assert_redirected_to admin_communities_and_collections_url
+      assert_equal I18n.t('communities.destroy.deleted'), flash[:notice]
+    end
+
+    should 'not destroy collection if has items' do
+      # Give the community a collection
+      Collection.new_locked_ldp_object(
+        community_id: @community.id,
+        title: 'Nice collection',
+        owner: 1
+      ).unlock_and_fetch_ldp_object(&:save!)
+
+      assert_no_difference('Collection.count') do
+        delete community_url(@community)
+      end
+
+      assert_redirected_to admin_communities_and_collections_url
+      assert_equal I18n.t('communities.destroy.not_empty_error'), flash[:alert]
+    end
+  end
+
+
 
 end

--- a/test/models/collection_test.rb
+++ b/test/models/collection_test.rb
@@ -2,6 +2,12 @@ require 'test_helper'
 
 class CollectionTest < ActiveSupport::TestCase
 
+  test 'needs title' do
+    c = Collection.new_locked_ldp_object(owner: users(:admin).id)
+    refute c.valid?
+    assert_equal "Title can't be blank", c.errors.full_messages.first
+  end
+
   test 'visibility callback' do
     c = Collection.new_locked_ldp_object(title: 'foo', owner: users(:regular_user).id)
     assert c.valid?

--- a/test/models/community_test.rb
+++ b/test/models/community_test.rb
@@ -13,6 +13,7 @@ class CommunityTest < ActiveSupport::TestCase
   test 'needs title' do
     c = Community.new_locked_ldp_object(owner: users(:admin).id)
     refute c.valid?
+    assert_equal "Title can't be blank", c.errors.full_messages.first
   end
 
   test 'a logo can be attached' do


### PR DESCRIPTION
Previous communities forms would simply just 500 with an error. And collections would just create an empty collection object without a title. This fixes this.

More PRs coming regarding, reversing the admin communities and collections and how regular community/collection works with regarding to create/update/delete. Also fixing of Items form from crashing like these.