### PR TITLE
Use created/graduation_date in places we were incorrectly using sort_year

### DIFF
--- a/app/helpers/items_helper.rb
+++ b/app/helpers/items_helper.rb
@@ -21,4 +21,21 @@ module ItemsHelper
     return object.abstract if object.respond_to? :abstract
     return object.description if object.respond_to? :description
   end
+
+  # We have a lot of messy "date-ish" data. Created dates coming through the Draft interface are actual date types
+  # saved into Fedora/Solr as strings at the moment. Much of the legacy data is generally a freeform string containing
+  # anything from "2017/09/12" to '2013' to "2012-09-26T11:18:38Z" (on Theses) to "Fall 1978" to "Unknown"
+  # to "Late Roman antiquity" (ok, I'm making that one up, but it wouldn't surprise me).
+  #
+  # This complicates displaying the field because if we display the raw data we end up displaying decidedly unfriendly
+  # things like "1986-11-17 14:51:45 -0700" in cases where higher quality dates were recorded.
+  #
+  # Thus, we try to parse the date and display a simple iso8601 formated date if it succeeds, and fall back to
+  # displaying raw data otherwise.
+  def humanize_date(dateish)
+    return I18n.t('date_unknown') if dateish.blank?
+    Date.parse(dateish).iso8601
+  rescue ArgumentError
+    dateish
+  end
 end

--- a/app/models/concerns/item_properties.rb
+++ b/app/models/concerns/item_properties.rb
@@ -39,6 +39,10 @@ module ItemProperties
       respond_to?(:creators) ? creators : [dissertant]
     end
 
+    def creation_date
+      respond_to?(:created) ? created : graduation_date
+    end
+
     def doi_state
       @state ||= ItemDoiState.find_or_create_by!(item_id: id) do |state|
         state.aasm_state = (doi.present? ? :available : :not_available)

--- a/app/views/application/_item.html.erb
+++ b/app/views/application/_item.html.erb
@@ -30,7 +30,7 @@
     </div>
 
     <div class="mt-0">
-      <%= item.sort_year %>
+      <%= humanize_date(item.creation_date) %>
     </div>
     <div>
       <%# TODO: the search path may need to be revisited %>

--- a/app/views/application/_thesis.html.erb
+++ b/app/views/application/_thesis.html.erb
@@ -30,7 +30,7 @@
     </div>
 
     <div class="mt-0">
-      <%= thesis.sort_year %>
+      <%= humanize_date(thesis.creation_date) %>
     </div>
     <div>
       <%# TODO: the search path may need to be revisited %>

--- a/app/views/items/_google_scholar_metadata.html.erb
+++ b/app/views/items/_google_scholar_metadata.html.erb
@@ -3,12 +3,13 @@
 <% @item.authors.each do |author| %>
   <meta name="citation_author" content="<%= author %>"/>
 <% end %>
-<% if @item.sort_year.present? %>
-  <meta name="citation_publication_date" content="<%= @item.sort_year %>"/>
+<% if @item.creation_date.present? %>
+  <meta name="citation_publication_date" content="<%= humanize_date(@item.creation_date) %>"/>
 <% end %>
-<% if @item.file_sets.count > 0 %>
+<% citation_file = @item.file_sets.first %>
+<% if citation_file.present? %>
   <%# TODO: limit to pdf mime-type if/when that gets stored %>
-  <meta name="citation_pdf_url" content="<%= fileset_uri(@item.file_sets.first, :show) %>"/>
+  <meta name="citation_pdf_url" content="<%= fileset_uri(citation_file, :show) %>"/>
 <% end %>
 <meta name="dc.identifier" content="<%= @item.doi %>"/>
 <meta name="citation_doi" content="<%= @item.doi %>"/>

--- a/app/views/items/_item.html.erb
+++ b/app/views/items/_item.html.erb
@@ -26,11 +26,16 @@
     </li>
   <% end %>
 
-  <% if @item.sort_year.present? %>
+  <% if @item.creation_date.present? %>
     <li class="list-unstyled list-group-item-action">
       <dl>
