### PR TITLE
Better approach to solrization issues

### DIFF
--- a/app/models/community.rb
+++ b/app/models/community.rb
@@ -1,5 +1,7 @@
 class Community < JupiterCore::LockedLdpObject
 
+  ldp_object_includes Hydra::PCDM::ObjectBehavior
+
   # Needed for ActiveStorage (logo)...
   include GlobalID::Identification
 
@@ -32,6 +34,8 @@ class Community < JupiterCore::LockedLdpObject
   end
 
   unlocked do
+    type [::Hydra::PCDM::Vocab::PCDMTerms.Object, ::VOCABULARY[:jupiter_core].community]
+
     before_destroy :can_be_destroyed?
     before_destroy -> { logo.purge_later }
 

--- a/app/models/file_set.rb
+++ b/app/models/file_set.rb
@@ -1,5 +1,6 @@
-class FileSet < ActiveFedora::Base
+class FileSet < JupiterCore::LockedLdpObject
 
-  include Hydra::Works::FileSetBehavior
+  ldp_object_includes Hydra::Works::FileSetBehavior
+  use_existing_association :member_of_collections, using_name: :member_of_works
 
 end

--- a/app/models/file_set.rb
+++ b/app/models/file_set.rb
@@ -1,6 +1,6 @@
 class FileSet < JupiterCore::LockedLdpObject
 
   ldp_object_includes Hydra::Works::FileSetBehavior
-  use_existing_association :member_of_collections, using_name: :member_of_works
+  use_existing_association :member_of_collections, using_name: :items
 
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -20,7 +20,7 @@ class Item < JupiterCore::LockedLdpObject
   has_attribute :embargo_end_date, ::RDF::Vocab::DC.modified, type: :date, solrize_for: [:sort]
 
   additional_search_index :doi_without_label, solrize_for: :exact_match,
-                                 as: -> { doi.gsub('doi:', '') if doi.present? }
+                                              as: -> { doi.gsub('doi:', '') if doi.present? }
 
   def self.display_attribute_names
     super - [:member_of_paths]

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -19,7 +19,7 @@ class Item < JupiterCore::LockedLdpObject
   has_multival_attribute :member_of_paths, ::VOCABULARY[:ualib].path, type: :path, solrize_for: :pathing
   has_attribute :embargo_end_date, ::RDF::Vocab::DC.modified, type: :date, solrize_for: [:sort]
 
-  solr_index :doi_without_label, solrize_for: :exact_match,
+  additional_search_index :doi_without_label, solrize_for: :exact_match,
                                  as: -> { doi.gsub('doi:', '') if doi.present? }
 
   def self.display_attribute_names

--- a/app/models/jupiter_core/indexer.rb
+++ b/app/models/jupiter_core/indexer.rb
@@ -6,6 +6,8 @@ class JupiterCore::Indexer < ActiveFedora::IndexingService
     super.tap do |solr_doc|
       object.owning_class.solr_calc_attributes.each do |name, metadata|
         value = object.instance_exec(&metadata[:callable])
+        value.compact! if value.is_a? Array
+
         Solrizer.insert_field(solr_doc, name, value, metadata[:type])
       end
     end

--- a/app/models/jupiter_core/locked_ldp_object.rb
+++ b/app/models/jupiter_core/locked_ldp_object.rb
@@ -192,6 +192,13 @@ module JupiterCore
       new(solr_doc: results.first)
     end
 
+    # find with "return nil if no object with that ID is found" semantics
+    def self.find_by(id)
+      self.find(id)
+    rescue ObjectNotFound
+      return nil
+    end
+
     # Returns an array of all +LockedLDPObject+ in the LDP
     # def self.all(limit:, offset: )
     def self.all

