### PR TITLE
Mostly bug fixes from previous admin cleanup merge

### DIFF
--- a/app/assets/stylesheets/users.scss
+++ b/app/assets/stylesheets/users.scss
@@ -1,4 +1,4 @@
-$admin: $blue;
+$admin: $blue; // TODO: looks too much like a link...needs tweaking or just remove these colors?
 $suspended: $red;
 
 .user-admin {

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -36,6 +36,6 @@ module ApplicationHelper
 
   def jupiter_time_ago_in_words(date, blank_message: '')
     return blank_message if date.blank?
-    time_ago_in_words(date)
+    t('time_ago', time: time_ago_in_words(date))
   end
 end

--- a/app/views/admin/announcements/index.html.erb
+++ b/app/views/admin/announcements/index.html.erb
@@ -40,7 +40,7 @@
 <h2 class="mt-5"><%= t('.past_announcements') %></h2>
 
 <%= search_form_for @search, url: admin_announcements_path,
-                        html: { method: :get, class: 'js-autocomplete mt-3 form-inline'} do |f| %>
+                        html: { method: :get, class: 'js-autocomplete my-3 form-inline'} do |f| %>
 
   <div class="form-group">
     <%= f.label :message_cont, t('search_label'), class: 'mr-sm-2' %>

--- a/app/views/admin/communities/index.html.erb
+++ b/app/views/admin/communities/index.html.erb
@@ -3,8 +3,10 @@
 <div class="d-flex flex-wrap justify-content-between align-items-center mt-3">
   <h1><%= t('.header') %></h1>
 
-  <%= link_to t('communities.index.create_community'), new_admin_community_path,
-    class: 'btn btn-primary' %>
+  <%= link_to new_admin_community_path, class: 'btn btn-primary' do %>
+    <%= fa_icon('plus-circle') %>
+    <%=  t('communities.index.create_community') %>
+  <% end %>
 </div>
 
 <form>

--- a/app/views/admin/items/index.html.erb
+++ b/app/views/admin/items/index.html.erb
@@ -7,7 +7,7 @@
     <%= link_to item, class: "list-group-item list-group-item-action d-flex justify-content-between align-items-start" do %>
       <%= item.title %>
       <span class="badge badge-secondary">
-        <%= time_ago_in_words(item.record_created_at) %>
+        <%= jupiter_time_ago_in_words(item.record_created_at) %>
       </span>
     <% end %>
   <% end %>

--- a/app/views/admin/items/index.html.erb
+++ b/app/views/admin/items/index.html.erb
@@ -1,6 +1,15 @@
 <% page_title(t('.header')) %>
 
-<h1 class="my-3">(TODO: Not implemented) <%= t('.header') %></h1>
+<div class="d-flex flex-wrap align-items-center justify-content-between my-3">
+  <h1>
+    (TODO: Not implemented) <%= t('.header') %>
+  </h1>
+  <%= link_to new_item_path,
+      class: 'btn btn-primary' do %>
+    <%= fa_icon('plus-circle') %>
+    <%= t('items.new.header') %>
+  <% end %>
+</div>
 
 <div class="list-group">
   <% @items.each do |item| %>

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -4,7 +4,7 @@
 
 
 <%= search_form_for @search, url: admin_users_path,
-                        html: { method: :get, class: 'js-autocomplete d-flex mt-3 form-inline'} do |f| %>
+                        html: { method: :get, class: 'js-autocomplete d-flex my-3 form-inline'} do |f| %>
 
   <div class="form-group mr-auto">
     <%= f.label :name_or_email_cont, t('search_label'), class: 'mr-sm-2' %>

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -84,7 +84,16 @@
   </dd>
 </dl>
 
-
+<div class="row my-5">
+  <div class="col-md-12">
+    <h2><%= "(TODO) #{t('.draft_user_items')}" %></h2>
+    <div class="list-group mb-3">
+      <div class='list-group-item'>
+        <%= t('.no_items_found') %>
+      </div>
+    </div>
+  </div>
+</div>
 
 <div class="row my-5">
   <div class="col-md-12">

--- a/app/views/application/_announcement.html.erb
+++ b/app/views/application/_announcement.html.erb
@@ -1,7 +1,7 @@
 <% current_announcements.each do |announcement| %>
   <div class="alert alert-primary mb-0 rounded-0" role="alert">
     <p class="mb-0 text-center">
-      <%= fa_icon "exclamation-triangle" %>
+      <%= fa_icon "exclamation-circle" %>
       <%= announcement.message %>
     </p>
   </div>

--- a/app/views/collections/show.html.erb
+++ b/app/views/collections/show.html.erb
@@ -2,11 +2,11 @@
 
 <%= render partial: 'show_breadcrumbs' %>
 
-<div class="d-flex flex-wrap justify-content-between mt-3">
+<div class="d-flex flex-wrap justify-content-between align-items-center mt-3">
   <h1><%= @collection.title %></h1>
 
   <% if policy(@collection).edit? || policy(@collection).destroy? %>
-    <div class="btn-group align-self-center">
+    <div class="btn-group">
       <% if policy(@collection).edit? %>
         <%= link_to edit_admin_community_collection_path(@community, @collection),
             class:'btn btn-outline-secondary' do %>
@@ -31,9 +31,19 @@
   </div>
 <% end %>
 
-<h5 class="items-header p-3">
-  <%= t('.items_list_header') %>
-</h5>
+<div class="d-flex flex-wrap align-items-center justify-content-between mt-3">
+  <h4>
+    <%= t('.items_list_header') %>
+  </h4>
+  <% if policy(:item).new? %>
+      <%= link_to new_item_path,
+          class: 'btn btn-primary' do %>
+        <%= fa_icon('plus-circle') %>
+        <%= t('items.new.header') %>
+      <% end %>
+  <% end %>
+</div>
+
 
 <div class="row mt-3">
   <div class="col">

--- a/app/views/collections/show.html.erb
+++ b/app/views/collections/show.html.erb
@@ -8,13 +8,18 @@
   <% if policy(@collection).edit? || policy(@collection).destroy? %>
     <div class="btn-group align-self-center">
       <% if policy(@collection).edit? %>
-        <%= link_to t('edit'),
-            edit_admin_community_collection_path(@community, @collection),
-            class:'btn btn-outline-primary' %>
+        <%= link_to edit_admin_community_collection_path(@community, @collection),
+            class:'btn btn-outline-secondary' do %>
+          <%= fa_icon('pencil-square-o') %>
+          <%= t('edit') %>
+        <% end %>
       <% end %>
       <% if policy(@collection).destroy? %>
-        <%= link_to t('delete'), admin_community_collection_path(@community, @collection), method: :delete,
-            class:'btn btn-danger', data: { confirm: t('.delete_confirm', title: @collection.title) } %>
+        <%= link_to admin_community_collection_path(@community, @collection), method: :delete,
+            class:'btn btn-outline-secondary', data: { confirm: t('.delete_confirm', title: @collection.title) } do %>
+          <%= fa_icon('trash') %>
+          <%= t('delete') %>
+        <% end %>
       <% end %>
     </div>
   <% end %>
@@ -39,11 +44,17 @@
             <%= link_to item.title, item_path(item) %>
             <div class="btn-group">
               <% if policy(@collection).edit? %>
-                <%= link_to t('edit'), edit_item_path(item), class:'btn btn-outline-primary' %>
+                <%= link_to edit_item_path(item), class:'btn btn-outline-secondary'  do %>
+                  <%= fa_icon('trash') %>
+                  <%= t('edit') %>
+                <% end %>
               <% end %>
               <% if policy(@collection).destroy? %>
-                <%= link_to t('delete'), item_path(item), method: :delete, class:'btn btn-danger',
-                    data: { confirm: t('.item_delete_confirm', title: item.title) } %>
+                <%= link_to item_path(item), method: :delete, class:'btn btn-outline-secondary',
+                    data: { confirm: t('.item_delete_confirm', title: item.title) }  do %>
+                  <%= fa_icon('trash') %>
+                  <%= t('delete') %>
+                <% end %>
               <% end %>
             </div>
           </div>

--- a/app/views/communities/index.html.erb
+++ b/app/views/communities/index.html.erb
@@ -1,11 +1,14 @@
 <% page_title(t('.header')) %>
 
-<div class="d-flex flex-wrap justify-content-between mt-3">
+<div class="d-flex flex-wrap justify-content-between align-items-center mt-3">
   <h1><%= t('.header') %></h1>
 
   <% if policy(Community).create? %>
-    <%= link_to t('.create_community'), new_admin_community_path,
-      class: 'btn btn-primary align-self-center' %>
+    <%= link_to new_admin_community_path,
+        class: 'btn btn-primary' do %>
+      <%= fa_icon('plus-circle') %>
+      <%= t('.create_community') %>
+    <% end %>
   <% end %>
 </div>
 

--- a/app/views/communities/show.html.erb
+++ b/app/views/communities/show.html.erb
@@ -2,7 +2,7 @@
 
 <%= render partial: 'show_breadcrumbs' %>
 
-<div class="d-flex flex-wrap align-items-start justify-content-between mt-3">
+<div class="d-flex flex-wrap align-items-center justify-content-between mt-3">
   <h1><%= @community.title %></h1>
 
   <% if policy(@community).edit? || policy(@community).destroy? %>
@@ -33,7 +33,7 @@
   </div>
 </div>
 
-<div class="d-flex flex-wrap align-items-start justify-content-between mt-3">
+<div class="d-flex flex-wrap align-items-center justify-content-between mt-3">
   <h4>
     <%= t('.collections_list_header') %>
   </h4>

--- a/app/views/communities/show.html.erb
+++ b/app/views/communities/show.html.erb
@@ -8,13 +8,19 @@
   <% if policy(@community).edit? || policy(@community).destroy? %>
     <div class="btn-group">
     <% if policy(@community).edit? %>
-        <%= link_to t('edit'), edit_admin_community_path(@community),
-            class:'btn btn-outline-primary' %>
+        <%= link_to edit_admin_community_path(@community),
+            class:'btn btn-outline-secondary' do %>
+          <%= fa_icon('pencil-square-o') %>
+          <%= t('edit') %>
+        <% end %>
       <% end %>
           <% if policy(@community).destroy? %>
-        <%= link_to t('delete'), admin_community_path(@community), method: :delete,
-            class:'btn btn-danger',
-            data: { confirm: t('.delete_confirm', title: @community.title) } %>
+        <%= link_to admin_community_path(@community), method: :delete,
+            class:'btn btn-outline-secondary',
+            data: { confirm: t('.delete_confirm', title: @community.title) } do %>
+          <%= fa_icon('trash') %>
+          <%= t('delete') %>
+        <% end %>
       <% end %>
     </div>
   <% end %>
@@ -32,8 +38,11 @@
     <%= t('.collections_list_header') %>
   </h4>
   <% if policy(:collection).create? %>
-      <%= link_to t('.create_collection'), new_admin_community_collection_path(@community),
-          class: 'btn btn-primary' %>
+      <%= link_to new_admin_community_collection_path(@community),
+          class: 'btn btn-primary' do %>
+        <%= fa_icon('plus-circle') %>
+        <%= t('.create_collection') %>
+      <% end %>
   <% end %>
 </div>
 

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -22,10 +22,10 @@
       <%= active_link_to t('admin.items.index.header'), admin_items_path, class: 'nav-link', active: :exclusive  %>
     </li>
     <li class="nav-item">
-      <%= active_link_to t('admin.pages.index.header'), '#', class: 'nav-link', active: :exclusive  %>
+      <%= active_link_to "(TODO) #{t('admin.pages.index.header')}", '#', class: 'nav-link', active: :exclusive  %>
     </li>
     <li class="nav-item">
-      <%= active_link_to t('admin.analytics.index.header'), '#', class: 'nav-link', active: :exclusive  %>
+      <%= active_link_to "(TODO) #{t('admin.analytics.index.header')}", '#', class: 'nav-link', active: :exclusive  %>
     </li>
   </ul>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -43,6 +43,7 @@ en:
   filter_label: 'Filter By'
   search_label: 'Search'
   never_signed_in: 'Never Signed In'
+  time_ago: '%{time} ago'
 
   activemodel:
     errors:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -152,7 +152,7 @@ en:
         new_button_text: 'Post'
         current_announcements: 'Current Announcements'
         no_current_announcements: 'No Current Announcements'
-        posted: 'Posted %{created_at} ago'
+        posted: 'Posted %{created_at}'
         are_you_sure_you_want_to_remove: 'Are you sure you want to remove this announcement?'
         created_by: 'Created by'
         past_announcements: 'Past Announcements'
@@ -162,7 +162,7 @@ en:
         creator: 'Creator'
         posted_at: 'Posted'
         removed_at: 'Removed'
-        no_past_announcements: 'No Past Announcements'
+        no_past_announcements: 'We could not find any past announcements matching your search.'
         display_past_announcements_count:
           'Displaying %{past_announcements_count} of %{matching_past_announcements_count} matching past announcements
           ( %{total_past_announcements_count} total past announcements)'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -211,6 +211,7 @@ en:
         login_as_user_dialog: "Are you sure you want to login as %{user}?"
         login_as_user_flash: "You are now logged in as %{user}"
         no_items_found: 'There are no items for this user'
+        draft_user_items: "Draft User's Items"
         user_items: "User's Items"
         display_items_count: "Displaying %{items_count} of %{total_items_count} total items."
         # TODO: most of these are generic enough to be moved up in a common namespace

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -237,7 +237,7 @@ en:
       items_list_header: 'Items in this Collection'
       no_items_in_collection: 'There are no items in this Collection'
       item_delete_confirm: 'Are you sure you want to delete item "%{title}"?'
-
+      deposit_item: 'Deposit Item'
   communities:
     title: 'Communities'
     index:
@@ -269,7 +269,7 @@ en:
       original_filename: 'Original Filename'
       mime_type: 'MIME Type'
     new:
-      header: 'Create a new item'
+      header: 'Deposit Item'
     create:
       created: 'Item was successfully created!'
     form:

--- a/test/integration/collection_show_test.rb
+++ b/test/integration/collection_show_test.rb
@@ -55,7 +55,7 @@ class CollectionShowTest < ActionDispatch::IntegrationTest
       # Link to item
       assert item_links.first.text == item.title
       # Link to delete item
-      assert item_links.last.text == 'Delete'
+      assert_match 'Delete', item_links.last.text
       assert item_links.last.attributes['data-method'].to_s == 'delete'
 
       # Link to edit item


### PR DESCRIPTION
This PR is good enough to be reviewed and merged now. Cleaned up a few things:

- Fix spacing between user/announcement filter and  table
- Change all red buttons to secondary and add font awesome icons to all buttons in communities/collections
- Add "ago" after the relative timestamps to make them more english. `1 day` vs `1 day ago` etc.
- Add deposit item buttons on collections and admin items
- stub in users draft area
- tiny niceties in various places