### PR TITLE
 Thumbnails, Characterization, and Virus-Checking (Oh my!)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -90,6 +90,6 @@ group :test do
   gem 'shoulda', require: false
 end
 
-#group :uat, :staging, :production do
+group :uat, :staging, :production do
   gem 'clamby'
-#end
+end

--- a/Gemfile
+++ b/Gemfile
@@ -89,3 +89,7 @@ group :test do
   gem 'minitest-hooks'
   gem 'shoulda', require: false
 end
+
+#group :uat, :staging, :production do
+  gem 'clamby'
+#end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -109,6 +109,7 @@ GEM
       xpath (>= 2.0, < 4.0)
     childprocess (0.8.0)
       ffi (~> 1.0, >= 1.0.11)
+    clamby (1.3.1)
     coderay (1.1.2)
     concurrent-ruby (1.0.5)
     connection_pool (2.2.1)
@@ -406,6 +407,7 @@ DEPENDENCIES
   binding_of_caller
   bootstrap (~> 4.0.0)
   capybara (~> 2.17)
+  clamby
   dropzonejs-rails
   faker
   font-awesome-rails

--- a/README.md
+++ b/README.md
@@ -141,8 +141,7 @@ And everything else is how you would normally develop in a rails project.
 The Clamby repository has [instructions](https://github.com/kobaltz/clamby#dependencies) on setting up clamav on various operating systems
 
 For characterization you need to install [FITS](https://github.com/harvard-lts/fits) and ensure that `fits.sh` is in your Rails' process' PATH
-[Hydra-File_Characterization](https://github.com/samvera/hydra-file_characterization), which Hydra-Works leverages, has more information on configuring the
-characterization setup.
+[Hydra-File_Characterization](https://github.com/samvera/hydra-file_characterization), which Hydra-Works leverages, has more information on configuring the characterization setup.
 
 ## Common gotchas?
 - If your having issues, logs are the best place to first look at what went wrong.

--- a/app/models/community.rb
+++ b/app/models/community.rb
@@ -1,11 +1,10 @@
 class Community < JupiterCore::LockedLdpObject
 
   include ObjectProperties
-
-  ldp_object_includes Hydra::PCDM::ObjectBehavior
-
   # Needed for ActiveStorage (logo)...
   include GlobalID::Identification
+
+  ldp_object_includes Hydra::PCDM::ObjectBehavior
 
   has_attribute :description, ::RDF::Vocab::DC.description, solrize_for: [:search]
   has_multival_attribute :creators, ::RDF::Vocab::DC.creator, solrize_for: :exact_match

--- a/app/models/draft_item.rb
+++ b/app/models/draft_item.rb
@@ -219,6 +219,10 @@ class DraftItem < ApplicationRecord
       path = file_path_for(file)
       original_filename = file.filename.to_s
       File.open(path) do |f|
+        # We're exploiting the fact that Hydra-Works calls original_filename on objects passed to it, if they
+        # respond to that method, in preference to looking at the final portion of the file path, which,
+        # because we fished this out of ActiveStorage, is just a hash. In this way we present Fedora with the original
+        # file name of the object and not a hashed or otherwise modified version temporarily created during ingest
         f.send(:define_singleton_method, :original_filename, ->() { original_filename })
         yield f
       end

--- a/app/models/file_set.rb
+++ b/app/models/file_set.rb
@@ -11,7 +11,7 @@ class FileSet < JupiterCore::LockedLdpObject
   belongs_to :item, using_existing_association: :member_of_collections
 
   def owning_item
-    Item.find(item)
+    JupiterCore::LockedLdpObject.find(item, types: [Item, Thesis])
   end
 
   # TODO: Should move embargo visibility up into LockedLdpObject

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -2,6 +2,8 @@ class Item < JupiterCore::LockedLdpObject
 
   include ObjectProperties
   include ItemProperties
+  # Needed for ActiveStorage (logo)...
+  include GlobalID::Identification
   ldp_object_includes Hydra::Works::WorkBehavior
 
   # Contributors (faceted in `all_contributors`)

--- a/app/models/thesis.rb
+++ b/app/models/thesis.rb
@@ -2,6 +2,8 @@ class Thesis < JupiterCore::LockedLdpObject
 
   include ObjectProperties
   include ItemProperties
+  # Needed for ActiveStorage (logo)...
+  include GlobalID::Identification
   ldp_object_includes Hydra::Works::WorkBehavior
 
   # Dublin Core attributes

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -54,4 +54,7 @@ Rails.application.configure do
 
   # Which ActiveStorage service to use
   config.active_storage.service = (ENV['ACTIVE_STORAGE_SERVICE'] || :local).to_sym
+
+  # FITS characterization
+  config.run_fits_characterization = false
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -86,4 +86,7 @@ Rails.application.configure do
 
   # Which ActiveStorage service to use
   config.active_storage.service = (ENV['ACTIVE_STORAGE_SERVICE'] || :local).to_sym
+
+  # FITS characterization
+  config.run_fits_characterization = true
 end

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -83,4 +83,7 @@ Rails.application.configure do
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
+
+  # FITS characterization
+  config.run_fits_characterization = true
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -42,4 +42,7 @@ Rails.application.configure do
 
   # Which ActiveStorage service to use
   config.active_storage.service = (ENV['ACTIVE_STORAGE_SERVICE'] || :test).to_sym
+
+  # FITS characterization
+  config.run_fits_characterization = false
 end

--- a/config/environments/uat.rb
+++ b/config/environments/uat.rb
@@ -86,4 +86,7 @@ Rails.application.configure do
 
   # Which ActiveStorage service to use
   config.active_storage.service = (ENV['ACTIVE_STORAGE_SERVICE'] || :local).to_sym
+
+  # FITS characterization
+  config.run_fits_characterization = true
 end

--- a/config/initializers/clamby.rb
+++ b/config/initializers/clamby.rb
@@ -1,0 +1,5 @@
+if defined?(Clamby)
+  Clamby.configure(check: true,
+                   daemonize: true,
+                   silence_output: false)
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -81,8 +81,6 @@ en:
               must_be_absent_for_non_articles: 'must be absent for non-articles'
             visibility_after_embargo:
               not_recognized: 'is not recognized'
-            files:
-              infected: 'is infected with a virus'
         ir_thesis:
           attributes:
             member_of_paths:
@@ -137,6 +135,8 @@ en:
             member_of_paths:
               community_not_found: "Community can't be blank"
               collection_not_found: "Collection can't be blank"
+            files:
+              infected: '%{filename} is infected with a virus'
 
   application:
     navbar:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -81,6 +81,8 @@ en:
               must_be_absent_for_non_articles: 'must be absent for non-articles'
             visibility_after_embargo:
               not_recognized: 'is not recognized'
+            files:
+              infected: 'is infected with a virus'
         ir_thesis:
           attributes:
             member_of_paths:

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -169,20 +169,23 @@ if Rails.env.development? || Rails.env.uat?
         item_attributes[:source] = "Chapter 5 of '#{thing.pluralize.capitalize} and what they drink'"
       end
 
-      Item.new_locked_ldp_object(item_attributes).unlock_and_fetch_ldp_object do |uo|
+      item = Item.new_locked_ldp_object(item_attributes).unlock_and_fetch_ldp_object do |uo|
         if i == 8
           uo.add_to_path(community.id, item_collection.id)
           uo.add_to_path(community.id, thesis_collection.id)
           uo.save!
           # Attach a file to the mondo-item
-          file = File.open(Rails.root + 'app/assets/images/era-logo.png', 'r')
-          uo.add_files([file])
-          file.close
+          File.open(Rails.root + 'app/assets/images/era-logo.png', 'r') do |file|
+            uo.add_files([file])
+          end
+          uo.thumbnail_fileset(uo.file_sets.first)
         else
           uo.add_to_path(community.id, item_collection.id)
           uo.save!
         end
       end
+
+      item.thumbnail_fileset(item.file_sets.first) if item.file_sets.first.present?
 
       field = Faker::Job.field
       level = ["Master's", 'Doctorate'][i % 2]
@@ -216,20 +219,21 @@ if Rails.env.development? || Rails.env.uat?
         thesis_attributes[:committee_members] += ["#{contributors[(seed + 7 * seed2) % 10]} (#{department2})"]
       end
 
-      Thesis.new_locked_ldp_object(thesis_attributes).unlock_and_fetch_ldp_object do |uo|
+      thesis = Thesis.new_locked_ldp_object(thesis_attributes).unlock_and_fetch_ldp_object do |uo|
         if i == 8
           uo.add_to_path(community.id, item_collection.id)
           uo.add_to_path(community.id, thesis_collection.id)
           uo.save!
           # Attach a file to the mondo-item
-          file = File.open(Rails.root + 'app/assets/images/era-logo.png', 'r')
-          uo.add_files([file])
-          file.close
+          File.open(Rails.root + 'app/assets/images/era-logo.png', 'r') do |file|
+            uo.add_files([file])
+          end
         else
           uo.add_to_path(community.id, thesis_collection.id)
           uo.save!
         end
       end
+      thesis.thumbnail_fileset(thesis.file_sets.first) if thesis.file_sets.first.present?
     end
 
     # Add a private item

--- a/test/models/file_set_test.rb
+++ b/test/models/file_set_test.rb
@@ -55,6 +55,9 @@ class FileSetTest < ActiveSupport::TestCase
     file_set.unlock_and_fetch_ldp_object do |unlocked_fileset|
       assert unlocked_fileset.original_file.uri =~ /http.*fcrepo\/rest\/.*#{file_set.id}\/files\/.*/
     end
+
+    item.thumbnail_fileset(file_set)
+    assert item.thumbnail.url.present?
   end
 
 end


### PR DESCRIPTION
Closes #19 

Also closes #402 and #362.

I've made virus-checking and FITS optional for development purposes. For UAT, Staging, and Production, clamav should be running as a daemon on the machine, and fits needs to be installed and in the Rails' process' user's path.

@weiweishi For your migration script, for each item or thesis, you'll need to call `thumbnail_fileset` on the item after saving, and pass it a fileset on that item that contains the file that should be used to derive the thumbnail. Presumably this will be the first (only) file on most items, since we didn't support multi-file items in Hydranorth, so you probably just need to do something like:

```ruby
item.thumbnail_fileset(item.file_sets.first) 
```