### PR TITLE
Allow unauthenticated users to view CCID-protected metadata

### DIFF
--- a/app/models/jupiter_core/search.rb
+++ b/app/models/jupiter_core/search.rb
@@ -27,8 +27,11 @@ class JupiterCore::Search
 
     # Our query permissions are white-list based. You only get public results unless the results of +calculate_ownership_query+
     # assign you additional permissions based on the user passed to it.
+
+    # Why can't I split %Q() strings over multiple lines? Seems incorrect
     # rubocop:disable Metrics/LineLength
     fq << %Q((visibility_ssim:"#{JupiterCore::VISIBILITY_PUBLIC}" OR visibility_ssim:"#{JupiterCore::VISIBILITY_AUTHENTICATED}"#{ownership_query}))
+    # rubocop:enable Metrics/LineLength
 
     base_query << q if q.present?
     facets.each do |key, values|
@@ -39,7 +42,8 @@ class JupiterCore::Search
 
     # queried fields, by default, are all of the fields marked as :search (see calculate_queried_fields).
     # We can revist if we need to customize this more granularly
-    JupiterCore::DeferredFacetedSolrQuery.new(q: base_query, fq: fq.join(' AND '),
+    JupiterCore::DeferredFacetedSolrQuery.new(q: base_query,
+                                              fq: fq.join(' AND '),
                                               qf: calculate_queried_fields(models),
                                               facet_map: construct_facet_map(models),
                                               facet_fields: models.map(&:facets).flatten.uniq,

--- a/app/models/jupiter_core/search.rb
+++ b/app/models/jupiter_core/search.rb
@@ -22,14 +22,15 @@ class JupiterCore::Search
     facets = [] if facets.blank?
 
     base_query = []
+    fq = []
     ownership_query = calculate_ownership_query(as)
 
     # Our query permissions are white-list based. You only get public results unless the results of +calculate_ownership_query+
     # assign you additional permissions based on the user passed to it.
-    base_query << %Q((_query_:"{!raw f=visibility_ssim}#{JupiterCore::VISIBILITY_PUBLIC}"#{ownership_query}))
-    base_query << q if q.present?
+    # rubocop:disable Metrics/LineLength
+    fq << %Q((visibility_ssim:"#{JupiterCore::VISIBILITY_PUBLIC}" OR visibility_ssim:"#{JupiterCore::VISIBILITY_AUTHENTICATED}"#{ownership_query}))
 
-    fq = []
+    base_query << q if q.present?
     facets.each do |key, values|
       values.each do |value|
         fq << %Q(#{key}: "#{value}")

--- a/app/policies/item_policy.rb
+++ b/app/policies/item_policy.rb
@@ -5,7 +5,7 @@ class ItemPolicy < LockedLdpObjectPolicy
   end
 
   def show?
-    owned? || admin? || public?
+    owned? || admin? || public? || record_requires_authentication?
   end
 
   def new?
@@ -26,6 +26,10 @@ class ItemPolicy < LockedLdpObjectPolicy
 
   def download?
     admin? || owned? || public? || user_is_authenticated_for_record?
+  end
+
+  def thumbnail?
+    download?
   end
 
 end

--- a/app/policies/thesis_policy.rb
+++ b/app/policies/thesis_policy.rb
@@ -5,7 +5,7 @@ class ThesisPolicy < LockedLdpObjectPolicy
   end
 
   def show?
-    owned? || admin? || public?
+    owned? || admin? || public? || record_requires_authentication?
   end
 
   def new?
@@ -26,6 +26,10 @@ class ThesisPolicy < LockedLdpObjectPolicy
 
   def download?
     admin? || owned? || public? || user_is_authenticated_for_record?
+  end
+
+  def thumbnail?
+    download?
   end
 
 end

--- a/app/views/application/_thumbnail.html.erb
+++ b/app/views/application/_thumbnail.html.erb
@@ -1,11 +1,12 @@
 <%# TODO: might want to add a size parameter (e.g. list view vs item view) %>
 <%# TODO: Need to consolidate this with logo and other thumbnail/logo code in ERA as they are pretty much identical %>
+
 <% size_class = if local_assigns[:size].present? && size == :large
                   'logo-large'
                 else
                   'logo-small'
                 end %>
-<% if object.thumbnail&.attached? %>
+<% if object.thumbnail&.attached? && policy(object).thumbnail? %>
   <%= image_tag(object.thumbnail.url, alt: "#{t('search.thumbnail.thumbnail')} - #{object.title}", class: "d-flex img-thumbnail #{size_class}") %>
 <% else %>
   <div class="d-flex justify-content-center align-items-center img-thumbnail <%= size_class %>">

--- a/test/integration/item_show_test.rb
+++ b/test/integration/item_show_test.rb
@@ -35,6 +35,22 @@ class ItemShowTest < ActionDispatch::IntegrationTest
       uo.add_to_path(@community1.id, @collection2.id)
       uo.save!
     end
+    @item1 = Item.new_locked_ldp_object.unlock_and_fetch_ldp_object do |uo|
+      uo.title = 'Fantastic item'
+      uo.owner = 1
+      uo.creators = ['Joe Blow']
+      uo.visibility = JupiterCore::VISIBILITY_PUBLIC
+      uo.created = '1999-09-09'
+      uo.languages = [CONTROLLED_VOCABULARIES[:language].english]
+      uo.license = CONTROLLED_VOCABULARIES[:license].attribution_4_0_international
+      uo.item_type = CONTROLLED_VOCABULARIES[:item_type].article
+      uo.publication_status = [CONTROLLED_VOCABULARIES[:publication_status].draft,
+                               CONTROLLED_VOCABULARIES[:publication_status].submitted]
+      uo.subject = ['Items']
+      uo.add_to_path(@community1.id, @collection1.id)
+      uo.add_to_path(@community1.id, @collection2.id)
+      uo.save!
+    end
   end
 
   test 'visiting the show page for an item with two collections as an admin' do

--- a/test/policies/item_policy_test.rb
+++ b/test/policies/item_policy_test.rb
@@ -2,65 +2,97 @@ require 'test_helper'
 
 class ItemPolicyTest < ActiveSupport::TestCase
 
-  context 'admin user' do
-    should 'have proper authorization over items' do
-      current_user = users(:admin)
-      item = Item.new_locked_ldp_object
+  test 'admin should have proper authorization over items' do
+    current_user = users(:admin)
+    item = Item.new_locked_ldp_object
 
-      assert ItemPolicy.new(current_user, item).index?
-      assert ItemPolicy.new(current_user, item).create?
-      assert ItemPolicy.new(current_user, item).new?
-      assert ItemPolicy.new(current_user, item).show?
-      assert ItemPolicy.new(current_user, item).edit?
-      assert ItemPolicy.new(current_user, item).update?
-      assert ItemPolicy.new(current_user, item).destroy?
-    end
+    assert ItemPolicy.new(current_user, item).index?
+    assert ItemPolicy.new(current_user, item).create?
+    assert ItemPolicy.new(current_user, item).new?
+    assert ItemPolicy.new(current_user, item).show?
+    assert ItemPolicy.new(current_user, item).edit?
+    assert ItemPolicy.new(current_user, item).update?
+    assert ItemPolicy.new(current_user, item).destroy?
+    assert ItemPolicy.new(current_user, item).download?
+    assert ItemPolicy.new(current_user, item).thumbnail?
   end
 
-  context 'general user' do
-    should 'only be able to create, see and modify, but not delete, your own items' do
-      current_user = users(:regular)
-      item = Item.new_locked_ldp_object(owner: current_user.id)
+  test 'authenticated user should only be able to create, see and modify, but not delete, their own items' do
+    current_user = users(:regular)
+    item = Item.new_locked_ldp_object(owner: current_user.id)
 
-      assert ItemPolicy.new(current_user, item).index?
-      assert ItemPolicy.new(current_user, item).show?
-      assert ItemPolicy.new(current_user, item).edit?
-      assert ItemPolicy.new(current_user, item).update?
+    assert ItemPolicy.new(current_user, item).index?
+    assert ItemPolicy.new(current_user, item).show?
+    assert ItemPolicy.new(current_user, item).edit?
+    assert ItemPolicy.new(current_user, item).update?
 
-      assert ItemPolicy.new(current_user, item).create?
-      assert ItemPolicy.new(current_user, item).new?
-      refute ItemPolicy.new(current_user, item).destroy?
-    end
-
-    should 'not have access to other items' do
-      current_user = users(:regular)
-      another_user = users(:admin)
-
-      item = Item.new_locked_ldp_object(owner: another_user.id, visibility: JupiterCore::VISIBILITY_PUBLIC)
-
-      assert ItemPolicy.new(current_user, item).index?
-      assert ItemPolicy.new(current_user, item).show?
-
-      refute ItemPolicy.new(current_user, item).edit?
-      refute ItemPolicy.new(current_user, item).update?
-      refute ItemPolicy.new(current_user, item).destroy?
-    end
+    assert ItemPolicy.new(current_user, item).create?
+    assert ItemPolicy.new(current_user, item).new?
+    refute ItemPolicy.new(current_user, item).destroy?
   end
 
-  context 'anon user' do
-    should 'only be able to see index and show of items' do
-      current_user = nil
-      item = Item.new_locked_ldp_object(visibility: JupiterCore::VISIBILITY_PUBLIC)
+  test 'authenticated user should not have edit access to public items' do
+    current_user = users(:regular)
+    another_user = users(:admin)
 
-      assert ItemPolicy.new(current_user, item).index?
-      assert ItemPolicy.new(current_user, item).show?
+    item = Item.new_locked_ldp_object(owner: another_user.id, visibility: JupiterCore::VISIBILITY_PUBLIC)
 
-      refute ItemPolicy.new(current_user, item).create?
-      refute ItemPolicy.new(current_user, item).new?
-      refute ItemPolicy.new(current_user, item).edit?
-      refute ItemPolicy.new(current_user, item).update?
-      refute ItemPolicy.new(current_user, item).destroy?
-    end
+    assert ItemPolicy.new(current_user, item).index?
+    assert ItemPolicy.new(current_user, item).show?
+    assert ItemPolicy.new(current_user, item).download?
+    assert ItemPolicy.new(current_user, item).thumbnail?
+
+    refute ItemPolicy.new(current_user, item).edit?
+    refute ItemPolicy.new(current_user, item).update?
+    refute ItemPolicy.new(current_user, item).destroy?
+  end
+
+  test 'authenticated user should not have edit access to authenticated items' do
+    current_user = users(:regular)
+    another_user = users(:admin)
+
+    item = Item.new_locked_ldp_object(owner: another_user.id, visibility: JupiterCore::VISIBILITY_AUTHENTICATED)
+
+    assert ItemPolicy.new(current_user, item).index?
+    assert ItemPolicy.new(current_user, item).show?
+    assert ItemPolicy.new(current_user, item).download?
+    assert ItemPolicy.new(current_user, item).thumbnail?
+
+    refute ItemPolicy.new(current_user, item).edit?
+    refute ItemPolicy.new(current_user, item).update?
+    refute ItemPolicy.new(current_user, item).destroy?
+  end
+
+  test 'anon user should only be able to index, show, download, and view thumbnails of public items' do
+    current_user = nil
+    item = Item.new_locked_ldp_object(visibility: JupiterCore::VISIBILITY_PUBLIC)
+
+    assert ItemPolicy.new(current_user, item).index?
+    assert ItemPolicy.new(current_user, item).show?
+    assert ItemPolicy.new(current_user, item).download?
+    assert ItemPolicy.new(current_user, item).thumbnail?
+
+    refute ItemPolicy.new(current_user, item).create?
+    refute ItemPolicy.new(current_user, item).new?
+    refute ItemPolicy.new(current_user, item).edit?
+    refute ItemPolicy.new(current_user, item).update?
+    refute ItemPolicy.new(current_user, item).destroy?
+  end
+
+  test 'anon user should only be able to index and show authenticated items' do
+    current_user = nil
+    item = Item.new_locked_ldp_object(visibility: JupiterCore::VISIBILITY_AUTHENTICATED)
+
+    assert ItemPolicy.new(current_user, item).index?
+    assert ItemPolicy.new(current_user, item).show?
+
+    refute ItemPolicy.new(current_user, item).create?
+    refute ItemPolicy.new(current_user, item).new?
+    refute ItemPolicy.new(current_user, item).edit?
+    refute ItemPolicy.new(current_user, item).update?
+    refute ItemPolicy.new(current_user, item).destroy?
+    refute ItemPolicy.new(current_user, item).download?
+    refute ItemPolicy.new(current_user, item).thumbnail?
   end
 
 end

--- a/test/system/item_show_test.rb
+++ b/test/system/item_show_test.rb
@@ -47,7 +47,7 @@ class ItemShowTest < ApplicationSystemTestCase
     end
   end
 
-  test 'be able to download files' do
+  test 'Users should be able to download public files en-masse' do
     visit item_path @item1
     assert_selector '.js-download', count: 2
     assert_selector '.js-download-all'

--- a/test/system/item_show_test.rb
+++ b/test/system/item_show_test.rb
@@ -34,15 +34,15 @@ class ItemShowTest < ApplicationSystemTestCase
     end
 
     @item2 = Item.new_locked_ldp_object(visibility: JupiterCore::VISIBILITY_AUTHENTICATED,
-                                       owner: @user.id, title: 'CCID Item',
-                                       creators: ['Joe Blow'],
-                                       created: '2011-11-11',
-                                       languages: [CONTROLLED_VOCABULARIES[:language].english],
-                                       license: CONTROLLED_VOCABULARIES[:license].attribution_4_0_international,
-                                       item_type: CONTROLLED_VOCABULARIES[:item_type].article,
-                                       publication_status: [CONTROLLED_VOCABULARIES[:publication_status].published],
-                                       subject: ['Fancy things'])
-                .unlock_and_fetch_ldp_object do |uo|
+                                        owner: @user.id, title: 'CCID Item',
+                                        creators: ['Joe Blow'],
+                                        created: '2011-11-11',
+                                        languages: [CONTROLLED_VOCABULARIES[:language].english],
+                                        license: CONTROLLED_VOCABULARIES[:license].attribution_4_0_international,
+                                        item_type: CONTROLLED_VOCABULARIES[:item_type].article,
+                                        publication_status: [CONTROLLED_VOCABULARIES[:publication_status].published],
+                                        subject: ['Fancy things'])
+                 .unlock_and_fetch_ldp_object do |uo|
       uo.add_to_path(@community.id, @collection.id)
       uo.add_to_path(@community.id, @collection.id)
       uo.save!

--- a/test/system/item_show_test.rb
+++ b/test/system/item_show_test.rb
@@ -4,41 +4,65 @@ class ItemShowTest < ApplicationSystemTestCase
 
   def before_all
     super
-    @user = User.find_by(email: 'john_snow@example.com')
     @community = Community.new_locked_ldp_object(title: 'Fancy Community', owner: 1)
                           .unlock_and_fetch_ldp_object(&:save!)
     @collection = Collection.new_locked_ldp_object(community_id: @community.id,
                                                    title: 'Fancy Collection', owner: 1)
                             .unlock_and_fetch_ldp_object(&:save!)
 
-    file1 = File.open(Rails.root + 'app/assets/images/era-logo.png', 'r')
-    file2 = File.open(Rails.root + 'app/assets/images/ualib-logo.png', 'r')
     # Half items have 'Fancy' in title, others have 'Nice', distributed between the two collections
-    @item = Item.new_locked_ldp_object(visibility: JupiterCore::VISIBILITY_PUBLIC,
-                                       owner: @user.id, title: 'Fancy Item',
-                                       creators: ['Joe Blow'],
-                                       created: '2011-11-11',
-                                       languages: [CONTROLLED_VOCABULARIES[:language].english],
-                                       license: CONTROLLED_VOCABULARIES[:license].attribution_4_0_international,
-                                       item_type: CONTROLLED_VOCABULARIES[:item_type].article,
-                                       publication_status: [CONTROLLED_VOCABULARIES[:publication_status].published],
-                                       subject: ['Fancy things'])
-                .unlock_and_fetch_ldp_object do |uo|
+    @item1 = Item.new_locked_ldp_object(visibility: JupiterCore::VISIBILITY_PUBLIC,
+                                        owner: users(:regular).id, title: 'Fancy Item',
+                                        creators: ['Joe Blow'],
+                                        created: '2011-11-11',
+                                        languages: [CONTROLLED_VOCABULARIES[:language].english],
+                                        license: CONTROLLED_VOCABULARIES[:license].attribution_4_0_international,
+                                        item_type: CONTROLLED_VOCABULARIES[:item_type].article,
+                                        publication_status: [CONTROLLED_VOCABULARIES[:publication_status].published],
+                                        subject: ['Fancy things'])
+                 .unlock_and_fetch_ldp_object do |uo|
       uo.add_to_path(@community.id, @collection.id)
       uo.add_to_path(@community.id, @collection.id)
       uo.save!
       # Attach multiple files to the mondo-item
-      uo.add_files([file1, file2])
+      File.open(Rails.root + 'app/assets/images/era-logo.png', 'r') do |file1|
+        File.open(Rails.root + 'app/assets/images/ualib-logo.png', 'r') do |file2|
+          uo.add_files([file1, file2])
+        end
+      end
     end
-    file1.close
-    file2.close
+    @item2 = Item.new_locked_ldp_object(visibility: JupiterCore::VISIBILITY_AUTHENTICATED,
+                                        owner: users(:regular).id, title: 'CCID Item',
+                                        creators: ['Joe Blow'],
+                                        created: '2011-11-11',
+                                        languages: [CONTROLLED_VOCABULARIES[:language].english],
+                                        license: CONTROLLED_VOCABULARIES[:license].attribution_4_0_international,
+                                        item_type: CONTROLLED_VOCABULARIES[:item_type].article,
+                                        publication_status: [CONTROLLED_VOCABULARIES[:publication_status].published],
+                                        subject: ['Fancy things'])
+                 .unlock_and_fetch_ldp_object do |uo|
+      uo.add_to_path(@community.id, @collection.id)
+      uo.add_to_path(@community.id, @collection.id)
+      uo.save!
+    end
   end
 
-  should 'be able to download files' do
-    visit item_path @item
+  test 'be able to download files' do
+    visit item_path @item1
     assert_selector '.js-download', count: 2
     assert_selector '.js-download-all'
     # TODO: test that the files are downloaded via js successfully without making the suite brittle
+  end
+
+  test 'Search faceting on item values is not broken' do
+    visit item_path @item1
+    click_link 'Joe Blow'
+    assert_selector "[href='/search?tab=item']", count: 1
+  end
+
+  test 'Visiting authenticated items as an unauthenticated user works' do
+    visit item_path @item2
+    assert_selector 'h1', text: 'CCID Item', count: 1
   end
 
 end

--- a/test/system/item_show_test.rb
+++ b/test/system/item_show_test.rb
@@ -4,6 +4,7 @@ class ItemShowTest < ApplicationSystemTestCase
 
   def before_all
     super
+    @user = User.find_by(email: 'john_snow@example.com')
     @community = Community.new_locked_ldp_object(title: 'Fancy Community', owner: 1)
                           .unlock_and_fetch_ldp_object(&:save!)
     @collection = Collection.new_locked_ldp_object(community_id: @community.id,
@@ -11,16 +12,16 @@ class ItemShowTest < ApplicationSystemTestCase
                             .unlock_and_fetch_ldp_object(&:save!)
 
     # Half items have 'Fancy' in title, others have 'Nice', distributed between the two collections
-    @item1 = Item.new_locked_ldp_object(visibility: JupiterCore::VISIBILITY_PUBLIC,
-                                        owner: users(:regular).id, title: 'Fancy Item',
-                                        creators: ['Joe Blow'],
-                                        created: '2011-11-11',
-                                        languages: [CONTROLLED_VOCABULARIES[:language].english],
-                                        license: CONTROLLED_VOCABULARIES[:license].attribution_4_0_international,
-                                        item_type: CONTROLLED_VOCABULARIES[:item_type].article,
-                                        publication_status: [CONTROLLED_VOCABULARIES[:publication_status].published],
-                                        subject: ['Fancy things'])
-                 .unlock_and_fetch_ldp_object do |uo|
+    @item = Item.new_locked_ldp_object(visibility: JupiterCore::VISIBILITY_PUBLIC,
+                                       owner: @user.id, title: 'Fancy Item',
+                                       creators: ['Joe Blow'],
+                                       created: '2011-11-11',
+                                       languages: [CONTROLLED_VOCABULARIES[:language].english],
+                                       license: CONTROLLED_VOCABULARIES[:license].attribution_4_0_international,
+                                       item_type: CONTROLLED_VOCABULARIES[:item_type].article,
+                                       publication_status: [CONTROLLED_VOCABULARIES[:publication_status].published],
+                                       subject: ['Fancy things'])
+                .unlock_and_fetch_ldp_object do |uo|
       uo.add_to_path(@community.id, @collection.id)
       uo.add_to_path(@community.id, @collection.id)
       uo.save!
@@ -31,33 +32,34 @@ class ItemShowTest < ApplicationSystemTestCase
         end
       end
     end
+
     @item2 = Item.new_locked_ldp_object(visibility: JupiterCore::VISIBILITY_AUTHENTICATED,
-                                        owner: users(:regular).id, title: 'CCID Item',
-                                        creators: ['Joe Blow'],
-                                        created: '2011-11-11',
-                                        languages: [CONTROLLED_VOCABULARIES[:language].english],
-                                        license: CONTROLLED_VOCABULARIES[:license].attribution_4_0_international,
-                                        item_type: CONTROLLED_VOCABULARIES[:item_type].article,
-                                        publication_status: [CONTROLLED_VOCABULARIES[:publication_status].published],
-                                        subject: ['Fancy things'])
-                 .unlock_and_fetch_ldp_object do |uo|
+                                       owner: @user.id, title: 'CCID Item',
+                                       creators: ['Joe Blow'],
+                                       created: '2011-11-11',
+                                       languages: [CONTROLLED_VOCABULARIES[:language].english],
+                                       license: CONTROLLED_VOCABULARIES[:license].attribution_4_0_international,
+                                       item_type: CONTROLLED_VOCABULARIES[:item_type].article,
+                                       publication_status: [CONTROLLED_VOCABULARIES[:publication_status].published],
+                                       subject: ['Fancy things'])
+                .unlock_and_fetch_ldp_object do |uo|
       uo.add_to_path(@community.id, @collection.id)
       uo.add_to_path(@community.id, @collection.id)
       uo.save!
     end
   end
 
-  test 'Users should be able to download public files en-masse' do
-    visit item_path @item1
+  test 'unauthed users should be able to download all files from a public item' do
+    visit item_path @item
     assert_selector '.js-download', count: 2
     assert_selector '.js-download-all'
     # TODO: test that the files are downloaded via js successfully without making the suite brittle
   end
 
   test 'Search faceting on item values is not broken' do
-    visit item_path @item1
+    visit item_path @item
     click_link 'Joe Blow'
-    assert_selector "[href='/search?tab=item']", count: 1
+    assert_selector "a[href='/search?tab=item']", count: 1
   end
 
   test 'Visiting authenticated items as an unauthenticated user works' do


### PR DESCRIPTION
but not download files or view thumbnails. Also adds a regression test for the issue fixed yesterday where click a facet link on an item page was broken.