### PR TITLE
Pluralize some multi-valued attributes.

### DIFF
--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -12,7 +12,7 @@ class Collection < JupiterCore::LockedLdpObject
                 solrize_for: :pathing
 
   has_attribute :description, ::RDF::Vocab::DC.description, solrize_for: [:search]
-  has_multival_attribute :creator, ::RDF::Vocab::DC.creator, solrize_for: :exact_match
+  has_multival_attribute :creators, ::RDF::Vocab::DC.creator, solrize_for: :exact_match
   has_attribute :fedora3_uuid, ::TERMS[:ual].fedora3uuid, solrize_for: :exact_match
 
   additional_search_index :community_title, solrize_for: :sort,

--- a/app/models/community.rb
+++ b/app/models/community.rb
@@ -7,7 +7,7 @@ class Community < JupiterCore::LockedLdpObject
 
   has_attribute :title, ::RDF::Vocab::DC.title, solrize_for: [:search, :sort]
   has_attribute :description, ::RDF::Vocab::DC.description, solrize_for: [:search]
-  has_multival_attribute :creator, ::RDF::Vocab::DC.creator, solrize_for: :exact_match
+  has_multival_attribute :creators, ::RDF::Vocab::DC.creator, solrize_for: :exact_match
   has_attribute :fedora3_uuid, ::TERMS[:ual].fedora3uuid, solrize_for: :exact_match
 
   # this method can be used on the SolrCached object OR the ActiveFedora object

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -11,15 +11,15 @@ class Item < JupiterCore::LockedLdpObject
 
   # Dublin Core attributes
   has_attribute :title, ::RDF::Vocab::DC.title, solrize_for: [:search, :sort]
-  has_multival_attribute :creator, ::RDF::Vocab::DC.creator, solrize_for: [:search, :facet]
-  has_multival_attribute :contributor, ::RDF::Vocab::DC.contributor, solrize_for: [:search, :facet]
+  has_multival_attribute :creators, ::RDF::Vocab::DC.creator, solrize_for: [:search, :facet]
+  has_multival_attribute :contributors, ::RDF::Vocab::DC.contributor, solrize_for: [:search, :facet]
   has_attribute :created, ::RDF::Vocab::DC.created, solrize_for: [:search, :sort]
   has_attribute :sort_year, ::TERMS[:ual].sortyear, solrize_for: [:search, :sort, :facet]
   has_multival_attribute :subject, ::RDF::Vocab::DC.subject, solrize_for: [:search, :facet]
   has_attribute :description, ::RDF::Vocab::DC.description, type: :text, solrize_for: :search
   has_attribute :publisher, ::RDF::Vocab::DC.publisher, solrize_for: [:search, :facet]
   # has_attribute :date_modified, ::RDF::Vocab::DC.modified, type: :date, solrize_for: :sort
-  has_multival_attribute :language, ::RDF::Vocab::DC.language, solrize_for: [:search, :facet]
+  has_multival_attribute :languages, ::RDF::Vocab::DC.language, solrize_for: [:search, :facet]
   has_attribute :embargo_end_date, ::RDF::Vocab::DC.available, type: :date, solrize_for: [:sort]
   has_attribute :license, ::RDF::Vocab::DC.license, solrize_for: [:search]
   has_attribute :rights, ::RDF::Vocab::DC.rights, solrize_for: :exact_match
@@ -100,7 +100,7 @@ class Item < JupiterCore::LockedLdpObject
     validates :visibility_after_embargo, absence: true, if: ->(item) { item.visibility != VISIBILITY_EMBARGO }
     validates :member_of_paths, presence: true
     validates :title, presence: true
-    validates :language, presence: true
+    validates :languages, presence: true
     validates :item_type, presence: true
     validate :communities_and_collections_validations
     validate :language_validations
@@ -169,8 +169,8 @@ class Item < JupiterCore::LockedLdpObject
     end
 
     def language_validations
-      language.each do |lang|
-        uri_validation(lang, :language)
+      languages.each do |lang|
+        uri_validation(lang, :languages, :language)
       end
     end
 

