### PR TITLE
Fix alignment of buttons on search results, buttons float left, title right

### DIFF
--- a/app/views/application/_item.html.erb
+++ b/app/views/application/_item.html.erb
@@ -4,8 +4,8 @@
     <%= render partial: 'thumbnail', locals: { thumbnail: item.thumbnail.attachment, object: item } %>
   <% end %>
   <div class="media-body ml-3">
-    <div class="d-flex flex-wrap flex-lg-nowrap justify-content-between align-items-start">
-      <h5 class="mt-0"><%= link_to item.title, path_for_result(item) %></h5>
+    <div class="d-flex flex-wrap flex-lg-nowrap align-items-start">
+      <h5 class="mt-0 mr-auto"><%= link_to item.title, path_for_result(item) %></h5>
 
       <% primary_file = item.file_sets.first %>
       <% if primary_file.present? %>

--- a/app/views/application/_thesis.html.erb
+++ b/app/views/application/_thesis.html.erb
@@ -3,8 +3,8 @@
     <%= render partial: 'thumbnail', locals: { thumbnail: thesis.thumbnail.attachment, object: thesis } %>
   <% end %>
   <div class="media-body ml-3">
-    <div class="d-flex flex-wrap flex-lg-nowrap justify-content-between align-items-start">
-      <h5 class="mt-0"><%= link_to thesis.title, path_for_result(thesis) %></h5>
+    <div class="d-flex flex-wrap flex-lg-nowrap align-items-start">
+      <h5 class="mt-0 mr-auto"><%= link_to thesis.title, path_for_result(thesis) %></h5>
 
       <% primary_file = thesis.file_sets.first %>
       <% if primary_file.present? %>


### PR DESCRIPTION
Issue was when logged in as admin (where you see both download and edit/delete buttons), download buttons were being justify-content-between so therefore sitting in the middle inconsistently. This should fix this.
![image](https://user-images.githubusercontent.com/1930474/38431695-4d7e14ca-3982-11e8-9935-63e8092ddf7b.png)

Essentially do the second example here: 
https://getbootstrap.com/docs/4.0/utilities/flex/#auto-margins