--- a/app/models/jupiter_core/locked_ldp_object.rb
+++ b/app/models/jupiter_core/locked_ldp_object.rb
@@ -532,6 +532,14 @@ module JupiterCore
         raise ArgumentError, "No such association" unless association_names.include? association
         raise ArgumentError, "Invalid association" if derived_af_class.reflect_on_all_associations[association].is_a? ActiveFedora::Reflection::HasSubresourceReflection
 
+        self.attribute_cache[using_name] = {
+          predicate: nil,
+          multiple: true,
+          solrize_for: [:search],
+          type: :string,
+          solr_names: [Solrizer.solr_name(using_name, SOLR_DESCRIPTOR_MAP[:search], type: :string)]
+        }
+
         self.association_indexes ||= []
         self.association_indexes << using_name
 
@@ -543,7 +551,7 @@ module JupiterCore
                      end}
         # add a reader to the locked object
         define_cached_reader(using_name, multiple:true, type: :string,
-          canonical_solr_name:Solrizer.solr_name(using_name, SOLR_DESCRIPTOR_MAP[:search], type: :string),
+          canonical_solr_name: Solrizer.solr_name(using_name, SOLR_DESCRIPTOR_MAP[:search], type: :string),
           specialized_reader: -> {
             self.send(association)&.map do |member|
               member.id

--- a/app/models/jupiter_core/locked_ldp_object.rb
+++ b/app/models/jupiter_core/locked_ldp_object.rb
@@ -40,7 +40,7 @@ module JupiterCore
 
     # inheritable class attributes (not all class-level attributes in this class should be inherited,
     # these are the inheritance-safe attributes)
-    class_attribute :af_parent_class, :attribute_cache, :attribute_names, :facets,
+    class_attribute :af_parent_class, :attribute_cache, :attribute_names, :facets, :association_indexes,
                     :reverse_solr_name_cache, :solr_calc_attributes
 
     # Returns the id of the object in LDP as a String
@@ -79,7 +79,8 @@ module JupiterCore
 
     # A better debug representation for LDP Objects
     def inspect
-      "#<#{self.class.name || 'AnonymousClass'} " + self.class.attribute_names.map do |name|
+      attrs = self.class.attribute_names + self.class.association_indexes
+      debugstr = attrs.map do |name|
         val = self.send(name)
         val_display = if val.is_a?(String)
                         %Q("#{val}")
@@ -93,7 +94,8 @@ module JupiterCore
                         val.to_s
                       end
         "#{name}: #{val_display}"
-      end.join(', ') + '>'
+      end
+      return "#<#{self.class.name || 'AnonymousClass'} " + debugstr.join(', ') + '>'
     end
 
     # Has this object been persisted? (Defined for ActiveModel compatibility)
@@ -348,8 +350,7 @@ module JupiterCore
         child.attribute_cache = self.attribute_cache ? self.attribute_cache.dup : {}
         child.facets = self.facets ? self.facets.dup : []
         child.solr_calc_attributes = self.solr_calc_attributes.present? ? self.solr_calc_attributes.dup : {}
-        # child.derived_af_class
-
+        child.association_indexes = self.association_indexes.present? ? self.association_indexes.dup : []
         # If there's no class between +LockedLdpObject+ and this child that's
         # already had +visibility+ and +owner+ defined, define them.
         child.class_eval do
@@ -490,19 +491,75 @@ module JupiterCore
         @derived_af_class ||= generate_af_class
       end
 
+      def define_cached_reader(name, multiple:, type:, canonical_solr_name:, specialized_reader:nil)
+        define_method name do
+          val = if ldp_object.present?
+                  unless specialized_reader.present?
+                    ldp_object.send(name)
+                  else
+                    ldp_object.instance_exec(&specialized_reader)
+                  end
+                else
+                  solr_representation[canonical_solr_name]
+                end
+          return if val.nil?
+          val = val.first if val.is_a?(Array) && !multiple
+          return coerce_value(val, to: type).freeze unless multiple
+          coerced_values = val.map do |v|
+            coerce_value(v, to: type).freeze
+          end
+          return coerced_values.freeze
+        end
+      end
+
       # Write properties directly to the solr index for an LDP object, without having to back them in the LDP
       # a lambda, +as+, controls how it is calculated.
       # Examples:
       #
-      #    solr_index :downcased_title, solrize_for: :exact_match, as: -> { title.downcase }
+      #    additional_search_index :downcased_title, solrize_for: :exact_match, as: -> { title.downcase }
       #
-      def solr_index(name, solrize_for:, as:)
+      def additional_search_index(name, solrize_for:, as:)
         raise PropertyInvalidError unless as.respond_to?(:call)
         raise PropertyInvalidError unless name.present?
         raise PropertyInvalidError unless solrize_for.present? && solrize_for.is_a?(Symbol)
 
         self.solr_calc_attributes ||= {}
         self.solr_calc_attributes[name] = { type: SOLR_DESCRIPTOR_MAP[solrize_for], callable: as }
+      end
+
+      def use_existing_association(association, using_name: )
+        association_names = derived_af_class.reflect_on_all_associations.keys
+        raise ArgumentError, "No such association" unless association_names.include? association
+        raise ArgumentError, "Invalid association" if derived_af_class.reflect_on_all_associations[association].is_a? ActiveFedora::Reflection::HasSubresourceReflection
+
+        self.association_indexes ||= []
+        self.association_indexes << using_name
+
+        # fix this not-in-solr idiocy
+        additional_search_index using_name, solrize_for: :search,
+                   as: -> {
+                     self.send(association)&.map do |member|
+                       member.id
+                     end}
+        # add a reader to the locked object
+        define_cached_reader(using_name, multiple:true, type: :string,
+          canonical_solr_name:Solrizer.solr_name(using_name, SOLR_DESCRIPTOR_MAP[:search], type: :string),
+          specialized_reader: -> {
+            self.send(association)&.map do |member|
+              member.id
+            end})
+
+        # let people use the "better name" when unlocked, for sheer sanity
+        # eg. if you index the awful "member_of_collections" as "member_of_works" on FileSet to better reflect that it
+        # has nothing whatsoever to do with collections, let people use and assign to that when unlocked
+        # this also simplifies functioning of method forwarding between the locked and unlocked object
+        # as that generally assumes that "attribute" names are identically named on both objects
+        if association != using_name
+          derived_af_class.class_eval do
+            alias_method using_name, association
+            alias_method :"#{using_name}=", :"#{association}="
+          end
+        end
       end
 
       def has_multival_attribute(name, predicate, solrize_for: [], type: :string)
@@ -546,20 +603,8 @@ module JupiterCore
           solr_names: solr_name_cache
         }
 
-        define_method name do
-          val = if ldp_object.present?
-                  ldp_object.send(name)
-                else
-                  solr_representation[solr_name_cache.first]
-                end
-          return if val.nil?
-          val = val.first if val.is_a?(Array) && !multiple
-          return coerce_value(val, to: type).freeze unless multiple
-          coerced_values = val.map do |v|
-            coerce_value(v, to: type).freeze
-          end
-          return coerced_values.freeze
-        end
+        # define the read-only attribute method for the locked object
+        define_cached_reader(name, multiple:multiple, type:type, canonical_solr_name:solr_name_cache.first)
 
         define_method "#{name}=" do |*_args|
           raise LockedInstanceError, 'The Locked LDP object cannot be mutated outside of an unlocked block or without'\

--- a/config/vocabularies.yml
+++ b/config/vocabularies.yml
@@ -22,8 +22,9 @@
     - path
 
 - vocabulary: jupiter_core
-  schema: 'http://fake.figurethisout.todo'
+  schema: 'http://fake.figurethisout.todo#'
   terms:
-    - visibility
-    - owner
-    - record_created_at
+    - visibility # sharon is looking into vocabularies related to this at the moment
+    - owner # not the same as depositor, potentially, as we may need to re-own works in the future while continue to record the original depositor
+    - record_created_at # separate from date_created, we need to track a precise time the metadata record was created
+    - community # rdf:type for community objects, which aren't merely rdf:objects but our own custom derivation

--- a/test/models/jupiter_core/locked_ldp_object_test.rb
+++ b/test/models/jupiter_core/locked_ldp_object_test.rb
@@ -327,23 +327,23 @@ class LockedLdpObjectTest < ActiveSupport::TestCase
   test 'hoisted activefedora associations' do
     klass = Class.new(JupiterCore::LockedLdpObject) do
       ldp_object_includes Hydra::Works::FileSetBehavior
-      use_existing_association :member_of_collections, using_name: :member_of_works
+      use_existing_association :member_of_collections, using_name: :items
     end
     instance = klass.new_locked_ldp_object(owner: 1, visibility: JupiterCore::VISIBILITY_PUBLIC)
 
-    assert instance.respond_to?(:member_of_works)
+    assert instance.respond_to?(:items)
     assert_equal instance.inspect, '#<AnonymousClass id: nil, visibility: "public", owner: 1,'\
-                                   ' record_created_at: nil, member_of_works: []>'
+                                   ' record_created_at: nil, items: []>'
     instance.unlock_and_fetch_ldp_object do |uo|
       uo.save
 
       instance2 = klass.new_locked_ldp_object(owner: 1,
-                                              visibility: JupiterCore::VISIBILITY_PUBLIC, member_of_works: [uo])
+                                              visibility: JupiterCore::VISIBILITY_PUBLIC, items: [uo])
 
       instance2.unlock_and_fetch_ldp_object(&:save)