--- a/app/views/search/_item_hit.html.erb
+++ b/app/views/search/_item_hit.html.erb
@@ -33,7 +33,7 @@
     </div>
     <div>
       <%# TODO: the search path may need to be revisited %>
-      <%= result.creator&.map { |creator| link_to creator, search_path(search: result.search_term_for(:creator)) }
+      <%= result.creators&.map { |creator| link_to creator, search_path(search: result.search_term_for(:creators)) }
                         &.join(', ')&.html_safe %>
     </div>
     <div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -61,7 +61,7 @@ en:
             member_of_paths:
               community_not_found: 'is missing community with ID "%{id}"'
               collection_not_found: 'is missing collection with ID "%{id}"'
-            language:
+            languages:
               not_recognized: 'is not recognized'
             license:
               not_recognized: 'is not recognized'

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -113,13 +113,13 @@ if Rails.env.development? || Rails.env.uat?
         licence_right = {}
         attributes = {
           owner: admin.id,
-          creator: creator.uniq,
-          contributor: [contributors[rand(10)]],
+          creators: creator.uniq,
+          contributors: [contributors[rand(10)]],
           created: (Time.now - rand(20_000).days).to_s,
           visibility: JupiterCore::VISIBILITY_PUBLIC,
           title: "The effects of #{Faker::Beer.name} on #{thing.pluralize}",
           description: description,
-          language: [language],
+          languages: [language],
         }
         if seed % 10 < 7
           attributes[:license] = CONTROLLED_VOCABULARIES[:license].attribution_4_0_international
@@ -146,7 +146,7 @@ if Rails.env.development? || Rails.env.uat?
         visibility: JupiterCore::VISIBILITY_PRIVATE,
         title: "Private #{thing.pluralize}, public lives: a survey of social media trends",
         description: Faker::Lorem.sentence(20, false, 0).chop,
-        language: [CONTROLLED_VOCABULARIES[:language].eng],
+        languages: [CONTROLLED_VOCABULARIES[:language].eng],
         license: CONTROLLED_VOCABULARIES[:license].attribution_4_0_international,
         item_type: CONTROLLED_VOCABULARIES[:item_type].chapter
       ).unlock_and_fetch_ldp_object do |uo|
@@ -160,7 +160,7 @@ if Rails.env.development? || Rails.env.uat?
         visibility: Item::VISIBILITY_EMBARGO,
         title: "Embargo and #{Faker::Address.country}: were the #{thing.pluralize} left behind?",
         description: Faker::Lorem.sentence(20, false, 0).chop,
-        language: [CONTROLLED_VOCABULARIES[:language].eng],
+        languages: [CONTROLLED_VOCABULARIES[:language].eng],
         license: CONTROLLED_VOCABULARIES[:license].attribution_4_0_international,
         item_type: CONTROLLED_VOCABULARIES[:item_type].conference_paper
       ).unlock_and_fetch_ldp_object do |uo|
@@ -176,7 +176,7 @@ if Rails.env.development? || Rails.env.uat?
         visibility: Item::VISIBILITY_EMBARGO,
         title: "Former embargo of #{Faker::Address.country}: the day the #{thing.pluralize} were free",
         description: Faker::Lorem.sentence(20, false, 0).chop,
-        language: [CONTROLLED_VOCABULARIES[:language].eng],
+        languages: [CONTROLLED_VOCABULARIES[:language].eng],
         license: CONTROLLED_VOCABULARIES[:license].attribution_4_0_international,
         item_type: CONTROLLED_VOCABULARIES[:item_type].dataset
       ).unlock_and_fetch_ldp_object do |uo|
@@ -192,7 +192,7 @@ if Rails.env.development? || Rails.env.uat?
         visibility: JupiterCore::VISIBILITY_PUBLIC,
         title: "Impact of non-admin users on #{thing.pluralize}",
         description: Faker::Lorem.sentence(20, false, 0).chop,
-        language: [CONTROLLED_VOCABULARIES[:language].eng],
+        languages: [CONTROLLED_VOCABULARIES[:language].eng],
         license: CONTROLLED_VOCABULARIES[:license].attribution_4_0_international,
         item_type: CONTROLLED_VOCABULARIES[:item_type].learning_object
       ).unlock_and_fetch_ldp_object do |uo|
