### PR TITLE
Mixed bag of changes to metadata:

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -31,7 +31,7 @@ Metrics/AbcSize:
   Enabled: false
 
 Metrics/ClassLength:
-  Max: 500 # default 100
+  Max: 1000 # default 100
 
 # A complexity metric that is strongly correlated to the number
 # of test cases needed to validate a method.

--- a/app/models/jupiter_core/locked_ldp_object.rb
+++ b/app/models/jupiter_core/locked_ldp_object.rb
@@ -421,6 +421,12 @@ module JupiterCore
             has_attribute :record_created_at, ::TERMS[:jupiter_core].record_created_at, type: :date,
                                                                                         solrize_for: [:sort]
           end
+          unless attribute_names.include?(:hydra_noid)
+            has_attribute :hydra_noid, ::TERMS[:ual].hydraNoid, solrize_for: [:exact_match]
+          end
+          unless attribute_names.include?(:date_ingested)
+            has_attribute :date_ingested, RDF::Vocab::EBUCore.dateIngested, type: :date, solrize_for: [:sort]
+          end
         end
       end
 
@@ -451,13 +457,20 @@ module JupiterCore
           validate :visibility_must_be_known
           validates :owner, presence: true
           validates :record_created_at, presence: true
+          validates :date_ingested, presence: true
 
           before_validation :set_record_created_at, on: :create
+          before_validation :set_date_ingested
 
           # ActiveFedora gives us system_create_dtsi, but that only exists in Solr, because what everyone wants
           # is a created_at that jumps around when you rebuild your index
           def set_record_created_at
             self.record_created_at = Time.current.utc.iso8601(3)
+          end
+
+          def set_date_ingested
+            return if date_ingested.present?
+            self.date_ingested = record_created_at
           end
 
           def visibility_must_be_known

--- a/config/terms.yml
+++ b/config/terms.yml
@@ -16,7 +16,7 @@
 #
 
 - vocabulary: ual
-  schema: http://terms.library.ualberta.ca/identifiers/
+  schema: http://terms.library.ualberta.ca/
   terms:
     - depositor
     - fedora3handle
@@ -24,6 +24,7 @@
     - ingestbatch
     - path
     - sortyear
+    - hydraNoid
 
 - vocabulary: prism
   schema: http://prismstandard.org/namespaces/basic/3.0/

--- a/test/models/jupiter_core/locked_ldp_object_test.rb
+++ b/test/models/jupiter_core/locked_ldp_object_test.rb
@@ -56,8 +56,8 @@ class LockedLdpObjectTest < ActiveSupport::TestCase
   end
 
   test 'attribute definitions are working' do
-    assert_equal [:creator, :id, :member_of_paths, :owner, :record_created_at, :title, :visibility],
-                 @@klass.attribute_names.sort
+    assert_equal [:creator, :date_ingested, :hydra_noid, :id, :member_of_paths, :owner, :record_created_at, :title,
+                  :visibility], @@klass.attribute_names.sort
   end
 
   test 'attribute metadata is being tracked properly' do
@@ -172,8 +172,8 @@ class LockedLdpObjectTest < ActiveSupport::TestCase
   test '#inspect works as expected' do
     title = generate_random_string
     obj = @@klass.new_locked_ldp_object(title: title)
-    assert_equal "#<AnonymousClass id: nil, visibility: nil, owner: nil, record_created_at: nil, title: \"#{title}\","\
-                 ' creator: [], member_of_paths: []>', obj.inspect
+    assert_equal '#<AnonymousClass id: nil, visibility: nil, owner: nil, record_created_at: nil, hydra_noid: nil, '\
+                 "date_ingested: nil, title: \"#{title}\", creator: [], member_of_paths: []>", obj.inspect
   end
 
   test 'attribute inheritance is working' do
@@ -181,11 +181,11 @@ class LockedLdpObjectTest < ActiveSupport::TestCase
       has_attribute :subject, ::RDF::Vocab::DC.subject, solrize_for: :search
     end
 
-    assert_equal [:creator, :id, :member_of_paths, :owner, :record_created_at, :subject, :title, :visibility],
-                 subclass.attribute_names.sort
+    assert_equal [:creator, :date_ingested, :hydra_noid, :id, :member_of_paths, :owner, :record_created_at,
+                  :subject, :title, :visibility], subclass.attribute_names.sort
     # ensure mutating subclass attribute lists isn't trickling back to the superclass
-    assert_equal [:creator, :id, :member_of_paths, :owner, :record_created_at, :title, :visibility],
-                 @@klass.attribute_names.sort
+    assert_equal [:creator, :date_ingested, :hydra_noid, :id, :member_of_paths, :owner, :record_created_at,
+                  :title, :visibility], @@klass.attribute_names.sort
   end
 
   test 'attributes are declaring properly' do
@@ -351,7 +351,7 @@ class LockedLdpObjectTest < ActiveSupport::TestCase
     assert instance.respond_to?(:item)
     assert_nil instance.item, nil
     assert_equal instance.inspect, '#<AnonymousClass id: nil, visibility: "http://terms.library.ualberta.ca/public",'\
-                                   ' owner: 1, record_created_at: nil, item: nil>'
+                                   ' owner: 1, record_created_at: nil, hydra_noid: nil, date_ingested: nil, item: nil>'
     instance.unlock_and_fetch_ldp_object(&:save)
 
     instance2 = klass.new_locked_ldp_object(owner: 1,


### PR DESCRIPTION
* use correct URI for `ual` namespace;
* add `hydra_noid` and `date_ingested` to all models;
* make `date_ingested` required and set it to `record_created_at` when not present

Also:

* double the max lines in a file to 1000 for rubocop