### PR TITLE
Use select2 for communities/collections typeahead

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,7 @@ gem 'bootstrap', '~> 4.0.0.beta2.1'
 gem 'font-awesome-rails'
 gem 'jquery-rails'
 gem 'sass-rails', '~> 5'
+gem 'select2-rails'
 gem 'turbolinks', '~> 5'
 gem 'uglifier', '>= 1.3.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -326,6 +326,8 @@ GEM
     sdoc (0.4.2)
       json (~> 1.7, >= 1.7.7)
       rdoc (~> 4.0)
+    select2-rails (4.0.3)
+      thor (~> 0.14)
     selenium-webdriver (3.7.0)
       childprocess (~> 0.5)
       rubyzip (~> 1.0)
@@ -422,6 +424,7 @@ DEPENDENCIES
   sass-rails (~> 5)
   scss_lint (>= 0.56.0)
   sdoc
+  select2-rails
   selenium-webdriver
   shoulda
   sidekiq (~> 5.0)

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -15,4 +15,5 @@
 //= require jquery3
 //= require popper
 //= require bootstrap
+//= require select2
 //= require_tree ./jupiter

--- a/app/assets/javascripts/jupiter/communities_collections_searchbox.js
+++ b/app/assets/javascripts/jupiter/communities_collections_searchbox.js
@@ -1,0 +1,26 @@
+$(document).on('turbolinks:load', function() {
+  $('.js-communities-collections-searchbox').each(function() {
+    $(this).select2({
+      theme: 'bootstrap',
+      ajax: {
+        // The '.json' fixes issues with chrome cacheing
+        url: 'communities.json',
+        allowClear: true,
+        dataType: 'json',
+        data: function(params) {
+          var query = {
+            query: params.term
+          }
+          return query;
+        }
+      }
+    }).on('select2:select', function(e) {
+      var data = e.params.data;
+      if (data.path) {
+        // To ensure we get the placeholder when user clicks back (firefox)
+        $(this).val('');
+        window.location.href = data.path;
+      }
+    });
+  });
+});