@@ -209,7 +209,7 @@ if Rails.env.development? || Rails.env.uat?
       title: "Multi-collection random images of #{thing.pluralize}",
       description: Faker::Lorem.sentence(20, false, 0).chop,
       # No linguistic content
-      language: [CONTROLLED_VOCABULARIES[:language].zxx],
+      languages: [CONTROLLED_VOCABULARIES[:language].zxx],
       license: CONTROLLED_VOCABULARIES[:license].attribution_4_0_international,
       item_type: CONTROLLED_VOCABULARIES[:item_type].image
     ).unlock_and_fetch_ldp_object do |uo|

--- a/test/controllers/admin/collections_controller_test.rb
+++ b/test/controllers/admin/collections_controller_test.rb
@@ -97,7 +97,7 @@ class Admin::CollectionsControllerTest < ActionDispatch::IntegrationTest
       Item.new_locked_ldp_object(
         title: 'thesis blocking deletion',
         owner: 1,
-        language: [CONTROLLED_VOCABULARIES[:language].eng],
+        languages: [CONTROLLED_VOCABULARIES[:language].eng],
         license: CONTROLLED_VOCABULARIES[:license].attribution_4_0_international,
         visibility: JupiterCore::VISIBILITY_PRIVATE,
         item_type: CONTROLLED_VOCABULARIES[:item_type].article,

--- a/test/integration/collection_show_test.rb
+++ b/test/integration/collection_show_test.rb
@@ -18,7 +18,7 @@ class CollectionShowTest < ActionDispatch::IntegrationTest
     @items = ['Fancy', 'Nice'].map do |adjective|
       Item.new_locked_ldp_object(visibility: JupiterCore::VISIBILITY_PUBLIC,
                                  owner: 1,
-                                 language: [CONTROLLED_VOCABULARIES[:language].eng],
+                                 languages: [CONTROLLED_VOCABULARIES[:language].eng],
                                  license: CONTROLLED_VOCABULARIES[:license].attribution_4_0_international,
                                  item_type: CONTROLLED_VOCABULARIES[:item_type].article,
                                  publication_status: CONTROLLED_VOCABULARIES[:publication_status].published,

--- a/test/integration/item_show_test.rb
+++ b/test/integration/item_show_test.rb
@@ -23,7 +23,7 @@ class ItemShowTest < ActionDispatch::IntegrationTest
       uo.title = 'Fantastic item'
       uo.owner = 1
       uo.visibility = JupiterCore::VISIBILITY_PUBLIC
-      uo.language = [CONTROLLED_VOCABULARIES[:language].eng]
+      uo.languages = [CONTROLLED_VOCABULARIES[:language].eng]
       uo.license = CONTROLLED_VOCABULARIES[:license].attribution_4_0_international
       uo.item_type = CONTROLLED_VOCABULARIES[:item_type].article
       uo.publication_status = CONTROLLED_VOCABULARIES[:publication_status].draft

--- a/test/models/file_set_test.rb
+++ b/test/models/file_set_test.rb
@@ -36,7 +36,7 @@ class FileSetTest < ActiveSupport::TestCase
                                       visibility: JupiterCore::VISIBILITY_PUBLIC,
                                       owner: 1,
                                       item_type: CONTROLLED_VOCABULARIES[:item_type].report,
-                                      language: [CONTROLLED_VOCABULARIES[:language].eng],
+                                      languages: [CONTROLLED_VOCABULARIES[:language].eng],
                                       license: CONTROLLED_VOCABULARIES[:license].attribution_4_0_international)
 
     item.unlock_and_fetch_ldp_object do |unlocked_item|

--- a/test/models/item_test.rb
+++ b/test/models/item_test.rb
@@ -11,7 +11,7 @@ class ItemTest < ActiveSupport::TestCase
                                                   community_id: community.id)
     collection.unlock_and_fetch_ldp_object(&:save!)
     item = Item.new_locked_ldp_object(title: 'Item', owner: 1, visibility: JupiterCore::VISIBILITY_PUBLIC,
-                                      language: [CONTROLLED_VOCABULARIES[:language].eng],
+                                      languages: [CONTROLLED_VOCABULARIES[:language].eng],
                                       license: CONTROLLED_VOCABULARIES[:license].attribution_4_0_international,
                                       item_type: CONTROLLED_VOCABULARIES[:item_type].article,
                                       publication_status: CONTROLLED_VOCABULARIES[:publication_status].draft)
