### PR TITLE
Update gems including bootstrap

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ script:
   - docker-compose run --rm -e RAILS_ENV=test web rails test
   - docker-compose run --rm -e RAILS_ENV=test web rails test:system
   - docker-compose run --rm web rubocop
-  - docker-compose run --rm web scss-lint
+  # - docker-compose run --rm web scss-lint
 
 # after_success:
  # Do autodeploy magic here to UAT

--- a/Gemfile
+++ b/Gemfile
@@ -10,10 +10,10 @@ gem 'puma', '~> 3.7'
 gem 'rails', '~> 5.1.1'
 
 # Assets (CSS/JS) stuff
-gem 'bootstrap', '~> 4.0.0.beta'
+gem 'bootstrap', '~> 4.0.0.beta2.1'
 gem 'font-awesome-rails'
 gem 'jquery-rails'
-gem 'sass-rails', '~> 5.0'
+gem 'sass-rails', '~> 5'
 gem 'turbolinks', '~> 5'
 gem 'uglifier', '>= 1.3.0'
 
@@ -63,7 +63,10 @@ group :development, :test do
   # TODO: Pointing rubocop at master to resolve this bug: https://github.com/bbatsov/rubocop/pull/4749
   # Once 0.50.1 or something lands, point back to the gem
   gem 'rubocop', github: 'bbatsov/rubocop', require: false
-  gem 'scss_lint', require: false
+
+  # Need to wait till scss_lint is using sass 3.5+
+  # More details here: https://github.com/brigade/scss-lint/issues/877
+  # gem 'scss_lint', '>= 0.55.0', require: false
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 GIT
   remote: https://github.com/bbatsov/rubocop.git
-  revision: 9f7548a90d0f18314a2b140172f381f4a6b11efb
+  revision: a6b6786ede8cf97447d0cdb9154c4e22d78d6071
   specs:
-    rubocop (0.50.0)
+    rubocop (0.51.0)
       parallel (~> 1.10)
       parser (>= 2.3.3.1, < 3.0)
       powerpack (~> 0.1)
@@ -95,19 +95,19 @@ GEM
       public_suffix (>= 2.0.2, < 4.0)
     arel (8.0.0)
     ast (2.3.0)
-    autoprefixer-rails (7.1.4.1)
+    autoprefixer-rails (7.1.6)
       execjs
     better_errors (2.4.0)
       coderay (>= 1.0.0)
       erubi (>= 1.0.0)
       rack (>= 0.9.0)
     bindex (0.5.0)
-    binding_of_caller (0.7.2)
+    binding_of_caller (0.7.3)
       debug_inspector (>= 0.0.1)
-    bootstrap (4.0.0.beta)
+    bootstrap (4.0.0.beta2.1)
       autoprefixer-rails (>= 6.0.3)
-      popper_js (~> 1.11.1)
-      sass (>= 3.4.19)
+      popper_js (>= 1.12.3, < 2)
+      sass (>= 3.5.2)
     builder (3.2.3)
     capybara (2.15.4)
       addressable
@@ -122,7 +122,7 @@ GEM
     concurrent-ruby (1.0.5)
     connection_pool (2.2.1)
     crass (1.0.2)
-    daemons (1.2.4)
+    daemons (1.2.5)
     debug_inspector (0.0.3)
     deprecation (1.0.0)
       activesupport
@@ -173,21 +173,21 @@ GEM
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
     json (1.8.6)
-    json-ld (2.1.5)
+    json-ld (2.1.7)
       multi_json (~> 1.12)
-      rdf (~> 2.2)
-    kaminari (1.1.0)
+      rdf (~> 2.2, >= 2.2.8)
+    kaminari (1.1.1)
       activesupport (>= 4.1.0)
-      kaminari-actionview (= 1.1.0)
-      kaminari-activerecord (= 1.1.0)
-      kaminari-core (= 1.1.0)
-    kaminari-actionview (1.1.0)
+      kaminari-actionview (= 1.1.1)
+      kaminari-activerecord (= 1.1.1)
+      kaminari-core (= 1.1.1)
+    kaminari-actionview (1.1.1)
       actionview
-      kaminari-core (= 1.1.0)
-    kaminari-activerecord (1.1.0)
+      kaminari-core (= 1.1.1)
+    kaminari-activerecord (1.1.1)
       activerecord
-      kaminari-core (= 1.1.0)
-    kaminari-core (1.1.0)
+      kaminari-core (= 1.1.1)
+    kaminari-core (1.1.1)
     ldp (0.7.0)
       deprecation
       faraday
@@ -238,7 +238,7 @@ GEM
     parallel (1.12.0)
     parser (2.4.0.0)
       ast (~> 2.2)
