### PR TITLE
New rubocop release, point it to the new version instead of github

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,9 +60,7 @@ group :development, :test do
   gem 'pry'
   gem 'pry-rails'
 
-  # TODO: Pointing rubocop at master to resolve this bug: https://github.com/bbatsov/rubocop/pull/4749
-  # Once 0.50.1 or something lands, point back to the gem
-  gem 'rubocop', github: 'bbatsov/rubocop', require: false
+  gem 'rubocop', '~> 0.51.0', require: false
 
   # Need to wait till scss_lint is using sass 3.5+
   # More details here: https://github.com/brigade/scss-lint/issues/877

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,16 +1,4 @@
 GIT
-  remote: https://github.com/bbatsov/rubocop.git
-  revision: a6b6786ede8cf97447d0cdb9154c4e22d78d6071
-  specs:
-    rubocop (0.51.0)
-      parallel (~> 1.10)
-      parser (>= 2.3.3.1, < 3.0)
-      powerpack (~> 0.1)
-      rainbow (>= 2.2.2, < 3.0)
-      ruby-progressbar (~> 1.7)
-      unicode-display_width (~> 1.0, >= 1.0.1)
-
-GIT
   remote: https://github.com/mbarnett/active_fedora.git
   revision: 052c2bcd6fa2a5e810671bea471b4808150004d8
   branch: fix_types_literally_do_nothing
@@ -298,6 +286,13 @@ GEM
     rsolr (2.0.2)
       builder (>= 2.1.2)
       faraday
+    rubocop (0.51.0)
+      parallel (~> 1.10)
+      parser (>= 2.3.3.1, < 3.0)
+      powerpack (~> 0.1)
+      rainbow (>= 2.2.2, < 3.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (~> 1.0, >= 1.0.1)
     ruby-progressbar (1.9.0)
     ruby-saml (1.5.0)
       nokogiri (>= 1.5.10)
@@ -407,7 +402,7 @@ DEPENDENCIES
   rdf-vocab
   redis (~> 4.0)
   rsolr
-  rubocop!
+  rubocop (~> 0.51.0)
   sass-rails (~> 5)
   sdoc
   selenium-webdriver


### PR DESCRIPTION
Shut dependabot up about updating references