### PR TITLE
Remove clamby gem from uat environment

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -92,6 +92,6 @@ group :test do
   gem 'shoulda', require: false
 end
 
-group :uat, :staging, :production do
+group :staging, :production do
   gem 'clamby'
 end


### PR DESCRIPTION
So we can deploy docker on uat without it crashing on deposit item

(other option is try to shoehorn apt get clamav stuff in the docker container...)