-        <dt><%= t('.sort_year') %></dt>
-        <dd><%= search_link_for(@item, :sort_year) %></dd>
+        <dt><%= t('.created') %></dt>
+        <% if @item.sort_year.present? %>
+          <%# Display the recorded date created, but link to searching on the facetable sort year if it is present %>
+          <dd><%= search_link_for(@item, :sort_year, display: humanize_date(@item.creation_date)) %></dd>
+        <% else %>
+          <dd><%= humanize_date(@item.creation_date) %></dd>
+        <% end %>
       </dl>
     </li>
   <% end %>

--- a/app/views/items/_item_page_description.html.erb
+++ b/app/views/items/_item_page_description.html.erb
@@ -1,3 +1,3 @@
-Publication Date: <%= @item.sort_year %>
+Publication Date: <%= humanize_date(@item.creation_date) %>
 Author(s): <%= safe_join(@item.authors, ', ') %>
 Description: <%= jupiter_truncate description(@item) %>

--- a/app/views/items/_thesis.html.erb
+++ b/app/views/items/_thesis.html.erb
@@ -37,7 +37,7 @@
     <li class="list-unstyled list-group-item-action">
       <dl>
         <dt><%= t('.graduation_date') %></dt>
-        <dd><%= @item.graduation_date %></dd>
+        <dd><%= humanize_date(@item.graduation_date) %></dd>
       </dl>
     </li>
   <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -38,6 +38,7 @@ en:
   browse_all: 'Browse all'
   cancel: 'Cancel'
   close: 'Close'
+  date_unknown: 'Unknown'
   delete: 'Delete'
   download: 'Download'
   edit: 'Edit'
@@ -393,7 +394,7 @@ en:
     item:
       creators: 'Author(s) / Creator(s)'
       description: 'Description / Abstract'
-      sort_year: 'Date created'
+      created: 'Date created'
       contributors: 'Additional contributors'
       related_link: 'Link to related item'
       source: 'Source'

--- a/test/integration/site_for_bots_test.rb
+++ b/test/integration/site_for_bots_test.rb
@@ -110,7 +110,7 @@ class SiteForBotsTest < ActionDispatch::IntegrationTest
   test 'nofollow for item metadata links to search' do
     get item_path @item
     assert_select "a[rel='nofollow']", text: @item.creators.first
-    assert_select "a[rel='nofollow']", text: @item.sort_year.to_s
+    assert_select "a[rel='nofollow']", text: @item.creation_date
     assert_select "a[rel='nofollow']", text: 'English'
     assert_select "a[rel='nofollow']", text: 'Article (Draft / Submitted)'
     assert_select "a[rel='nofollow']", text: @item.subject.first
@@ -121,7 +121,7 @@ class SiteForBotsTest < ActionDispatch::IntegrationTest
     get item_path @thesis
     assert_select "meta[name='citation_title'][content='#{@thesis.title}']"
     assert_select "meta[name='citation_author'][content='#{@thesis.dissertant}']"
-    assert_select "meta[name='citation_publication_date'][content='#{@thesis.sort_year}']"
+    assert_select "meta[name='citation_publication_date'][content='#{@thesis.creation_date}']"
     assert_select format("meta[name='citation_pdf_url'][content='%s']",
                          Rails.application.routes.url_helpers.url_for(
                            controller: :file_sets, action: :show, id: @thesis.id,
@@ -137,7 +137,7 @@ class SiteForBotsTest < ActionDispatch::IntegrationTest
     @item.creators.each do |author|
       assert_select "meta[name='citation_author'][content='#{author}']"
     end
-    assert_select "meta[name='citation_publication_date'][content='#{@item.sort_year}']"
+    assert_select "meta[name='citation_publication_date'][content='#{@item.creation_date}']"
     assert_select format("meta[name='citation_pdf_url'][content='%s']",
                          Rails.application.routes.url_helpers.url_for(
                            controller: :file_sets, action: :show, id: @item.id,


### PR DESCRIPTION
Also catches a small performance issue where we were generating multiple Solr queries relating to filesets when rendering the Google Scholar metadata