--- a/app/assets/javascripts/jupiter/communities_collections_searchbox.js
+++ b/app/assets/javascripts/jupiter/communities_collections_searchbox.js
@@ -1,25 +1,23 @@
 $(document).on('turbolinks:load', function() {
-  $('.js-communities-collections-searchbox').each(function() {
-    $(this).select2({
-      theme: 'bootstrap',
-      ajax: {
-        url: 'communities',
-        cache: false,
-        dataType: 'json',
-        data: function(params) {
-          var query = {
-            query: params.term
-          };
-          return query;
-        }
+  $('.js-communities-collections-searchbox').select2({
+    theme: 'bootstrap',
+    ajax: {
+      url: 'communities',
+      cache: false,
+      dataType: 'json',
+      data: function(params) {
+        var query = {
+          query: params.term
+        };
+        return query;
       }
-    }).on('select2:select', function(e) {
-      var data = e.params.data;
-      if (data.path) {
-        // To ensure we get the placeholder text when user clicks selection then back button (firefox)
-        $(this).val(null).trigger("change");
-        window.location.href = data.path;
-      }
-    });
+    }
+  }).on('select2:select', function(e) {
+    var data = e.params.data;
+    if (data.path) {
+      // To ensure we get the placeholder text when user clicks selection then back button (firefox)
+      $(this).val(null).trigger("change");
+      window.location.href = data.path;
+    }
   });
 });

--- a/app/assets/javascripts/jupiter/communities_collections_searchbox.js
+++ b/app/assets/javascripts/jupiter/communities_collections_searchbox.js
@@ -10,7 +10,7 @@ $(document).on('turbolinks:load', function() {
         data: function(params) {
           var query = {
             query: params.term
-          }
+          };
           return query;
         }
       }

--- a/app/assets/javascripts/jupiter/communities_collections_searchbox.js
+++ b/app/assets/javascripts/jupiter/communities_collections_searchbox.js
@@ -3,9 +3,8 @@ $(document).on('turbolinks:load', function() {
     $(this).select2({
       theme: 'bootstrap',
       ajax: {
-        // The '.json' fixes issues with chrome cacheing
-        url: 'communities.json',
-        allowClear: true,
+        url: 'communities',
+        cache: false,
         dataType: 'json',
         data: function(params) {
           var query = {
@@ -17,8 +16,8 @@ $(document).on('turbolinks:load', function() {
     }).on('select2:select', function(e) {
       var data = e.params.data;
       if (data.path) {
-        // To ensure we get the placeholder when user clicks back (firefox)
-        $(this).val('');
+        // To ensure we get the placeholder text when user clicks selection then back button (firefox)
+        $(this).val(null).trigger("change");
         window.location.href = data.path;
       }
     });

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,5 +1,7 @@
 @import 'bootstrap';
 @import 'font-awesome';
+@import 'select2';
+@import 'select2-bootstrap';
 
 @import 'jupiter';
 @import 'simple_form';

--- a/app/controllers/admin/communities_controller.rb
+++ b/app/controllers/admin/communities_controller.rb
@@ -89,7 +89,7 @@ class Admin::CommunitiesController < Admin::AdminController
     @community = Community.find(params[:id])
   end
 
-  # Duck-types so that both admin and non-admin paths can reuse code
+  # Override the regular non-admin paths set in CommunitiesCollectionsTypeahead
   def path_to_community(community)
     admin_community_path(community)
   end

--- a/app/controllers/admin/communities_controller.rb
+++ b/app/controllers/admin/communities_controller.rb
@@ -1,11 +1,21 @@
 class Admin::CommunitiesController < Admin::AdminController
 
+  include CommunitiesCollectionsTypeahead
+
   before_action :fetch_community, only: [:show, :edit, :update, :destroy]
 
   def index
-    @communities = Community.sort(sort_column, sort_direction).page params[:page]
-    @title = t('.header')
-    render template: 'communities/index'
+    respond_to do |format|
+      format.html do
+        @communities = Community.sort(sort_column, sort_direction).page params[:page]
+        @title = t('.header')
+        render template: 'communities/index'
+      end
+      format.json do
+        results = typeahead_results(params[:query])
+        render json: { results: results }
+      end
+    end
   end
 
   def show
@@ -77,6 +87,15 @@ class Admin::CommunitiesController < Admin::AdminController
 
   def fetch_community
     @community = Community.find(params[:id])
+  end
+
+  # Duck-types so that both admin and non-admin paths can reuse code
+  def path_to_community(community)
+    admin_community_path(community)
+  end
+
+  def path_to_collection(collection)
+    admin_community_collection_path(collection.community, collection)
   end
 
 end

--- a/app/controllers/communities_controller.rb
+++ b/app/controllers/communities_controller.rb
@@ -35,15 +35,4 @@ class CommunitiesController < ApplicationController
     end
   end
 
-  private
-
-  # Duck-types so that both admin and non-admin paths can reuse code
-  def path_to_community(community)
-    community_path(community)
-  end
-
-  def path_to_collection(collection)
-    community_collection_path(collection.community, collection)
-  end
-
 end

--- a/app/controllers/communities_controller.rb
+++ b/app/controllers/communities_controller.rb
@@ -1,9 +1,19 @@
 class CommunitiesController < ApplicationController
 
+  include CommunitiesCollectionsTypeahead
+
   def index
     authorize Community
-    @communities = Community.sort(sort_column, sort_direction).page params[:page]
-    @title = t('.header')
+    respond_to do |format|
+      format.html do
+        @communities = Community.sort(sort_column, sort_direction).page params[:page]
+        @title = t('.header')
+      end
+      format.json do
+        results = typeahead_results(params[:query])
+        render json: { results: results }
+      end
+    end
   end
 
   def show
@@ -23,6 +33,17 @@ class CommunitiesController < ApplicationController
         render json: @community.attributes.merge(collections: @community.member_collections)
       end
     end
+  end
+
+  private
+
+  # Duck-types so that both admin and non-admin paths can reuse code
+  def path_to_community(community)
+    community_path(community)
+  end
+
+  def path_to_collection(collection)
+    community_collection_path(collection.community, collection)
   end
 
 end

--- a/app/controllers/concerns/communities_collections_typeahead.rb
+++ b/app/controllers/concerns/communities_collections_typeahead.rb
@@ -1,5 +1,4 @@
 module CommunitiesCollectionsTypeahead
-  # Note: needs these duck-typed methods: `path_to_community`, `path_to_collection`
   def typeahead_results(term)
     results = []
     if term.present?
@@ -24,5 +23,16 @@ module CommunitiesCollectionsTypeahead
       end
     end
     results
+  end
+
+  private
+
+  # Note: these get overridden in admin communities controller
+  def path_to_community(community)
+    community_path(community)
+  end
+
+  def path_to_collection(collection)
+    community_collection_path(collection.community, collection)
   end
 end

--- a/app/controllers/concerns/communities_collections_typeahead.rb
+++ b/app/controllers/concerns/communities_collections_typeahead.rb
@@ -1,0 +1,28 @@
+module CommunitiesCollectionsTypeahead
+  # Note: needs these duck-typed methods: `path_to_community`, `path_to_collection`
+  def typeahead_results(term)
+    results = []
+    if term.present?
+      communities = JupiterCore::Search.faceted_search(q: "title_tesim:#{term}*",
+                                                       models: [Community], as: current_user)
+                                       .sort(:title, :asc)
+                                       .map do |c|
+        { id: c.id, text: c.title, path: path_to_community(c) }
+      end
+      if communities.any?
+        results.append(text: 'Communities', children: communities)
+      end
+      # TODO: sort by community name first, collection name second (see Issue #276)
+      collections = JupiterCore::Search.faceted_search(q: "title_tesim:#{term}*",
+                                                       models: [Collection], as: current_user)
+                                       .sort(:title, :asc)
+                                       .map do |c|
+        { id: c.id, text: "#{c.community.title} -- #{c.title}", path: path_to_collection(c) }
+      end
+      if collections.any?
+        results.append(text: 'Collections', children: collections)
+      end
+    end
+    results
+  end
+end

--- a/app/models/jupiter_core/deferred_simple_solr_query.rb
+++ b/app/models/jupiter_core/deferred_simple_solr_query.rb
@@ -115,7 +115,7 @@ class JupiterCore::DeferredSimpleSolrQuery
       attr_queries = []
       attr_queries << criteria[:where].map do |k, v|
         solr_key = k == :id ? k : criteria[:model].attribute_metadata(k)[:solr_names].first
-        %Q(_query_:"{!field f=#{solr_key}}#{v}")
+        %Q(_query_:"#{solr_key}:#{v}")
       end
     else
       ''

--- a/app/views/communities/index.html.erb
+++ b/app/views/communities/index.html.erb
@@ -14,10 +14,9 @@
 <form>
   <div class="form-group">
     <label class="mr-sm-2" for="query"><%= t('search_label') %></label>
-    <%= search_field_tag :query,
-        params[:query],
-        placeholder: t('communities.index.search_placeholder'),
-        class: 'form-control' %>
+    <%= select_tag :query, '',
+        data: { placeholder: t('communities.index.search_placeholder') },
+        class: 'form-control js-communities-collections-searchbox' %>
   </div>
 </form>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -249,7 +249,7 @@ en:
       header: 'Communities'
       delete_confirm: 'Are you sure you want to delete community "%{title}"?'
       create_community: 'Create Community'
-      search_placeholder: 'collection name or community name... (TODO not implemented)'
+      search_placeholder: 'Type all or part of a community or collection name ...'
     show:
       collections_list_header: 'Collections in this Community'
       create_collection: 'Create Collection'

--- a/solr/config/schema.xml
+++ b/solr/config/schema.xml
@@ -143,6 +143,13 @@
         -->
         <filter class="solr.TrimFilterFactory"/>
       </analyzer>
+      <analyzer type="multiterm">
+        <tokenizer class="solr.ICUTokenizerFactory"/>
+        <filter class="solr.ICUFoldingFilterFactory"/>
+        <filter class="solr.EnglishPossessiveFilterFactory"/>
+        <filter class="solr.EnglishMinimalStemFilterFactory"/>
+        <filter class="solr.TrimFilterFactory"/>
+      </analyzer>
     </fieldType>
 
     <!-- queries for paths match documents at that path, or in descendent paths -->

--- a/test/system/communities_typeahead_test.rb
+++ b/test/system/communities_typeahead_test.rb
@@ -1,0 +1,46 @@
+require 'application_system_test_case'
+
+class CommunitiesTypeaheadTest < ApplicationSystemTestCase
+
+  def before_all
+    super
+    @community = Community.new_locked_ldp_object(title: 'Department of thing', owner: 1)
+                          .unlock_and_fetch_ldp_object(&:save!)
+    @community2 = Community.new_locked_ldp_object(title: 'Other community', owner: 1)
+                           .unlock_and_fetch_ldp_object(&:save!)
+    Collection.new_locked_ldp_object(title: 'Articles about thing', owner: 1, community_id: @community.id)
+              .unlock_and_fetch_ldp_object(&:save!)
+    Collection.new_locked_ldp_object(title: 'Other stuff', owner: 1, community_id: @community.id)
+              .unlock_and_fetch_ldp_object(&:save!)
+    @collection = Collection.new_locked_ldp_object(title: 'Other stuff things', owner: 1, community_id: @community2.id)
+                            .unlock_and_fetch_ldp_object(&:save!)
+  end
+
+  context 'Non-logged in user (or anybody really)' do
+    should 'be able to typeahead communities and collections' do
+      visit communities_path
+      # Click to expose input
+      find('.select2-container').click
+
+      # Start typing ...
+      find('.select2-search input').set('thin')
+
+      # Community search results
+      communities = find('.select2-results li:first-child', text: 'Communities')
+      communities.assert_selector('li', count: 1)
+      communities.assert_selector('li', text: 'Department of thing')
+      communities.refute_selector('li', text: 'Other community')
+
+      # Collection search results
+      collections = find('.select2-results li:last-child', text: 'Collections')
+      collections.assert_selector('li', count: 2)
+      collections.assert_selector('li', text: 'Department of thing -- Articles about thing')
+      collections.assert_selector('li', text: 'Other community -- Other stuff things')
+
+      # Select a result to visit the page
+      collections.find('li', text: 'Other community -- Other stuff things').click
+      assert_equal URI.parse(current_url).request_uri, community_collection_path(@community2, @collection)
+    end
+  end
+
+end


### PR DESCRIPTION
Does what it's supposed to, as per the mockup here:

https://jupiter.mybalsamiq.com/projects/jupiter/Communities%20and%20Collections

Added to both communities and admin communities index pages.
Added a system test.

Here is a screenshot:

![communities_typeahead](https://user-images.githubusercontent.com/672104/33149138-d30074fa-cf8b-11e7-9c69-192777318c05.png)

Fixes #242 
This fills in the last checkbox of #229 