### PR TITLE
[WIP] Add a basic cached sitemap. Some work remaining to flesh it out

### DIFF
--- a/app/controllers/sitemap_controller.rb
+++ b/app/controllers/sitemap_controller.rb
@@ -1,0 +1,13 @@
+class SitemapController < ApplicationController
+
+  def index
+    authorize :sitemap, :index?
+
+    @cache_key = Time.current
+
+    @communities = Community.all
+    @collections = Collection.all
+    @items = Item.all # should be non-private
+    # TODO: Theses
+  end
+end

--- a/app/controllers/sitemap_controller.rb
+++ b/app/controllers/sitemap_controller.rb
@@ -3,12 +3,10 @@ class SitemapController < ApplicationController
   def index
     authorize :sitemap, :index?
 
-    @cache_key = Time.current
-
     @communities = Community.all
     @collections = Collection.all
     @items = Item.all # should be non-private
-    # TODO: Theses
+    # TODO: Theses or combine both with Chris' abstract superclass work
   end
 
 end

--- a/app/controllers/sitemap_controller.rb
+++ b/app/controllers/sitemap_controller.rb
@@ -10,4 +10,5 @@ class SitemapController < ApplicationController
     @items = Item.all # should be non-private
     # TODO: Theses
   end
+
 end

--- a/app/policies/sitemap_policy.rb
+++ b/app/policies/sitemap_policy.rb
@@ -1,0 +1,7 @@
+class SitemapPolicy < LockedLdpObjectPolicy
+
+  def index?
+    true
+  end
+
+end

--- a/app/views/sitemap/index.xml.builder
+++ b/app/views/sitemap/index.xml.builder
@@ -13,7 +13,8 @@ cache 'sitemap', expires_in: 24.hours do
         xml.loc community_url(community)
         xml.changefreq 'weekly'
         xml.priority   1
-        xml.lastmod Time.current.utc.iso8601 # TODO
+        # TODO: replace with modified_at (needs indexing, Matt to add to LockedLDPObject)
+        xml.lastmod Time.current.utc.iso8601
       end
     end
 
@@ -22,7 +23,8 @@ cache 'sitemap', expires_in: 24.hours do
         xml.loc community_collection_url(collection.community, collection)
         xml.changefreq 'weekly'
         xml.priority   1
-        xml.lastmod Time.current.utc.iso8601 # TODO
+        # TODO: replace with modified_at (needs indexing, Matt to add to LockedLDPObject)
+        xml.lastmod Time.current.utc.iso8601
       end
     end
 
@@ -31,7 +33,8 @@ cache 'sitemap', expires_in: 24.hours do
         xml.loc item_url(item)
         xml.changefreq 'weekly'
         xml.priority   1
-        xml.lastmod Time.current.utc.iso8601 # TODO
+        # TODO: replace with modified_at (needs indexing, Matt to add to LockedLDPObject)
+        xml.lastmod Time.current.utc.iso8601
       end
     end
   end

--- a/app/views/sitemap/index.xml.builder
+++ b/app/views/sitemap/index.xml.builder
@@ -1,0 +1,38 @@
+xml.instruct! :xml, :version => "1.0"
+cache 'sitemap', expires_in: 24.hours do
+  xml.urlset(:xmlns => 'http://www.sitemaps.org/schemas/sitemap/0.9') do
+    xml.url do
+      xml.loc        root_url
+      xml.lastmod    Time.current.utc.iso8601
+      xml.changefreq 'weekly'
+      xml.priority   1
+    end
+
+    @communities.each do |community|
+      xml.url do
+        xml.loc community_url(community)
+        xml.changefreq 'weekly'
+        xml.priority   1
+        xml.lastmod Time.current.utc.iso8601 # TODO
+      end
+    end
+
+    @collections.each do |collection|
+      xml.url do
+        xml.loc community_collection_url(collection.community, collection)
+        xml.changefreq 'weekly'
+        xml.priority   1
+        xml.lastmod Time.current.utc.iso8601 # TODO
+      end
+    end
+
+    @items.each do |item|
+      xml.url do
+        xml.loc item_url(item)
+        xml.changefreq 'weekly'
+        xml.priority   1
+        xml.lastmod Time.current.utc.iso8601 # TODO
+      end
+    end
+  end
+end

--- a/app/views/sitemap/index.xml.builder
+++ b/app/views/sitemap/index.xml.builder
@@ -1,6 +1,6 @@
-xml.instruct! :xml, :version => "1.0"
+xml.instruct! :xml, version: '1.0'
 cache 'sitemap', expires_in: 24.hours do
-  xml.urlset(:xmlns => 'http://www.sitemaps.org/schemas/sitemap/0.9') do
+  xml.urlset(xmlns: 'http://www.sitemaps.org/schemas/sitemap/0.9') do
     xml.url do
       xml.loc        root_url
       xml.lastmod    Time.current.utc.iso8601

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -50,6 +50,6 @@ Rails.application.routes.draw do
     mount Sidekiq::Web => '/sidekiq', constraints: AdminConstraint.new
   end
 
-  get 'sitemap.xml', to: 'sitemap#index', defaults:  {format: :xml}
+  get 'sitemap.xml', to: 'sitemap#index', defaults: { format: :xml }
   root to: 'welcome#index'
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -50,5 +50,6 @@ Rails.application.routes.draw do
     mount Sidekiq::Web => '/sidekiq', constraints: AdminConstraint.new
   end
 
+  get 'sitemap.xml', to: 'sitemap#index', defaults:  {format: :xml}
   root to: 'welcome#index'
 end


### PR DESCRIPTION
@weiweishi As discussed, this wouldn't be a bad first place for Tricia to get her feet wet, depending on what other requirements come from Peter.

Caching currently lasts 24 hours from the first request to /sitemap.xml, although we can raise or lower this as desired. My back-of-the envelope math says it will take around 45 seconds to respond to the first request assuming about 45k items in the repository. A nightly cron task to curl the URL would eliminate any lag for most users.

Remaining work:

- [x] Get the modified date indexed into Solr 
- [ ] Theses.
- [x] Item visibility (filter out private items)
- [x] Add a static robots.txt file?
- [x] Other requirements from Peter (I think #234 is the tracking ticket?)
- [x] Change SitemapPolicy to simply inherit from ApplicationPolicy.

Closes #9 