-      assert instance2.member_of_works.include? instance.id
+      assert instance2.items.include? instance.id
 
-      fetched_object = klass.where(member_of_works: instance.id).first
+      fetched_object = klass.where(items: instance.id).first
 
       assert fetched_object.present?
       assert_equal fetched_object.id, instance2.id

--- a/test/models/jupiter_core/locked_ldp_object_test.rb
+++ b/test/models/jupiter_core/locked_ldp_object_test.rb
@@ -8,7 +8,7 @@ class LockedLdpObjectTest < ActiveSupport::TestCase
     has_attribute :creator, ::RDF::Vocab::DC.creator, solrize_for: [:search, :facet]
     has_multival_attribute :member_of_paths, ::VOCABULARY[:ualib].path, solrize_for: :pathing
 
-    solr_index :my_solr_doc_attr, solrize_for: :search, as: -> { title&.upcase }
+    additional_search_index :my_solr_doc_attr, solrize_for: :search, as: -> { title&.upcase }
 
     def locked_method_shouldnt_mutate(attempted_title)
       self.title = attempted_title
@@ -322,6 +322,27 @@ class LockedLdpObjectTest < ActiveSupport::TestCase
     # of the time, causing our embargo date to silently become today when saved.
     # This test will fail if we haven't succesfully corrected for this in JupiterCore::LockedLdpObject
     assert instance.embargo_date.year != Time.now.year
