### PR TITLE
Turn encode/decode signature methods into pass-throughs

### DIFF
--- a/config/initializers/activestorage.rb
+++ b/config/initializers/activestorage.rb
@@ -2,12 +2,6 @@ require 'active_storage'
 require 'active_storage/verified_key_with_expiration.rb'
 require 'active_storage/attached'
 
-# Note the following line can go away in Rails 5.2 because 'class_attribute' has
-# support for a 'default' value.
-# https://github.com/rails/activestorage/blob/v0.1/lib/active_storage/verified_key_with_expiration.rb#L2
-ActiveStorage::VerifiedKeyWithExpiration.verifier =
-  Rails.application.message_verifier('ActiveStorage')
-
 # Monkey patch ActiveStorage to replace existing attachments
 # https://github.com/rails/activestorage/blob/v0.1/lib/active_storage/attached/one.rb
 class ActiveStorage::Attached::One < ActiveStorage::Attached
@@ -27,6 +21,25 @@ class ActiveStorage::Attached::One < ActiveStorage::Attached
       ActiveStorage::Attachment.create!(record_gid: record.to_gid.to_s,
                                         name: name, blob: create_blob_from(attachable))
     old_attachments.each(&:purge_later)
+  end
+
+end
+
+# Turn these methods into pass-throughs to disable signing blob URLs
+class ActiveStorage::VerifiedKeyWithExpiration
+
+  class << self
+
+    # rubocop:disable Lint/UnusedMethodArgument
+    def encode(key, expires_in: nil)
+      key
+    end
+    # rubocop:enable Lint/UnusedMethodArgument
+
+    def decode(encoded_key)
+      encoded_key
+    end
+
   end
 
 end


### PR DESCRIPTION
This _might_ resolve the occasional 404s we're seeing on thumbnails in production, if they stem from signature mismatch or expiry issues between the app servers.