### PR TITLE
Install chromedriver via gem instead

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,14 +17,6 @@ rvm:
 cache: bundler
 bundler_args: --without development production --jobs=3 --retry=3
 
-before_install: # Install ChromeDriver
-  - wget -N http://chromedriver.storage.googleapis.com/2.34/chromedriver_linux64.zip -P ~/
-  - unzip ~/chromedriver_linux64.zip -d ~/
-  - rm ~/chromedriver_linux64.zip
-  - sudo mv -f ~/chromedriver /usr/local/share/
-  - sudo chmod +x /usr/local/share/chromedriver
-  - sudo ln -s /usr/local/share/chromedriver /usr/local/bin/chromedriver
-
 before_script:
   - docker version
   - docker-compose version

--- a/Gemfile
+++ b/Gemfile
@@ -93,6 +93,9 @@ group :test do
   gem 'haikunator'
   gem 'minitest-hooks'
   gem 'shoulda', require: false
+
+  # Easy installation and use of chromedriver to run system tests with Chrome
+  gem 'chromedriver-helper'
 end
 
 group :staging, :production do


### PR DESCRIPTION
https://github.com/ualbertalib/jupiter/pull/532#discussion_r172315937

> As comment says this will install chromedriver for you. This is a new default rails gem in rails 5.2 (when you rails new this gem is in the gemfile etc.) Might be easier to just use this gem install of having people install chromedriver on their own and might make travisCI work better as well (currently travisCI is being flaky when it comes with the chromedriver/system tests)?