+  end
+
+  test "hoisted activefedora associations" do
+    klass = Class.new(JupiterCore::LockedLdpObject) do
+      ldp_object_includes Hydra::Works::FileSetBehavior
+      use_existing_association :member_of_collections, using_name: :member_of_works
+    end
+    instance = klass.new_locked_ldp_object(owner: 1, visibility: JupiterCore::VISIBILITY_PUBLIC)
+
+    assert instance.respond_to?(:member_of_works)
+    assert_equal instance.inspect, "#<AnonymousClass id: nil, visibility: \"public\", owner: 1, record_created_at: nil, member_of_works: []>"
+    instance2 = klass.new_locked_ldp_object(owner: 1, visibility: JupiterCore::VISIBILITY_PUBLIC)
+    instance2.unlock_and_fetch_ldp_object do |uo2|
+      uo2.save!
+      instance.unlock_and_fetch_ldp_object do |uo|
+        uo.member_of_works += [uo2]
+        uo.save!
+      end
+    end
+
+    assert instance.member_of_works.include? instance2.id
   end
 
 end

--- a/test/models/jupiter_core/locked_ldp_object_test.rb
+++ b/test/models/jupiter_core/locked_ldp_object_test.rb
@@ -239,6 +239,8 @@ class LockedLdpObjectTest < ActiveSupport::TestCase
       @@klass.find(generate_random_string)
     end
 
