### PR TITLE
Add an API for looking up the solr name of an attribute

### DIFF
--- a/app/models/jupiter_core/deferred_faceted_solr_query.rb
+++ b/app/models/jupiter_core/deferred_faceted_solr_query.rb
@@ -38,16 +38,7 @@ class JupiterCore::DeferredFacetedSolrQuery
 
   def sort(attr, order = :desc)
     raise ArgumentError, 'order must be :asc or :desc' unless [:asc, :desc].include?(order.to_sym)
-
-    # Right now we're just going to look this up on the first model, but for this to make sense,
-    # as something results can be sorted by, all models should have the same attribute name, solrized_for_sorting
-    metadata = criteria[:restrict_to_model].first.owning_class.attribute_metadata(attr.to_sym)
-    raise ArgumentError, "No metadata found for attribute #{attr}" if metadata.blank?
-
-    sort_attr_index = metadata[:solrize_for].index(:sort)
-    raise ArgumentError, "The given attribute, #{attr}, is not solrized for sorting" if sort_attr_index.blank?
-
-    criteria[:sort] = metadata[:solr_names][sort_attr_index]
+    criteria[:sort] = criteria[:restrict_to_model].first.owning_class.solr_name_for(attr.to_sym, role: :sort)
     criteria[:sort_order] = order
     self
   end

--- a/app/models/jupiter_core/deferred_simple_solr_query.rb
+++ b/app/models/jupiter_core/deferred_simple_solr_query.rb
@@ -31,14 +31,7 @@ class JupiterCore::DeferredSimpleSolrQuery
 
   def sort(attr, order = :desc)
     raise ArgumentError, 'order must be :asc or :desc' unless [:asc, :desc].include?(order.to_sym)
-
-    metadata = criteria[:model].attribute_metadata(attr.to_sym)
-    raise ArgumentError, "No metadata found for attribute #{attr}" if metadata.blank?
-
-    sort_attr_index = metadata[:solrize_for].index(:sort)
-    raise ArgumentError, "The given attribute, #{attr}, is not solrized for sorting" if sort_attr_index.blank?
-
-    criteria[:sort] = metadata[:solr_names][sort_attr_index]
+    criteria[:sort] = criteria[:model].solr_name_for(attr.to_sym, role: :sort)
     criteria[:sort_order] = order
     self
   end

--- a/app/models/jupiter_core/locked_ldp_object.rb
+++ b/app/models/jupiter_core/locked_ldp_object.rb
@@ -182,6 +182,23 @@ module JupiterCore
       self.reverse_solr_name_cache[solr_name]
     end
 
+    # Accepts the symbolic name of an attribute, and the "solrize_for" role, and returns the string
+    # representing the mangled solr name for that role. eg)
+    #
+    # Given a subclass +Item+ with an attribute declaration:
+    #   has_attribute :title, ::RDF::Vocab::DC.title, solrize_for: [:search, :facet]
+    #
+    # then:
+    #   Item.solr_name_for(:title, role: :search)
+    #   => "title_tesim"
+    def self.solr_name_for(attribute_name, role:)
+      attribute_metadata = self.attribute_cache[attribute_name]
+      raise ArgumentError, "No such attribute is defined, #{attribute_name}" if attribute_metadata.blank?
+      sort_attr_index = attribute_metadata[:solrize_for].index(role)
+      raise ArgumentError, "No such solr role is defined for #{attribute_name}" if sort_attr_index.blank?
+      attribute_metadata[:solr_names][sort_attr_index]
+    end
+
     # Accepts a string id of an object in the LDP, and returns a +LockedLDPObjects+ representation of that object
     # or raises <tt>JupiterCore::ObjectNotFound</tt> if there is no object corresponding to that id
     def self.find(id)

--- a/app/models/jupiter_core/locked_ldp_object.rb
+++ b/app/models/jupiter_core/locked_ldp_object.rb
@@ -123,6 +123,15 @@ module JupiterCore
       ldp_object.errors
     end
 
+    # Derives a solr-formatted (mangled_attr_name: value) search term for an instance's attribute.
+    # eg)
+    #    obj.search_term_for(:title)
+    #    => "title_tesim:\"The effects of Celebrator Doppelbock on cats\""
+    def search_term_for(attr_name)
+      solr_attr_name = self.class.solr_name_for(attr_name, role: :search)
+      %Q(#{solr_attr_name}:"#{self.send(attr_name)}")
+    end
+
     # Use this to create a new +LockedLDPObjects+ and its underlying LDP instance. attrs populate the new object's
     # attributes
     def self.new_locked_ldp_object(*attrs)
@@ -195,7 +204,7 @@ module JupiterCore
       attribute_metadata = self.attribute_cache[attribute_name]
       raise ArgumentError, "No such attribute is defined, #{attribute_name}" if attribute_metadata.blank?
       sort_attr_index = attribute_metadata[:solrize_for].index(role)
-      raise ArgumentError, "No such solr role is defined for #{attribute_name}" if sort_attr_index.blank?
+      raise ArgumentError, "No #{role} solr role is defined for #{attribute_name}" if sort_attr_index.blank?
       attribute_metadata[:solr_names][sort_attr_index]
     end
 

--- a/test/models/jupiter_core/locked_ldp_object_test.rb
+++ b/test/models/jupiter_core/locked_ldp_object_test.rb
@@ -130,6 +130,10 @@ class LockedLdpObjectTest < ActiveSupport::TestCase
     end
   end
 
+  test 'solr_name_for' do
+    assert_equal @@klass.solr_name_for(:title, role: :search), 'title_tesim'
+  end
+
   test 'unlocked methods can perform mutation' do
     orig_title = generate_random_string
     obj = @@klass.new_locked_ldp_object(title: orig_title)

--- a/test/models/jupiter_core/locked_ldp_object_test.rb
+++ b/test/models/jupiter_core/locked_ldp_object_test.rb
@@ -71,6 +71,11 @@ class LockedLdpObjectTest < ActiveSupport::TestCase
     assert_equal ['title_tesim', 'title_sim'], title_metadata[:solr_names]
 
     assert @@klass.attribute_metadata(:member_of_paths)[:multiple]
+
+    title = generate_random_string
+    obj = @@klass.new_locked_ldp_object(title: title)
+
+    assert_equal obj.search_term_for(:title), %Q(title_tesim:"#{title}")
   end
 
   test 'solr calculated attributes are working properly' do


### PR DESCRIPTION
Adds an API so you don't have to hardcode the solr name of anything:

`search_path(search: "creator_tesim:#{creator}")`

Should become:

`search_path(search: "#{Item.solr_name_for(:creator, role: :search)}:#{creator}")`

Or something similar.