### PR TITLE
Add a couple of font awesome icons to admin and suspended users.

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -5,3 +5,4 @@
 @import 'communities';
 @import 'logo';
 @import 'search';
+@import 'users';

--- a/app/assets/stylesheets/users.scss
+++ b/app/assets/stylesheets/users.scss
@@ -1,0 +1,10 @@
+$admin: $blue;
+$suspended: $red;
+
+.user-admin {
+  color: $admin;
+}
+
+.user-suspended {
+  color: $suspended;
+}

--- a/app/helpers/admin/users_helper.rb
+++ b/app/helpers/admin/users_helper.rb
@@ -15,7 +15,8 @@ module Admin::UsersHelper
                 end
 
     # html_safe is used securely here
-    # The only param that is being consumed here is `params[:direction]` which is being sanitized by the "sort_direction" method
+    # The only param that is being consumed here is `params[:direction]` which is being sanitized by
+    # the "sort_direction" method
     link_to "#{title} #{fa_icon font_awesome_icon}".html_safe, # rubocop:disable Rails/OutputSafety
             params: { query: params[:query],
                       sort: column, direction: direction }
@@ -29,11 +30,22 @@ module Admin::UsersHelper
     link_to title, { params: { sort: column, direction: sort } }, class: klass
   end
 
+  # html_safe is used securely in the next two methods
+  # rubocop:disable Rails/OutputSafety
   def user_role(user)
-    user.admin ? t('admin.users.index.admin_role') : t('admin.users.index.user_role')
+    if user.admin
+      "<span class='user-admin'>#{fa_icon('shield')} #{t('admin.users.index.admin_role')}</span>".html_safe
+    else
+      t('admin.users.index.user_role')
+    end
   end
 
   def user_status(user)
-    user.suspended ? t('admin.users.index.suspended_status') : t('admin.users.index.active_status')
+    if user.suspended
+      "<span class='user-suspended'>#{fa_icon('ban')} #{t('admin.users.index.suspended_status')}</span>".html_safe
+    else
+      t('admin.users.index.active_status')
+    end
   end
+  # rubocop:enable Rails/OutputSafety
 end


### PR DESCRIPTION
As per the comment on the users page mockup. Also added some color.

I was playing around with this as part of the autocomplete PR, but thought it might be better to spin off as a separate PR.

This is what it looks like:

![fa_users](https://user-images.githubusercontent.com/672104/31505630-90a1be62-af32-11e7-878a-84c4e5153210.png)
