### PR TITLE
Use more efficient counting where possible

### DIFF
--- a/app/controllers/sitemap_controller.rb
+++ b/app/controllers/sitemap_controller.rb
@@ -6,22 +6,22 @@ class SitemapController < ApplicationController
 
   def communities
     @communities = Community.all
-    Rollbar.warning 'communities sitemap should contain less than 50,000 targets' if @communities.count > 50_000
+    Rollbar.warning 'communities sitemap should contain less than 50,000 targets' if @communities.total_count > 50_000
   end
 
   def collections
     @collections = Collection.all
-    Rollbar.warning 'collections sitemap should contain less than 50,000 targets' if @collections.count > 50_000
+    Rollbar.warning 'collections sitemap should contain less than 50,000 targets' if @collections.total_count > 50_000
   end
 
   def items
     @items = Item.public
-    Rollbar.warning 'items sitemap should contain less than 50,000 targets' if @items.count > 50_000
+    Rollbar.warning 'items sitemap should contain less than 50,000 targets' if @items.total_count > 50_000
   end
 
   def theses
     @theses = Thesis.public
-    Rollbar.warning 'thesis sitemap should contain less than 50,000 targets' if @theses.count > 50_000
+    Rollbar.warning 'thesis sitemap should contain less than 50,000 targets' if @theses.total_count > 50_000
   end
 
 end

--- a/app/models/jupiter_core/locked_ldp_object.rb
+++ b/app/models/jupiter_core/locked_ldp_object.rb
@@ -301,7 +301,10 @@ class JupiterCore::LockedLdpObject
 
   # Integer, the number of records in Solr/Fedora
   def self.count
-    all.count
+    # Note: call +total_count+ to do a query retrieving 0 results and get the numFound from Solr
+    # calling JupiterCore::DeferredSimpleSolrQuery#count would call the ActiveModel method, force the reification
+    # of all records, and then count the objects, which is very slow
+    all.total_count
   end
 
   # Accepts a hash of name-value pairs to query for, and returns an Array of matching +LockedLDPObject+


### PR DESCRIPTION
Fixes an issue with the Admin Dashboard loading very slowly (15+ seconds) when there are a lot of items to be counted. Also changes to a more efficient count query when building the sitemap.

The core issue here is that Solr always returns the total number of records matching a query, regardless of any row limits in place. This means that DeferredSimpleSolrQuery can't provide its own fast version of `count` that returns the numFound field from Solr for a given result set, since this won't match the actual number of results if there is a row limit in place. Instead, the ActiveModel implementation is used, which involves walking the result set. For large numbers of results, this is very slow. Thus, where possible, we should use `total_count` when we want the unlimited count from Solr, and only use `count` where we do not expect a large number of results, for example when displaying result counts for a given page in a paginated result set.