### PR TITLE
Issue # 164. Some format wrangling for dates encoded as strings.

### DIFF
--- a/app/models/jupiter_core/locked_ldp_object.rb
+++ b/app/models/jupiter_core/locked_ldp_object.rb
@@ -1,4 +1,5 @@
 # coding: utf-8
+
 # JupiterCore::LockedLdpObject classes are lightweight, read-only objects
 # TODO: this file could benefit from some reorganization, possibly into several files
 module JupiterCore
@@ -422,18 +423,16 @@ module JupiterCore
               # it serializes every other Date type to a string internally at a very low precision (second granularity)
               # so we convert all date types into strings ourselves to bypass ActiveFedora's serialization, and then
               # use our modifications to Solrizer to save them in solr in a proper date index.
-              if (value.is_a?(Date) || value.is_a?(String))
+              if value.is_a?(Date) || value.is_a?(String)
                 begin
                   value = value.to_datetime
                 rescue ArgumentError
-                  # Exception will get raised below
+                  # bbatsov is making me do this ...
+                  raise TypeError, "#{value} is not a Date type"
                 end
               end
-              if value.respond_to?(:iso8601)
-                value.utc.iso8601(3)
-              else
-                raise TypeError, "#{value} is not a Date type"
-              end
+              raise TypeError, "#{value} is not a Date type" unless value.respond_to?(:iso8601)
+              value.utc.iso8601(3)
             when :bool
               raise TyperError, "#{value} is not a boolean" unless [true, false].include?(value)
               value

--- a/app/models/jupiter_core/locked_ldp_object.rb
+++ b/app/models/jupiter_core/locked_ldp_object.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 # JupiterCore::LockedLdpObject classes are lightweight, read-only objects
 # TODO: this file could benefit from some reorganization, possibly into several files
 module JupiterCore
@@ -421,10 +422,14 @@ module JupiterCore
               # it serializes every other Date type to a string internally at a very low precision (second granularity)
               # so we convert all date types into strings ourselves to bypass ActiveFedora's serialization, and then
               # use our modifications to Solrizer to save them in solr in a proper date index.
-              value = value.to_datetime if value.is_a?(Date)
-              if value.is_a?(String)
-                value
-              elsif value.respond_to?(:iso8601)
+              if (value.is_a?(Date) || value.is_a?(String))
+                begin
+                  value = value.to_datetime
+                rescue ArgumentError
+                  # Exception will get raised below
+                end
+              end
+              if value.respond_to?(:iso8601)
                 value.utc.iso8601(3)
               else
                 raise TypeError, "#{value} is not a Date type"


### PR DESCRIPTION
This allows entering information about Items in our forms (create/update)
to work again.

This definitely needs a sanity check. An alternative approach would be to convert string dates coming from forms to dates in the controller (and hence can't use methods like `#update_attributes`).

Before:

```
uitem.date_created = '2017-09-29T20:29:25+00:00'
=> "2017-09-29T20:29:25+00:00"
uitem.save!
RSolr::Error::Http: RSolr::Error::Http - 400 Bad Request
Error: {"responseHeader":{"status":400,"QTime":0},"error":{"metadata":["error-c\
lass","org.apache.solr.common.SolrException","root-error-class","org.apache.sol\
r.common.SolrException"],"msg":"Invalid Date String:'2017-09-29T20:29:25+00:00'\
","code":400}}

uitem.date_created = '2017-09-29'
=> "2017-09-29"
uitem.save!
RSolr::Error::Http: RSolr::Error::Http - 400 Bad Request
Error: {"responseHeader":{"status":400,"QTime":0},"error":{"metadata":["error-c\
lass","org.apache.solr.common.SolrException","root-error-class","org.apache.sol\
r.common.SolrException"],"msg":"Invalid Date String:'2017-09-29'","code":400}}

uitem.date_created = 'dog'
=> "dog"
```

After:

```
uitem.date_created = '2017-09-29T20:29:25+00:00'
=> "2017-09-29T20:29:25+00:00"
uitem.save!
=> true

uitem.date_created = '2017-09-29'
=> "2017-09-29"
uitem.save!
=> true

uitem.date_created = 'dog'
TypeError: dog is not a Date type
```