### PR TITLE
Populate the 'visibility' field on Item edit form.

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -3,6 +3,7 @@ class Item < JupiterCore::LockedLdpObject
   ldp_object_includes Hydra::Works::WorkBehavior
 
   VISIBILITY_EMBARGO = 'embargo'.freeze
+  VISIBILITIES = (JupiterCore::VISIBILITIES + [VISIBILITY_EMBARGO]).freeze
 
   has_attribute :title, ::RDF::Vocab::DC.title, solrize_for: [:search, :facet, :sort]
   has_attribute :subject, ::RDF::Vocab::DC.subject, solrize_for: [:search, :facet]

--- a/app/models/jupiter_core/locked_ldp_object.rb
+++ b/app/models/jupiter_core/locked_ldp_object.rb
@@ -12,6 +12,8 @@ module JupiterCore
   VISIBILITY_PRIVATE = 'private'.freeze
   VISIBILITY_AUTHENTICATED = 'authenticated'.freeze
 
+  VISIBILITIES = [VISIBILITY_PUBLIC, VISIBILITY_PRIVATE, VISIBILITY_AUTHENTICATED].freeze
+
   class LockedLdpObject
 
     include ActiveModel::Model

--- a/app/views/items/_form.html.erb
+++ b/app/views/items/_form.html.erb
@@ -5,7 +5,7 @@
   <% end %>
   <%= f.input :visibility,
     as: :unread_select,
-    collection: ['public', 'private', 'authenticated'],
+    collection: Item::VISIBILITIES,
     selected: item.visibility,
     input_html: { name: 'item[visibility]' }
   %>

--- a/app/views/items/_form.html.erb
+++ b/app/views/items/_form.html.erb
@@ -4,9 +4,10 @@
     <%= f.input prop %>
   <% end %>
   <%= f.input :visibility,
-  as: :unread_select,
-  collection: ['public', 'private', 'authenticated'],
-  input_html: {name: 'item[visibility]'}
+    as: :unread_select,
+    collection: ['public', 'private', 'authenticated'],
+    selected: item.visibility,
+    input_html: { name: 'item[visibility]' }
   %>
   <%= f.input :community,
     as: :unread_select,


### PR DESCRIPTION
App was not filling in visibility correctly when editing an item, now it does. Although the current form doesn't seem to have an 'embargo' visibility -- oversight or feature?