-    popper_js (1.11.1)
+    popper_js (1.12.5)
     powerpack (0.1.1)
     pry (0.11.2)
       coderay (~> 1.1.0)
@@ -283,15 +283,15 @@ GEM
     rb-fsevent (0.10.2)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
-    rdf (2.2.9)
+    rdf (2.2.11)
       hamster (~> 3.0)
       link_header (~> 0.0, >= 0.0.8)
     rdf-isomorphic (2.0.0)
       rdf (~> 2.0)
-    rdf-turtle (2.2.0)
+    rdf-turtle (2.2.1)
       ebnf (~> 1.1)
       rdf (~> 2.2)
-    rdf-vocab (2.2.6)
+    rdf-vocab (2.2.8)
       rdf (~> 2.2)
     rdoc (4.3.0)
     redis (4.0.1)
@@ -303,16 +303,17 @@ GEM
       nokogiri (>= 1.5.10)
     ruby_dep (1.5.0)
     rubyzip (1.2.1)
-    sass (3.4.25)
+    sass (3.5.2)
+      sass-listen (~> 4.0.0)
+    sass-listen (4.0.0)
+      rb-fsevent (~> 0.9, >= 0.9.4)
+      rb-inotify (~> 0.9, >= 0.9.7)
     sass-rails (5.0.6)
       railties (>= 4.0.0, < 6)
       sass (~> 3.1)
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
-    scss_lint (0.55.0)
-      rake (>= 0.9, < 13)
-      sass (~> 3.4.20)
     sdoc (0.4.2)
       json (~> 1.7, >= 1.7.7)
       rdoc (~> 4.0)
@@ -343,7 +344,7 @@ GEM
       rack (~> 2.0)
       rack-protection (= 2.0.0)
       tilt (~> 2.0)
-    slop (4.5.0)
+    slop (4.6.0)
     sprockets (3.7.1)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -385,7 +386,7 @@ DEPENDENCIES
   activestorage
   better_errors (>= 2.3.0)
   binding_of_caller
-  bootstrap (~> 4.0.0.beta)
+  bootstrap (~> 4.0.0.beta2.1)
   capybara (~> 2.15)
   faker
   font-awesome-rails
@@ -407,8 +408,7 @@ DEPENDENCIES
   redis (~> 4.0)
   rsolr
   rubocop!
-  sass-rails (~> 5.0)
-  scss_lint
+  sass-rails (~> 5)
   sdoc
   selenium-webdriver
   shoulda

--- a/app/controllers/admin/site_notifications_controller.rb
+++ b/app/controllers/admin/site_notifications_controller.rb
@@ -24,7 +24,7 @@ class Admin::SiteNotificationsController < Admin::AdminController
 
   def destroy
     notification = SiteNotification.find(params[:id])
-    notification.removed_at = DateTime.current
+    notification.removed_at = Time.current
     notification.save!
 
     # TODO: Flash success?

--- a/app/models/jupiter_core/locked_ldp_object.rb
+++ b/app/models/jupiter_core/locked_ldp_object.rb
@@ -322,11 +322,11 @@ module JupiterCore
         value
       when :date
         if value.is_a?(String)
-          DateTime.parse(value).utc
+          Time.zone.parse(value)
         elsif value.is_a?(DateTime)
           value
         elsif value.is_a?(Date) || value.is_a?(Time)
-          DateTime.parse(value.iso8601(3)).utc
+          Time.zone.parse(value)
         end
       else
         raise TypeError, "Unknown coercion type: #{type}"

--- a/test/models/jupiter_core/locked_ldp_object_test.rb
+++ b/test/models/jupiter_core/locked_ldp_object_test.rb
@@ -288,14 +288,14 @@ class LockedLdpObjectTest < ActiveSupport::TestCase
 
     # This should work even with vanilla AF/Solrizer
     instance = klass.new
-    instance.foo = DateTime.current
+    instance.foo = Time.current
 
     assert instance.to_solr.key? 'foo_dtsi'
     refute instance.to_solr.key? 'foo_ssi'
 
     # This will be broken on vanilla AF/Solrizer. Assigning a string will reveal that the index.type is non-functional
     # and ignored. foo will be solrized as a stored sortable string, foo_ssi, and not a date.
-    instance.foo = DateTime.now.utc.iso8601(3)
+    instance.foo = Time.current
 
     assert instance.to_solr.key? 'foo_dtsi'
     refute instance.to_solr.key? 'foo_ssi'


### PR DESCRIPTION
* Update bootstrap (and other gems like sass/etc)
* Disable `scss_lint` for time being as it needs to work with sass 3.5+
* Fix new rubocop cop  (Use Date/Time over DateTime)