### PR TITLE
Turn down some of the noisier warnings in Rollbar

### DIFF
--- a/config/initializers/rollbar.rb
+++ b/config/initializers/rollbar.rb
@@ -39,6 +39,8 @@ Rollbar.configure do |config|
   #  Thread.new { Rollbar.process_from_async_handler(payload) }
   # }
 
+  config.exception_level_filters['ActionController::RoutingError'] = 'ignore'
+
   # Enable asynchronous reporting (using sucker_punch)
   # config.use_sucker_punch
 


### PR DESCRIPTION
Masking out random routing warnings in Rollbar, mostly noisy touch icon stuff, random bots sniffing for PHP, etc