### PR TITLE
Issue #117, add 'Add Collection' button to each community on admin Manage C & C page.

### DIFF
--- a/app/views/admin/communities/index.html.erb
+++ b/app/views/admin/communities/index.html.erb
@@ -21,15 +21,21 @@
         <% end %>
 
         <div class="d-flex justify-content-between">
-          <%= link_to admin_community_path(community), data: {community_id: community.id }, class: 'btn btn-outline-primary collection-btn', remote: true do %>
-            <%= t('admin.collections.title') %>
-            <%= fa_icon('chevron-down') %>
-          <% end %>
+          <div class="btn-group" role="group" aria-label="Collection Actions">
+            <%= link_to admin_community_path(community), data: {community_id: community.id },
+                class: 'btn btn-outline-primary collection-btn', remote: true do %>
+              <%= t('admin.collections.title') %>
+              <%= fa_icon('chevron-down') %>
+            <% end %>
+            <%= button_tag type: 'button', class: 'btn btn-outline-primary close-btn d-none',
+                data: {community_id: community.id } do %>
+              <%= t('close') %>
+              <%= fa_icon('chevron-up') %>
+            <% end %>
 
-          <%= button_tag type: 'button', class: 'btn btn-outline-primary close-btn d-none', data: {community_id: community.id } do %>
-            <%= t('close') %>
-            <%= fa_icon('chevron-up') %>
-          <% end %>
+            <%= link_to t('communities.show.create_new_collection'),
+                new_admin_community_collection_path(community), class:'btn btn-outline-primary' %>
+          </div>
 
           <div class="btn-group" role="group" aria-label="Community Actions">
             <%= link_to t('edit'), edit_admin_community_path(community), class:'btn btn-outline-primary' %>


### PR DESCRIPTION
See comments in Issue #117.

A question: I'm not an accessibility expert, but I noticed that the `aria-label` attributes aren't going through I18n -- is this intentional, or an oversight?

Here is screen shot, with the new 'Add Collection' buttons:

![add-collection](https://user-images.githubusercontent.com/672104/30654957-c983d51e-9dec-11e7-97fb-38deac21bbdd.png)
