### PR TITLE
Add basic facet rendering limit, closes #305

### DIFF
--- a/app/models/jupiter_core/search.rb
+++ b/app/models/jupiter_core/search.rb
@@ -4,6 +4,9 @@ class JupiterCore::Search
   # https://wiki.apache.org/solr/CommonQueryParameters
   MAX_RESULTS = 10_000_000
 
+  # Maximum number of facet results to retrieve per Facet
+  MAX_FACETS_RETURNED = 10
+
   # Performs a solr search using the given query and filtered query strings.
   # Returns an instance of +DeferredFacetedSolrQuery+ providing result counts, +LockedLDPObject+ representing results,
   # and access to result facets. Results are lazily generated when you attempt to enumerate them, so that you can
@@ -59,9 +62,9 @@ class JupiterCore::Search
     ' OR _query_:"-visibility_ssim:[* TO *] AND *:*" OR _query_:"visibility_ssim:*"'
   end
 
-  def self.perform_solr_query(q:, qf: '', fq: '', facet: false, facet_fields: [],
+  def self.perform_solr_query(q:, qf: '', fq: '', facet: false, facet_fields: [], facet_max: MAX_FACETS_RETURNED,
                               restrict_to_model: nil, rows: MAX_RESULTS, start: nil, sort: nil)
-    params = prepare_solr_query(q: q, qf: qf, fq: fq, facet: facet, facet_fields: facet_fields,
+    params = prepare_solr_query(q: q, qf: qf, fq: fq, facet: facet, facet_fields: facet_fields, facet_max: facet_max,
                                 restrict_to_model: restrict_to_model, rows: rows, start: start, sort: sort)
 
     response = ActiveFedora::SolrService.instance.conn.get('select', params: params)
@@ -71,7 +74,7 @@ class JupiterCore::Search
     [response['response']['numFound'], response['response']['docs'], response['facet_counts']]
   end
 
-  def self.prepare_solr_query(q:, qf: '', fq: '', facet: false, facet_fields: [],
+  def self.prepare_solr_query(q:, qf: '', fq: '', facet: false, facet_fields: [], facet_max: MAX_FACETS_RETURNED,
                               restrict_to_model: nil, rows: MAX_RESULTS, start: nil, sort: nil)
     query = []
     restrict_to_model = [restrict_to_model] unless restrict_to_model.is_a?(Array)
@@ -93,7 +96,8 @@ class JupiterCore::Search
       fq: fquery.join(' AND '),
       facet: facet,
       rows: rows,
-      'facet.field': facet_fields
+      'facet.field': facet_fields,
+      'facet.limit': facet_max
     }
 
     params[:start] = start if start.present?

--- a/test/system/search_test.rb
+++ b/test/system/search_test.rb
@@ -220,17 +220,17 @@ class SearchTest < ApplicationSystemTestCase
       assert_selector 'li div a', text: /Extra Community/, count: 6
 
       # Should be a 'Show more' button to see the rest
-      assert_selector 'a', text: 'Show 14 more', count: 1
+      assert_selector 'a[aria-controls="member_of_paths_dpsim_hidden"]', count: 1
 
-      click_link 'Show 14 more'
+      click_link 'Show 4 more', href: '#member_of_paths_dpsim_hidden'
 
       # Now 20 collections/communities should be shown
-      assert_selector 'li div a', text: /Extra Community/, count: 20
+      assert_selector 'li div a', text: /Extra Community/, count: 10
 
       # Should be a 'Hide' button now
-      assert_selector 'a', text: 'Hide last 14', count: 1
+      assert_selector 'a[aria-controls="member_of_paths_dpsim_hidden"]', count: 1
 
-      click_link 'Hide last 14'
+      click_link 'Hide last 4', href: '#member_of_paths_dpsim_hidden'
 
       # Again, only 6 collections/communities should be shown
       assert_selector 'li div a', text: /Extra Community/, count: 6


### PR DESCRIPTION
Clamps facets returned from Solr at 10 per facet category, to improve performance with large results sets. We can re-visit exact numbers and a broader "fetch a full set of facet results via ajax" as seen in Sufia post-beta.