### PR TITLE
WIP - Skip to search link

### DIFF
--- a/app/assets/javascripts/jupiter/skip.js
+++ b/app/assets/javascripts/jupiter/skip.js
@@ -1,0 +1,7 @@
+$("#skip-nav").click(function() {
+    $('main').focus();
+});
+$("#skip-to-results").click(function() {
+    $('main').blur();
+    $("#results-anchor").focus();
+});

--- a/app/assets/stylesheets/jupiter.scss
+++ b/app/assets/stylesheets/jupiter.scss
@@ -9,3 +9,50 @@ body {
   font-weight: bold;
   text-decoration: inherit;
 }
+#skiptocontent a {
+	padding:6px;
+	position: absolute;
+	top:-40px;
+	left:0px;
+	color:white;
+	border-right:1px solid white;
+	border-bottom:1px solid white;
+	border-bottom-right-radius:8px;
+	background:transparent;
+	-webkit-transition: top 1s ease-out, background 1s linear;
+    transition: top 1s ease-out, background 1s linear;
+    z-index: 100;
+}
+
+#skiptocontent a:focus {
+	position:absolute;
+	left:0px;
+	top:0px;
+	background:$red;
+	outline:0;	
+	-webkit-transition: top .1s ease-in, background .5s linear;
+    transition: top .1s ease-in, background .5s linear;
+}
+#skiptoresults a {
+        padding:6px;
+        position: absolute;
+        left:-1000px;
+        color: $white;
+        border-right:1px solid $white;
+        border-bottom:1px solid $white;
+        border-bottom-right-radius:8px;
+        background:transparent;
+        -webkit-transition: top 1s ease-out, background 1s linear;
+    transition: top 1s ease-out, background 1s linear;
+    z-index: 100;
+}
+
+#skiptoresults a:focus {
+        position:absolute;
+        left:100px;
+        background:$red;
+        outline:0;
+        -webkit-transition: top .1s ease-in, background .5s linear;
+    transition: top .1s ease-in, background .5s linear;
+}
+

--- a/app/views/application/_navbar.html.erb
+++ b/app/views/application/_navbar.html.erb
@@ -7,7 +7,7 @@
       <%= t('site_name') %>
     <% end %>
     <div id ="skiptocontent">
-      <%= link_to "Skip to Main Content", '#content-anchor', id:"skip-nav" %>
+      <%= link_to t('.skip_to_main_content'), '#main', id:"skip-nav" %>
     </div>
 
     <button type="button"

--- a/app/views/application/_navbar.html.erb
+++ b/app/views/application/_navbar.html.erb
@@ -6,6 +6,9 @@
       <%= image_tag 'mc_360.png', width: '30', height: '30', class: 'd-inline-block align-top', alt: t('.logo_alt') %>
       <%= t('site_name') %>
     <% end %>
+    <div id ="skiptocontent">
+      <%= link_to "Skip to Main Content", '#content-anchor', id:"skip-nav" %>
+    </div>
 
     <button type="button"
             class="navbar-toggler"
@@ -30,7 +33,6 @@
 
       <ul class="navbar-nav pull-xs-right mr-2">
         <li role="presentation" class="nav-item mr-3">
-
           <form class="form-inline" action="<%= search_path %>">
             <div class="input-group" aria-label="navbar-search">
               <%= search_field_tag 'search', nil, placeholder: t('.search.placeholder'),

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -17,7 +17,7 @@
     <%= render partial: 'navbar' %>
     <%= render partial: 'announcement' %>
 
-    <main class="container mt-5">
+    <main class="container mt-5" id="content-anchor">
       <%= render partial: 'flash' %>
       <%= content_for?(:content) ? yield(:content) : yield %>
     </main>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -17,7 +17,7 @@
     <%= render partial: 'navbar' %>
     <%= render partial: 'announcement' %>
 
-    <main class="container mt-5" id="content-anchor">
+    <main class="container mt-5" id="main">
       <%= render partial: 'flash' %>
       <%= content_for?(:content) ? yield(:content) : yield %>
     </main>

--- a/app/views/search/_model_results.html.erb
+++ b/app/views/search/_model_results.html.erb
@@ -50,7 +50,7 @@
     <div class='jupiter-results-list' id="results-anchor">
       <ul class="list-group">
         <% results.each do |result| %>
-          <li class="list-group-item list-group-item-action" id="results-anchor">
+          <li class="list-group-item list-group-item-action">
             <% if model == :item %>
               <%= render partial: 'search/item_hit', locals: { result: result } %>
             <% else %>

--- a/app/views/search/_model_results.html.erb
+++ b/app/views/search/_model_results.html.erb
@@ -1,5 +1,5 @@
 <div id="skiptoresults">
-<%= link_to "Skip to Search Results", '#search-sort-button', id: "skip-link" %>
+<%= link_to t('search.skip_to_search', '#results-anchor', id: "skip-to-results" %>
 </div>
 
 <div class="row mt-3 jupiter-model-results">
@@ -47,7 +47,7 @@
     </div>
 
     <%# Results list %>
-    <div class='jupiter-results-list'>
+    <div class='jupiter-results-list' id="results-anchor">
       <ul class="list-group">
         <% results.each do |result| %>
           <li class="list-group-item list-group-item-action" id="results-anchor">

--- a/app/views/search/_model_results.html.erb
+++ b/app/views/search/_model_results.html.erb
@@ -1,3 +1,7 @@
+<div id="skiptoresults">
+<%= link_to "Skip to Search Results", '#search-sort-button', id: "skip-link" %>
+</div>
+
 <div class="row mt-3 jupiter-model-results">
 
   <%# Facets panel %>
@@ -13,7 +17,6 @@
       </div>
     </div>
   </div>
-
   <%# Results panel %>
   <div class="col-md-9 col-sm-10 card jupiter-results">
     <div class='p-3'>
@@ -47,7 +50,7 @@
     <div class='jupiter-results-list'>
       <ul class="list-group">
         <% results.each do |result| %>
-          <li class="list-group-item list-group-item-action">
+          <li class="list-group-item list-group-item-action" id="results-anchor">
             <% if model == :item %>
               <%= render partial: 'search/item_hit', locals: { result: result } %>
             <% else %>
@@ -63,6 +66,5 @@
       </div>
     </div>
     <%= paginate results %>
-
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -89,6 +89,7 @@ en:
         logout_as_user: 'Logout as User'
       user_dropdown:
         heading_html: "Signed in as <strong>%{name}</strong>"
+      skip_to_main_content: "Skip to Main Content"
 
   locked_ldp_object:
     errors:
@@ -310,7 +311,7 @@ en:
     tab_header_items_with_count: 'Items (%{count})'
     tab_header_collections_with_count: 'Collections (%{count})'
     tab_header_communities_with_count: 'Communities (%{count})'
-
+    skip_to_results: 'Skip to Search Results'
     index:
       header: 'Search Items'
       no_results_found: No results found


### PR DESCRIPTION
This is to add "skip to main content" and "skip to search" links to the application following recommendations from https://webaim.org/techniques/skipnav/. 

Both links work fine independently, but when I use "skip to main content" and then "skip to search" link, the tab focus is incorrect, instead of focusing on the search list, it goes back to the header. 

I was trying to solve it with JS, but doesn't seem to help. The JS doesn't seem to be called after the URL is changed to the anchor link. @murny @mbarnett @cwant Dp you have any idea why that is? 