### PR TITLE
Final items in Issue #251 that aren't covered in other PRs.

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -22,10 +22,14 @@ class Item < JupiterCore::LockedLdpObject
   has_multival_attribute :languages, ::RDF::Vocab::DC.language, solrize_for: [:search, :facet]
   has_attribute :embargo_end_date, ::RDF::Vocab::DC.available, type: :date, solrize_for: [:sort]
   has_attribute :license, ::RDF::Vocab::DC.license, solrize_for: [:search]
-  has_attribute :rights, ::RDF::Vocab::DC.rights, solrize_for: :exact_match
+  has_attribute :rights, ::RDF::Vocab::DC11.rights, solrize_for: :exact_match
   # `type` is an ActiveFedora keyword, so we call it `item_type`
   # Note also the `item_type_with_status` below for searching, faceting and forms
   has_attribute :item_type, ::RDF::Vocab::DC.type, solrize_for: :exact_match
+  has_attribute :source, ::RDF::Vocab::DC.source, solrize_for: :exact_match
+  has_multival_attribute :is_version_of, ::RDF::Vocab::DC.isVersionOf, solrize_for: :exact_match
+  has_attribute :alternative, ::RDF::Vocab::DC.alternative, solrize_for: :search
+  has_attribute :relation, ::RDF::Vocab::DC.relation, solrize_for: :exact_match
 
   # UAL attributes
   has_attribute :depositor, ::TERMS[:ual].depositor, solrize_for: [:search]

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -69,6 +69,7 @@ class Item < JupiterCore::LockedLdpObject
                           as: -> { item_type_with_status_code }
 
   # Combine creators and contributors for faceting
+  # Note that contributors is converted to an array because it can be nil
   additional_search_index :all_contributors,
                           solrize_for: :facet,
                           as: -> { creators + contributors.to_a }
@@ -125,6 +126,7 @@ class Item < JupiterCore::LockedLdpObject
     validates :languages, presence: true
     validates :item_type, presence: true
     validates :subject, presence: true
+    validates :creators, presence: true
     validate :communities_and_collections_validations
     validate :language_validations
     validate :license_and_rights_validations

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -34,10 +34,10 @@ class Item < JupiterCore::LockedLdpObject
   # `type` is an ActiveFedora keyword, so we call it `item_type`
   # Note also the `item_type_with_status` below for searching, faceting and forms
   has_attribute :item_type, ::RDF::Vocab::DC.type, solrize_for: :exact_match
-  has_attribute :source, ::RDF::Vocab::DC.source, solrize_for: :exact_match
+  has_attribute :derived_from, ::RDF::Vocab::DC.source, solrize_for: :exact_match
   has_multival_attribute :is_version_of, ::RDF::Vocab::DC.isVersionOf, solrize_for: :exact_match