@@ -153,17 +153,17 @@ class ItemTest < ActiveSupport::TestCase
     item = Item.new_locked_ldp_object
 
     assert_not item.valid?
-    assert_includes item.errors[:language], "can't be blank"
+    assert_includes item.errors[:languages], "can't be blank"
   end
 
   test 'a language must be from the controlled vocabulary' do
-    item = Item.new_locked_ldp_object(language: ['whatever'])
+    item = Item.new_locked_ldp_object(languages: ['whatever'])
     assert_not item.valid?
-    assert_includes item.errors[:language], 'is not recognized'
+    assert_includes item.errors[:languages], 'is not recognized'
 
-    item = Item.new_locked_ldp_object(language: [CONTROLLED_VOCABULARIES[:language].eng])
+    item = Item.new_locked_ldp_object(languages: [CONTROLLED_VOCABULARIES[:language].eng])
     assert_not item.valid?
-    refute_includes item.errors.keys, :language
+    refute_includes item.errors.keys, :languages
   end
 
   test 'a license or rights statement must be present' do

--- a/test/system/search_test.rb
+++ b/test/system/search_test.rb
@@ -16,7 +16,7 @@ class SearchTest < ApplicationSystemTestCase
     @items = 10.times.map do |i|
       Item.new_locked_ldp_object(visibility: JupiterCore::VISIBILITY_PUBLIC,
                                  owner: 1, title: "#{['Fancy', 'Nice'][i % 2]} Item #{i}",
-                                 language: [CONTROLLED_VOCABULARIES[:language].eng],
+                                 languages: [CONTROLLED_VOCABULARIES[:language].eng],
                                  item_type: CONTROLLED_VOCABULARIES[:item_type].article,
                                  publication_status: CONTROLLED_VOCABULARIES[:publication_status].published,
                                  license: CONTROLLED_VOCABULARIES[:license].attribution_4_0_international)
@@ -29,7 +29,7 @@ class SearchTest < ApplicationSystemTestCase
     @items += 10.times.map do |i|
       Item.new_locked_ldp_object(visibility: JupiterCore::VISIBILITY_PRIVATE,
                                  owner: 1, title: "#{['Fancy', 'Nice'][i % 2]} Private Item #{i + 10}",
-                                 language: [CONTROLLED_VOCABULARIES[:language].eng],
+                                 languages: [CONTROLLED_VOCABULARIES[:language].eng],
                                  item_type: CONTROLLED_VOCABULARIES[:item_type].article,
                                  publication_status: CONTROLLED_VOCABULARIES[:publication_status].published,
                                  license: CONTROLLED_VOCABULARIES[:license].attribution_4_0_international)
@@ -48,7 +48,7 @@ class SearchTest < ApplicationSystemTestCase
                              .unlock_and_fetch_ldp_object(&:save!)
       Item.new_locked_ldp_object(visibility: JupiterCore::VISIBILITY_PUBLIC,
                                  owner: 1, title: "Extra Item #{i}",
-                                 language: [CONTROLLED_VOCABULARIES[:language].eng],
+                                 languages: [CONTROLLED_VOCABULARIES[:language].eng],
                                  item_type: CONTROLLED_VOCABULARIES[:item_type].article,
                                  publication_status: CONTROLLED_VOCABULARIES[:publication_status].published,
                                  license: CONTROLLED_VOCABULARIES[:license].attribution_4_0_international)


### PR DESCRIPTION
Pluralize a few multi-valued attributes:

* `creator` --> `creators`
* `contributor` --> `contributors`
* `language` --> `languages`

Not pluralized:

* `subject`: `subjects` is a reserved keyword in ActiveFedora
* `embargo_history`: not so great when pluralized