+    assert_nil @@klass.find_by(generate_random_string)
+
     assert @@klass.find(obj.id).present?
 
     assert_equal @@klass.first.id, obj.id

--- a/test/models/jupiter_core/locked_ldp_object_test.rb
+++ b/test/models/jupiter_core/locked_ldp_object_test.rb
@@ -343,6 +343,7 @@ class LockedLdpObjectTest < ActiveSupport::TestCase
     end
 
     assert instance.member_of_works.include? instance2.id
+    assert_equal klass.where(member_of_works: instance2.id).first.id, instance.id
   end
 
 end

--- a/test/models/jupiter_core/locked_ldp_object_test.rb
+++ b/test/models/jupiter_core/locked_ldp_object_test.rb
@@ -324,7 +324,7 @@ class LockedLdpObjectTest < ActiveSupport::TestCase
     assert instance.embargo_date.year != Time.now.year
   end
 
-  test "hoisted activefedora associations" do
+  test 'hoisted activefedora associations' do
     klass = Class.new(JupiterCore::LockedLdpObject) do
       ldp_object_includes Hydra::Works::FileSetBehavior
       use_existing_association :member_of_collections, using_name: :member_of_works
@@ -332,7 +332,8 @@ class LockedLdpObjectTest < ActiveSupport::TestCase
     instance = klass.new_locked_ldp_object(owner: 1, visibility: JupiterCore::VISIBILITY_PUBLIC)
 
     assert instance.respond_to?(:member_of_works)
-    assert_equal instance.inspect, "#<AnonymousClass id: nil, visibility: \"public\", owner: 1, record_created_at: nil, member_of_works: []>"
+    assert_equal instance.inspect, '#<AnonymousClass id: nil, visibility: "public", owner: 1,'\
+                                   ' record_created_at: nil, member_of_works: []>'
     instance2 = klass.new_locked_ldp_object(owner: 1, visibility: JupiterCore::VISIBILITY_PUBLIC)
     instance2.unlock_and_fetch_ldp_object do |uo2|
       uo2.save!

--- a/test/models/jupiter_core/search_test.rb
+++ b/test/models/jupiter_core/search_test.rb
@@ -6,7 +6,7 @@ class SearchTest < ActiveSupport::TestCase
     has_attribute :creator, ::RDF::Vocab::DC.creator, solrize_for: [:search, :facet]
     has_multival_attribute :member_of_paths, ::VOCABULARY[:ualib].path, type: :path, solrize_for: :pathing
 
-    solr_index :my_solr_doc_attr, solrize_for: :search, as: -> { 'a_test_value' }
+    additional_search_index :my_solr_doc_attr, solrize_for: :search, as: -> { 'a_test_value' }
 
     def locked_method_shouldnt_mutate(attempted_title)
       self.title = attempted_title


### PR DESCRIPTION
Adds a class-level method to hoist already-defined ActiveFedora associations into the LockedLDPObject by indexing its IDs into Solr. Also allows for giving the association a new (better) name than the awful/misleading names some existing associations have. Also renames `solr_index` to `additional_search_index` in an effort to give it a name that indicates its purely adjunct nature/discourage use for non-primary use-cases -- we want to reserve this for cases where it's intended to transform data to better match a users' search.

 I'm thinking areas where we were trying to index attributes from associations onto an object for display are better served by either adding LockedLDPObjects representing the association, or denormalizing the join-happy Work-FileSet-File relationship and getting some of that data into Fedora on the Work or FileSet