### PR TITLE
Set travis to just run ruby 2.4.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,7 @@ addons:
   chrome: stable
 
 rvm:
-  - 2.4
-  - 2.5
+  - 2.4.1
 
 cache: bundler
 bundler_args: --without development production --jobs=3 --retry=3


### PR DESCRIPTION
Ruby 2.5.X build seems to be breaking, can't find rails command, for example:
https://travis-ci.org/ualbertalib/jupiter/jobs/361566490

Seems to be some issues pulling down and installing ruby 2.5.1 version:

> $ rvm use 2.5 --install --binary --fuzzy
> curl: (22) The requested URL returned error: 404 Not Found
> Required ruby-2.5.1 is not installed - installing.
> curl: (22) The requested URL returned error: 404 Not Found
> Searching for binary rubies, this might take some time.
> Found remote file https://rubies.travis-ci.org/ubuntu/14.04/x86_64/ruby-2.5.1.tar.bz2
> Checking requirements for ubuntu.
> Requirements installation successful.
> ruby-2.5.1 - #configure
> ruby-2.5.1 - #download
>   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
>                                  Dload  Upload   Total   Spent    Left  Speed
>   0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
> 100 14.4M  100 14.4M    0     0  8293k      0  0:00:01  0:00:01 --:--:-- 11.5M
> No checksum for downloaded archive, recording checksum in user configuration.
> ruby-2.5.1 - #validate archive
> ruby-2.5.1 - #extract
> ruby-2.5.1 - #validate binary
> ruby-2.5.1 - #setup
> ruby-2.5.1 - #gemset created /home/travis/.rvm/gems/ruby-2.5.1@global
> ruby-2.5.1 - #importing gemset /home/travis/.rvm/gemsets/global.gems................................................
> ruby-2.5.1 - #generating global wrappers........
> ruby-2.5.1 - #uninstalling gem rubygems-bundler-1.4.4.
> ruby-2.5.1 - #gemset created /home/travis/.rvm/gems/ruby-2.5.1
> ruby-2.5.1 - #importing gemset /home/travis/.rvm/gemsets/default.gems...............
> ruby-2.5.1 - #generating default wrappers........
> Using /home/travis/.rvm/gems/ruby-2.5.1

Let's just run 2.4.X for now, will help prevent some of the failing builds with regards to headless chrome too.