### PR TITLE
Add edit button on item view and fix some css/html

### DIFF
--- a/app/assets/stylesheets/logo.scss
+++ b/app/assets/stylesheets/logo.scss
@@ -1,7 +1,5 @@
 .logo-large {
   height: 400px;
-  max-width: inherit;
-  width: 300px;
 }
 
 .logo-small {

--- a/app/views/application/_item.html.erb
+++ b/app/views/application/_item.html.erb
@@ -2,7 +2,7 @@
   <%= link_to path_for_result(item) do %>
     <%= render partial: 'thumbnail', locals: { object: item } %>
   <% end %>
-  <div class="media-body">
+  <div class="media-body ml-3">
     <div class="d-flex flex-wrap flex-lg-nowrap justify-content-between align-items-start">
       <h5 class="mt-0"><%= link_to item.title, path_for_result(item) %></h5>
       <div class="btn-group">

--- a/app/views/application/_thesis.html.erb
+++ b/app/views/application/_thesis.html.erb
@@ -2,7 +2,7 @@
   <%= link_to path_for_result(thesis) do %>
     <%= render partial: 'thumbnail', locals: { object: thesis } %>
   <% end %>
-  <div class="media-body">
+  <div class="media-body ml-3">
     <div class="d-flex flex-wrap flex-lg-nowrap justify-content-between align-items-start">
       <h5 class="mt-0"><%= link_to thesis.title, path_for_result(thesis) %></h5>
       <div class="btn-group">

--- a/app/views/application/_thumbnail.html.erb
+++ b/app/views/application/_thumbnail.html.erb
@@ -1,13 +1,14 @@
 <%# TODO: might want to add a size parameter (e.g. list view vs item view) %>
+<%# TODO: Need to consolidate this with logo and other thumbnail/logo code in ERA as they are pretty much identical %>
 <% size_class = if local_assigns[:size].present? && size == :large
                   'logo-large'
                 else
                   'logo-small'
                 end %>
 <% if object.thumbnail&.attached? %>
-  <%= image_tag(object.thumbnail.url, alt: "#{t('search.thumbnail.thumbnail')} - #{object.title}", class: "d-flex mr-3 img-thumbnail #{size_class}") %>
+  <%= image_tag(object.thumbnail.url, alt: "#{t('search.thumbnail.thumbnail')} - #{object.title}", class: "d-flex img-thumbnail #{size_class}") %>
 <% else %>
-  <div class="d-flex justify-content-center align-items-center mr-3 img-thumbnail <%= size_class %>">
+  <div class="d-flex justify-content-center align-items-center img-thumbnail <%= size_class %>">
     <small class="text-muted">
       <i class="fa fa-5x fa-picture-o" aria-hidden="true"></i>
       <small class="sr-only"><%= "#{t('search.thumbnail.thumbnail')} - #{object.title}" %></small>

--- a/app/views/items/_files_section_sidebar.html.erb
+++ b/app/views/items/_files_section_sidebar.html.erb
@@ -1,33 +1,30 @@
-<div class="col">
-  <div class="d-flex justify-content-center">
-    <%= render partial: 'thumbnail', locals: { object: @item, size: :large } %>
-  </div>
-  <% if @item.file_sets.count == 1 %>
-    <div class="d-flex justify-content-center mt-3">
-      <div class="p-1">
-        <%= link_to(t('.view'), fileset_uri(@item.file_sets.first, :show), class: 'btn btn-outline-primary',
-            target: :_blank) %>
-      </div>
-      <div class="p-1">
-        <%= link_to(t('.download'), fileset_uri(@item.file_sets.first, :download), class: 'btn btn-outline-primary') %>
-      </div>
+<%= render partial: 'thumbnail', locals: { object: @item, size: :large } %>
+
+<% if @item.file_sets.count == 1 %>
+  <div class="d-flex justify-content-center mt-3">
+    <div class="p-1">
+      <%= link_to(t('.view'), fileset_uri(@item.file_sets.first, :show), class: 'btn btn-outline-primary',
+          target: :_blank) %>
     </div>
-  <% else %>
-    <h4><%= t('.header') %></h4>
-    <div class="list-group item-files">
-      <% @item.file_sets.each do |file_set| %>
-        <div class="list-group-item list-group-item-action d-flex flex-column">
-          <div class="item-filename text-center pb-3"><%= file_set.contained_filename %></div>
-          <div class="d-flex justify-content-center">
-            <div class="p-1">
-              <%= link_to(t('.view'), fileset_uri(file_set, :show), class: 'btn btn-outline-primary') %>
-            </div>
-            <div class="p-1">
-              <%= link_to(t('.download'), fileset_uri(file_set, :download), class: 'btn btn-outline-primary') %>
-            </div>
+    <div class="p-1">
+      <%= link_to(t('.download'), fileset_uri(@item.file_sets.first, :download), class: 'btn btn-outline-primary') %>
+    </div>
+  </div>
+<% else %>
+  <h4><%= t('.header') %></h4>
+  <div class="list-group item-files">
+    <% @item.file_sets.each do |file_set| %>
+      <div class="list-group-item list-group-item-action d-flex flex-column">
+        <div class="item-filename text-center pb-3"><%= file_set.contained_filename %></div>
+        <div class="d-flex justify-content-center">
+          <div class="p-1">
+            <%= link_to(t('.view'), fileset_uri(file_set, :show), class: 'btn btn-outline-primary') %>
+          </div>
+          <div class="p-1">
+            <%= link_to(t('.download'), fileset_uri(file_set, :download), class: 'btn btn-outline-primary') %>
           </div>
         </div>
-      <% end %>
-    </div>
-  <% end %>
-</div>
+      </div>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/items/_item.html.erb
+++ b/app/views/items/_item.html.erb
@@ -1,111 +1,106 @@
-<div>
-  <h1 class="mt-3" title="<%= t('items.show.title') %>"><%= @item.title %></h1>
+<ul class="list-group">
+  <% if @item.alternative_title.present? %>
+    <li class="list-unstyled list-group-item-action">
+      <p title="<%= t('items.show.alternative_title') %>"><%= @item.alternative_title %></p>
+    </li>
+  <% end %>
 
-  <ul class="list-group">
-    <% if @item.alternative_title.present? %>
-      <li class="list-unstyled list-group-item-action">
-        <p title="<%= t('items.show.alternative_title') %>"><%= @item.alternative_title %></p>
-      </li>
-    <% end %>
-
-    <% if @item.creators.present? %>
-      <li class="list-unstyled list-group-item-action">
-        <dl>
-          <dt><%= t('.creators') %></dt>
-          <dd>
-            <ul class="list-unstyled">
-              <% @item.creators.each do |creator| %>
-                <li><%= search_link_for(@item, :all_contributors, value: creator) %></li>
-              <% end %>
-            </ul>
-          </dd>
-        </dl>
-      </li>
-    <% end %>
-
-    <% if @item.description.present? %>
-      <li class="list-unstyled list-group-item-action">
-        <p title="<%= t('.description') %>"><%= @item.description %></p>
-      </li>
-    <% end %>
-
-    <% if @item.sort_year.present? %>
-      <li class="list-unstyled list-group-item-action">
-        <dl>
-          <dt><%= t('.sort_year') %></dt>
-          <dd><%= search_link_for(@item, :sort_year) %></dd>
-        </dl>
-      </li>
-    <% end %>
-
-    <% if @item.subject.present? %>
-      <li class="list-unstyled list-group-item-action">
-        <dl>
-          <dt><%= t('items.show.subject') %></dt>
-          <dd>
-            <ul class="list-unstyled">
-              <% @item.all_subjects.each do |subject| %>
-                <li><%= search_link_for(@item, :all_subjects, value: subject) %></li>
-              <% end %>
-            </ul>
-          </dd>
-        </dl>
-      </li>
-    <% end %>
-
+  <% if @item.creators.present? %>
     <li class="list-unstyled list-group-item-action">
       <dl>
-        <dt><%= t('items.show.item_type_with_status') %></dt>
-        <dd><%= item_type_search_link(@item) %></dd>
+        <dt><%= t('.creators') %></dt>
+        <dd>
+          <ul class="list-unstyled">
+            <% @item.creators.each do |creator| %>
+              <li><%= search_link_for(@item, :all_contributors, value: creator) %></li>
+            <% end %>
+          </ul>
+        </dd>
       </dl>
     </li>
+  <% end %>
 
-    <% if @item.doi.present? %>
-      <li class="list-unstyled list-group-item-action">
-        <dl>
-          <dt><%= t('items.show.doi_url') %></dt>
-          <dd><%= link_to @item.doi_url, @item.doi_url %></dd>
-        </dl>
-      </li>
-    <% end %>
+  <% if @item.description.present? %>
+    <li class="list-unstyled list-group-item-action">
+      <p title="<%= t('.description') %>"><%= @item.description %></p>
+    </li>
+  <% end %>
 
+  <% if @item.sort_year.present? %>
     <li class="list-unstyled list-group-item-action">
       <dl>
-        <dt><%= t('items.show.license') %></dt>
-        <% if @item.license.present? %>
-          <dd><%= license_link(@item.license) %></dd>
-        <% else %>
-          <dd><%= @item.rights %></dd>
-        <% end %>
+        <dt><%= t('.sort_year') %></dt>
+        <dd><%= search_link_for(@item, :sort_year) %></dd>
       </dl>
     </li>
-  </ul>
+  <% end %>
 
-  <%# ADDITIONAL INFORMATION %>
-  <div class='js-hideshow'>
-    <a data-toggle="collapse"
-       data-parent=".js-hideshow"
-       href="#more-information-hidden"
-       aria-expanded="false"
-       aria-controls="more-information-hidden">
-      <span class='js-hideshow-control font-weight-bold font-italic'>
-        <%= t(:more_information) %>
-      </span>
-    </a>
+  <% if @item.subject.present? %>
+    <li class="list-unstyled list-group-item-action">
+      <dl>
+        <dt><%= t('items.show.subject') %></dt>
+        <dd>
+          <ul class="list-unstyled">
+            <% @item.all_subjects.each do |subject| %>
+              <li><%= search_link_for(@item, :all_subjects, value: subject) %></li>
+            <% end %>
+          </ul>
+        </dd>
+      </dl>
+    </li>
+  <% end %>
 
-    <div class="collapse" id='more-information-hidden'>
-      <%= render partial: 'item_more_information' %>
-    </div>
+  <li class="list-unstyled list-group-item-action">
+    <dl>
+      <dt><%= t('items.show.item_type_with_status') %></dt>
+      <dd><%= item_type_search_link(@item) %></dd>
+    </dl>
+  </li>
 
-    <a data-toggle="collapse"
-       data-parent=".js-hideshow"
-       href="#more-information-hidden"
-       aria-expanded="false"
-       aria-controls="more-information-hidden">
-      <span class='js-hideshow-control font-weight-bold font-italic' style='display:none;'>
-        <%= t(:show_less) %>
-      </span>
-    </a>
+  <% if @item.doi.present? %>
+    <li class="list-unstyled list-group-item-action">
+      <dl>
+        <dt><%= t('items.show.doi_url') %></dt>
+        <dd><%= link_to @item.doi_url, @item.doi_url %></dd>
+      </dl>
+    </li>
+  <% end %>
+
+  <li class="list-unstyled list-group-item-action">
+    <dl>
+      <dt><%= t('items.show.license') %></dt>
+      <% if @item.license.present? %>
+        <dd><%= license_link(@item.license) %></dd>
+      <% else %>
+        <dd><%= @item.rights %></dd>
+      <% end %>
+    </dl>
+  </li>
+</ul>
+
+<%# ADDITIONAL INFORMATION %>
+<div class='js-hideshow'>
+  <a data-toggle="collapse"
+      data-parent=".js-hideshow"
+      href="#more-information-hidden"
+      aria-expanded="false"
+      aria-controls="more-information-hidden">
+    <span class='js-hideshow-control font-weight-bold font-italic'>
+      <%= t(:more_information) %>
+    </span>
+  </a>
+
+  <div class="collapse" id='more-information-hidden'>
+    <%= render partial: 'item_more_information' %>
   </div>
 
+  <a data-toggle="collapse"
+      data-parent=".js-hideshow"
+      href="#more-information-hidden"
+      aria-expanded="false"
+      aria-controls="more-information-hidden">
+    <span class='js-hideshow-control font-weight-bold font-italic' style='display:none;'>
+      <%= t(:show_less) %>
+    </span>
+  </a>
 </div>

--- a/app/views/items/_thesis.html.erb
+++ b/app/views/items/_thesis.html.erb
@@ -1,110 +1,105 @@
-<div>
-  <h1 class="mt-3" title="<%= t('items.show.title') %>"><%= @item.title %></h1>
+<ul class="list-group">
+  <% if @item.alternative_title.present? %>
+    <li class="list-unstyled list-group-item-action">
+      <p title="<%= t('items.show.alternative_title') %>"><%= @item.alternative_title %></p>
+    </li>
+  <% end %>
 
-  <ul class="list-group">
-    <% if @item.alternative_title.present? %>
-      <li class="list-unstyled list-group-item-action">
-        <p title="<%= t('items.show.alternative_title') %>"><%= @item.alternative_title %></p>
-      </li>
-    <% end %>
+  <li class="list-unstyled list-group-item-action">
+    <dl>
+      <dt><%= t('.dissertant') %></dt>
+      <dd><%= search_link_for(@item, :all_contributors, value: @item.dissertant) %></dd>
+    </dl>
+  </li>
 
+  <% if @item.abstract.present? %>
+    <li class="list-unstyled list-group-item-action">
+      <p title="<%= t('.abstract') %>"><%= @item.abstract %></p>
+    </li>
+  <% end %>
+
+  <% if @item.subject.present? %>
     <li class="list-unstyled list-group-item-action">
       <dl>
-        <dt><%= t('.dissertant') %></dt>
-        <dd><%= search_link_for(@item, :all_contributors, value: @item.dissertant) %></dd>
+        <dt><%= t('items.show.subject') %></dt>
+        <dd>
+          <ul class="list-unstyled">
+            <% @item.subject.each do |subject| %>
+              <li><%= search_link_for(@item, :all_subjects, value: subject) %></li>
+            <% end %>
+          </ul>
+        </dd>
       </dl>
     </li>
+  <% end %>
 
-    <% if @item.abstract.present? %>
-      <li class="list-unstyled list-group-item-action">
-        <p title="<%= t('.abstract') %>"><%= @item.abstract %></p>
-      </li>
-    <% end %>
-
-    <% if @item.subject.present? %>
-      <li class="list-unstyled list-group-item-action">
-        <dl>
-          <dt><%= t('items.show.subject') %></dt>
-          <dd>
-            <ul class="list-unstyled">
-              <% @item.subject.each do |subject| %>
-                <li><%= search_link_for(@item, :all_subjects, value: subject) %></li>
-              <% end %>
-            </ul>
-          </dd>
-        </dl>
-      </li>
-    <% end %>
-
-    <% if @item.graduation_date.present? %>
-      <li class="list-unstyled list-group-item-action">
-        <dl>
-          <dt><%= t('.graduation_date') %></dt>
-          <dd><%= @item.graduation_date %></dd>
-        </dl>
-      </li>
-    <% end %>
-
+  <% if @item.graduation_date.present? %>
     <li class="list-unstyled list-group-item-action">
       <dl>
-        <dt><%= t('items.show.item_type_with_status') %></dt>
-        <dd><%= item_type_search_link(@item) %></dd>
+        <dt><%= t('.graduation_date') %></dt>
+        <dd><%= @item.graduation_date %></dd>
       </dl>
     </li>
+  <% end %>
 
-    <% if @item.degree.present? %>
-      <li class="list-unstyled list-group-item-action">
-        <dl>
-          <dt><%= t('.degree') %></dt>
-          <dd><%= @item.degree %></dd>
-        </dl>
-      </li>
-    <% end %>
+  <li class="list-unstyled list-group-item-action">
+    <dl>
+      <dt><%= t('items.show.item_type_with_status') %></dt>
+      <dd><%= item_type_search_link(@item) %></dd>
+    </dl>
+  </li>
 
-    <% if @item.doi.present? %>
-      <li class="list-unstyled list-group-item-action">
-        <dl>
-          <dt><%= t('items.show.doi_url') %></dt>
-          <dd><%= link_to @item.doi_url, @item.doi_url %></dd>
-        </dl>
-      </li>
-    <% end %>
+  <% if @item.degree.present? %>
+    <li class="list-unstyled list-group-item-action">
+      <dl>
+        <dt><%= t('.degree') %></dt>
+        <dd><%= @item.degree %></dd>
+      </dl>
+    </li>
+  <% end %>
 
-    <% if @item.rights.present? %>
-      <li class="list-unstyled list-group-item-action">
-        <dl>
-          <dt><%= t('items.show.license') %></dt>
-          <dd><%= @item.rights %></dd>
-        </dl>
-      </li>
-    <% end %>
-  </ul>
+  <% if @item.doi.present? %>
+    <li class="list-unstyled list-group-item-action">
+      <dl>
+        <dt><%= t('items.show.doi_url') %></dt>
+        <dd><%= link_to @item.doi_url, @item.doi_url %></dd>
+      </dl>
+    </li>
+  <% end %>
 
-  <%# ADDITIONAL INFORMATION %>
-  <div class='js-hideshow'>
-    <a data-toggle="collapse"
-       data-parent=".js-hideshow"
-       href="#more-information-hidden"
-       aria-expanded="false"
-       aria-controls="more-information-hidden">
-      <span class='js-hideshow-control font-weight-bold font-italic'>
-        <%= t(:more_information) %>
-      </span>
-    </a>
+  <% if @item.rights.present? %>
+    <li class="list-unstyled list-group-item-action">
+      <dl>
+        <dt><%= t('items.show.license') %></dt>
+        <dd><%= @item.rights %></dd>
+      </dl>
+    </li>
+  <% end %>
+</ul>
 
-    <div class="collapse" id='more-information-hidden'>
-      <%= render partial: 'thesis_more_information' %>
-    </div>
+<%# ADDITIONAL INFORMATION %>
+<div class='js-hideshow'>
+  <a data-toggle="collapse"
+      data-parent=".js-hideshow"
+      href="#more-information-hidden"
+      aria-expanded="false"
+      aria-controls="more-information-hidden">
+    <span class='js-hideshow-control font-weight-bold font-italic'>
+      <%= t(:more_information) %>
+    </span>
+  </a>
 
-    <a data-toggle="collapse"
-       data-parent=".js-hideshow"
-       href="#more-information-hidden"
-       aria-expanded="false"
-       aria-controls="more-information-hidden">
-      <span class='js-hideshow-control font-weight-bold font-italic' style='display:none;'>
-        <%= t(:show_less) %>
-      </span>
-    </a>
+  <div class="collapse" id='more-information-hidden'>
+    <%= render partial: 'thesis_more_information' %>
   </div>
 
+  <a data-toggle="collapse"
+      data-parent=".js-hideshow"
+      href="#more-information-hidden"
+      aria-expanded="false"
+      aria-controls="more-information-hidden">
+    <span class='js-hideshow-control font-weight-bold font-italic' style='display:none;'>
+      <%= t(:show_less) %>
+    </span>
+  </a>
 </div>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -19,7 +19,7 @@
 </div>
 
 <div class="container">
-  <div class="row">
+  <div class="row mt-3">
     <%# LEFT SIDE %>
     <div class="col-4">
       <%# FILES SIDEBAR %>
@@ -49,6 +49,16 @@
 
     <%# MAIN CONTENT %>
     <div class="col-8 pl-5">
+      <% if policy(@item).edit? %>
+        <%= link_to edit_item_path(@item),
+                    class:'btn btn-outline-secondary pull-right' do %>
+            <%= fa_icon('pencil-square-o') %>
+            <%= t('edit') %>
+        <% end %>
+      <% end %>
+
+      <h1 title="<%= t('items.show.title') %>"><%= @item.title %></h1>
+
       <%= render @item %>
     </div>
   </div>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -19,9 +19,9 @@
 </div>
 
 <div class="container">
-  <div class="row mt-3">
+  <div class="row">
     <%# LEFT SIDE %>
-    <div class="col-4">
+    <div class="col-md-4 mt-5">
       <%# FILES SIDEBAR %>
       <% if @item.file_sets.present? %>
         <div class="mb-3">
@@ -48,7 +48,7 @@
     </div>
 
     <%# MAIN CONTENT %>
-    <div class="col-8 pl-5">
+    <div class="col-md-8 pl-5 mt-5">
       <% if policy(@item).edit? %>
         <%= link_to edit_item_path(@item),
                     class:'btn btn-outline-secondary pull-right' do %>


### PR DESCRIPTION
Fixes some CSS/HTML and adds a Edit button on the item detail view

Item detail view before this merge:
![image](https://user-images.githubusercontent.com/1930474/35754494-dcba886e-0820-11e8-9e63-1b9d077f5777.png)
Some weird padding/margin in the left column with the thumbnail. It's not equal in size as the comm/coll pairs. Left col is also very close to the breadcrumb while right col isn't. Etc.

![image](https://user-images.githubusercontent.com/1930474/35754514-f2dbb17c-0820-11e8-9445-373fc192e8b2.png)
The second `col` is actually to the right of this content and a giant whitespace is left below it. Not very mobile friendly.

Item detail view after this merge:
![image](https://user-images.githubusercontent.com/1930474/35754304-374fe2fc-0820-11e8-8a64-f94980b824ad.png)
![image](https://user-images.githubusercontent.com/1930474/35754537-0505538a-0821-11e8-8aa9-f07a39dc86d5.png)

