### PR TITLE
fix precompile with dummy keys and add shared volumes within containers

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,5 @@
 tmp/*
+!tmp/pids/*
 log/*
 .git/*
 *.md

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,5 @@
 tmp/*
-!tmp/pids/*
+!tmp/pids/.keep
 log/*
 .git/*
 *.md

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@
 /docs/rdoc/*
 /coverage/*
 /tmp/*
+#!/tmp/pids
+!/tmp/pids/.keep
 !/log/.keep
 !/tmp/.keep
 

--- a/Dockerfile.deployment
+++ b/Dockerfile.deployment
@@ -44,6 +44,8 @@ RUN bundle install --without development test
 COPY . $APP_ROOT
 
 # Precompile Rails assets. We set a dummy secret key
+ENV DATABASE_URL mysql2:assets_throwaway.db
+ENV  SECRET_KEY_BASE thisisatopsecret
 RUN RAILS_ENV=uat bundle exec rake assets:precompile
 
 EXPOSE 3000

--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -23,8 +23,8 @@ server {
  
     proxy_pass http://jupiter;
     # limit_req zone=one;
-    access_log /app/log/nginx.access.log;
-    error_log /app/log/nginx.error.log;
+    access_log /var/log/nginx.access.log;
+    error_log /var/log/nginx.error.log;
   }
  
   location ^~ /assets/ {

--- a/docker-compose.deployment.yml
+++ b/docker-compose.deployment.yml
@@ -9,7 +9,6 @@ volumes:
     driver: local
   redis:
     driver: local
-  approot:
 
 services:
   mysql:
@@ -53,8 +52,6 @@ services:
     image: ualbertalib/jupiter:deployment
     command: bundle exec sidekiq
     env_file: .env_deployment
-    volumes:
-      - approot:/app
     depends_on:
       - mysql
       - fcrepo
@@ -76,6 +73,5 @@ services:
     env_file: .env_deployment
     volumes:
       - ./config/nginx.conf:/etc/nginx/conf.d/default.conf
-      - approot:/app
     ports:
       - "80:80"

--- a/docker-compose.deployment.yml
+++ b/docker-compose.deployment.yml
@@ -9,6 +9,7 @@ volumes:
     driver: local
   redis:
     driver: local
+  approot:
 
 services:
   mysql:
@@ -49,12 +50,11 @@ services:
   # Sidekiq
   worker: &rails
     restart: always
-    build:
-      context: .
-      dockerfile: Dockerfile.deployment
-    image: ualbertalib/jupiter
+    image: ualbertalib/jupiter:deployment
     command: bundle exec sidekiq
     env_file: .env_deployment
+    volumes:
+      - approot:/app
     depends_on:
       - mysql
       - fcrepo
@@ -76,5 +76,6 @@ services:
     env_file: .env_deployment
     volumes:
       - ./config/nginx.conf:/etc/nginx/conf.d/default.conf
+      - approot:/app
     ports:
       - "80:80"


### PR DESCRIPTION
-  use dummy keys for assets precompile in Dockerfile
-  allow shared volume in web, nginx and worker containers 
-  remove building images and will use dockerhub autobuilt images instead. 