### PR TITLE
Fix null pointer exception when error occurs on login

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -41,7 +41,15 @@ class ApplicationController < ActionController::Base
   def sign_in(user)
     @current_user = user
     session[:user_id] = user.try(:id)
-    UpdateUserActivityJob.perform_now(@current_user.id, Time.now.utc.to_s, request.remote_ip, sign_in: true)
+
+    # rubocop:disable Style/GuardClause
+    if @current_user.present?
+      UpdateUserActivityJob.perform_now(@current_user.id,
+                                        Time.now.utc.to_s,
+                                        request.remote_ip,
+                                        sign_in: true)
+    end
+    # rubocop:enable Style/GuardClause
   end
 
   # Logs out the current user.


### PR DESCRIPTION
If you go to UAT right now and in the developer login, you just hit submit without filling anything in you will get a 500 error, this fixes that.