-  has_attribute :alternative, ::RDF::Vocab::DC.alternative, solrize_for: :search
-  has_attribute :relation, ::RDF::Vocab::DC.relation, solrize_for: :exact_match
+  has_attribute :alternative_title, ::RDF::Vocab::DC.alternative, solrize_for: :search
+  has_attribute :related_link, ::RDF::Vocab::DC.relation, solrize_for: :exact_match
 
   # UAL attributes
   has_attribute :depositor, ::TERMS[:ual].depositor, solrize_for: [:search]

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -144,6 +144,7 @@ if Rails.env.development? || Rails.env.uat?
       # Add an private item
       Item.new_locked_ldp_object(
         owner: admin.id,
+        creators: [creators[rand(10)]],
         visibility: JupiterCore::VISIBILITY_PRIVATE,
         title: "Private #{thing.pluralize}, public lives: a survey of social media trends",
         description: Faker::Lorem.sentence(20, false, 0).chop,
@@ -159,6 +160,7 @@ if Rails.env.development? || Rails.env.uat?
       # Add a currently embargoed item
       Item.new_locked_ldp_object(
         owner: admin.id,
+        creators: [creators[rand(10)]],
         visibility: Item::VISIBILITY_EMBARGO,
         title: "Embargo and #{Faker::Address.country}: were the #{thing.pluralize} left behind?",
         description: Faker::Lorem.sentence(20, false, 0).chop,
@@ -176,6 +178,7 @@ if Rails.env.development? || Rails.env.uat?
       # Add a formerly embargoed item
       Item.new_locked_ldp_object(
         owner: admin.id,
+        creators: [creators[rand(10)]],
         visibility: Item::VISIBILITY_EMBARGO,
         title: "Former embargo of #{Faker::Address.country}: the day the #{thing.pluralize} were free",
         description: Faker::Lorem.sentence(20, false, 0).chop,
@@ -193,6 +196,7 @@ if Rails.env.development? || Rails.env.uat?
       # Add an item owned by non-admin
       Item.new_locked_ldp_object(
         owner: non_admin.id,
+        creators: [creators[rand(10)]],
         visibility: JupiterCore::VISIBILITY_PUBLIC,
         title: "Impact of non-admin users on #{thing.pluralize}",
         description: Faker::Lorem.sentence(20, false, 0).chop,
@@ -212,6 +216,7 @@ if Rails.env.development? || Rails.env.uat?
     # Want one multi-collection item per community
     Item.new_locked_ldp_object(
       owner: admin.id,
+      creators: [creators[rand(10)]],
       visibility: JupiterCore::VISIBILITY_PUBLIC,
       title: "Multi-collection random images of #{thing.pluralize}",
       description: Faker::Lorem.sentence(20, false, 0).chop,

--- a/test/controllers/admin/collections_controller_test.rb
+++ b/test/controllers/admin/collections_controller_test.rb
@@ -97,6 +97,7 @@ class Admin::CollectionsControllerTest < ActionDispatch::IntegrationTest
       Item.new_locked_ldp_object(
         title: 'thesis blocking deletion',
         owner: 1,
+        creators: ['Joe Blow'],
         languages: [CONTROLLED_VOCABULARIES[:language].eng],
         license: CONTROLLED_VOCABULARIES[:license].attribution_4_0_international,
         visibility: JupiterCore::VISIBILITY_PRIVATE,

--- a/test/integration/collection_show_test.rb
+++ b/test/integration/collection_show_test.rb
@@ -18,6 +18,7 @@ class CollectionShowTest < ActionDispatch::IntegrationTest
     @items = ['Fancy', 'Nice'].map do |adjective|
       Item.new_locked_ldp_object(visibility: JupiterCore::VISIBILITY_PUBLIC,
                                  owner: 1,
+                                 creators: ['Joe Blow'],
                                  languages: [CONTROLLED_VOCABULARIES[:language].eng],
                                  license: CONTROLLED_VOCABULARIES[:license].attribution_4_0_international,
                                  item_type: CONTROLLED_VOCABULARIES[:item_type].article,

--- a/test/integration/item_show_test.rb
+++ b/test/integration/item_show_test.rb
@@ -22,6 +22,7 @@ class ItemShowTest < ActionDispatch::IntegrationTest
     @item1 = Item.new_locked_ldp_object.unlock_and_fetch_ldp_object do |uo|
       uo.title = 'Fantastic item'
       uo.owner = 1
+      uo.creators = ['Joe Blow']
       uo.visibility = JupiterCore::VISIBILITY_PUBLIC
       uo.languages = [CONTROLLED_VOCABULARIES[:language].eng]
       uo.license = CONTROLLED_VOCABULARIES[:license].attribution_4_0_international

--- a/test/models/file_set_test.rb
+++ b/test/models/file_set_test.rb
@@ -33,6 +33,7 @@ class FileSetTest < ActiveSupport::TestCase
                                                   community_id: community.id).unlock_and_fetch_ldp_object(&:save!)
 
     item = Item.new_locked_ldp_object(title: generate_random_string,
+                                      creators: [generate_random_string],
                                       visibility: JupiterCore::VISIBILITY_PUBLIC,
                                       owner: 1,
                                       item_type: CONTROLLED_VOCABULARIES[:item_type].report,

--- a/test/models/item_test.rb
+++ b/test/models/item_test.rb
@@ -12,6 +12,7 @@ class ItemTest < ActiveSupport::TestCase
     collection.unlock_and_fetch_ldp_object(&:save!)
     item = Item.new_locked_ldp_object(title: 'Item', owner: 1, visibility: JupiterCore::VISIBILITY_PUBLIC,
                                       languages: [CONTROLLED_VOCABULARIES[:language].eng],
+                                      creators: ['Joe Blow'],
                                       subject: ['Things'],
                                       license: CONTROLLED_VOCABULARIES[:license].attribution_4_0_international,
                                       item_type: CONTROLLED_VOCABULARIES[:item_type].article,
@@ -239,6 +240,12 @@ class ItemTest < ActiveSupport::TestCase
     item = Item.new_locked_ldp_object
     assert_not item.valid?
     assert_includes item.errors[:subject], "can't be blank"
+  end
+
+  test 'a creator is required' do
+    item = Item.new_locked_ldp_object
+    assert_not item.valid?
+    assert_includes item.errors[:creators], "can't be blank"
   end
 
 end

--- a/test/system/admin_users_show_test.rb
+++ b/test/system/admin_users_show_test.rb
@@ -163,6 +163,7 @@ class AdminUsersShowTest < ApplicationSystemTestCase
     ['Fancy', 'Nice'].each do |adjective|
       Item.new_locked_ldp_object(visibility: JupiterCore::VISIBILITY_PUBLIC,
                                  owner: user.id, title: "#{adjective} Item",
+                                 creators: ['Joe Blow'],
                                  languages: [CONTROLLED_VOCABULARIES[:language].eng],
                                  license: CONTROLLED_VOCABULARIES[:license].attribution_4_0_international,
                                  item_type: CONTROLLED_VOCABULARIES[:item_type].article,
@@ -176,6 +177,7 @@ class AdminUsersShowTest < ApplicationSystemTestCase
     # One item owned by admin
     Item.new_locked_ldp_object(visibility: JupiterCore::VISIBILITY_PUBLIC,
                                owner: admin.id, title: 'Admin Item',
+                               creators: ['Joe Blow'],
                                languages: [CONTROLLED_VOCABULARIES[:language].eng],
                                license: CONTROLLED_VOCABULARIES[:license].attribution_4_0_international,
                                item_type: CONTROLLED_VOCABULARIES[:item_type].article,

--- a/test/system/search_test.rb
+++ b/test/system/search_test.rb
@@ -16,6 +16,7 @@ class SearchTest < ApplicationSystemTestCase
     @items = 10.times.map do |i|
       Item.new_locked_ldp_object(visibility: JupiterCore::VISIBILITY_PUBLIC,
                                  owner: 1, title: "#{['Fancy', 'Nice'][i % 2]} Item #{i}",
+                                 creators: ['Joe Blow'],
                                  languages: [CONTROLLED_VOCABULARIES[:language].eng],
                                  item_type: CONTROLLED_VOCABULARIES[:item_type].article,
                                  publication_status: CONTROLLED_VOCABULARIES[:publication_status].published,
@@ -30,6 +31,7 @@ class SearchTest < ApplicationSystemTestCase
     @items += 10.times.map do |i|
       Item.new_locked_ldp_object(visibility: JupiterCore::VISIBILITY_PRIVATE,
                                  owner: 1, title: "#{['Fancy', 'Nice'][i % 2]} Private Item #{i + 10}",
+                                 creators: ['Joe Blow'],
                                  languages: [CONTROLLED_VOCABULARIES[:language].eng],
                                  item_type: CONTROLLED_VOCABULARIES[:item_type].article,
                                  publication_status: CONTROLLED_VOCABULARIES[:publication_status].published,
@@ -50,6 +52,7 @@ class SearchTest < ApplicationSystemTestCase
                              .unlock_and_fetch_ldp_object(&:save!)
       Item.new_locked_ldp_object(visibility: JupiterCore::VISIBILITY_PUBLIC,
                                  owner: 1, title: "Extra Item #{i}",
+                                 creators: ['Joe Blow'],
                                  languages: [CONTROLLED_VOCABULARIES[:language].eng],
                                  item_type: CONTROLLED_VOCABULARIES[:item_type].article,
                                  publication_status: CONTROLLED_VOCABULARIES[:publication_status].published,


### PR DESCRIPTION
Included:

* `derived_from`, which points to [dcterms:source](https://github.com/ualbertalib/metadata/blob/master/data_dictionary/profile_generic.md#dctermssource)
* `is_version_of`, which points to [dcterms:isVersionOf](https://github.com/ualbertalib/metadata/blob/master/data_dictionary/profile_generic.md#dctermsisversionof)
* `related_link`, which points to [dcterms:relation](https://github.com/ualbertalib/metadata/blob/master/data_dictionary/profile_generic.md#dctermsrelation)
* `alternative_title`, which points to [dcterms:alternative](https://github.com/ualbertalib/metadata/blob/master/data_dictionary/profile_generic.md#dctermsalternative)

But wait, also included:
* switch predicate from `dcterms` vocabulary to `dc` for [rights]().
* make [creators](https://github.com/ualbertalib/metadata/blob/master/data_dictionary/profile_generic.md#dccreator) required and update seeds/tests.