### PR TITLE
Specify a host and protocol manually for target URL generation 

### DIFF
--- a/app/services/doi_service.rb
+++ b/app/services/doi_service.rb
@@ -80,13 +80,17 @@ class DOIService
   private
 
   def ezid_metadata
+    # deal with the fact that there's no request object when running under resque
+    url_opts = { id: @item.id,
+                 host: Rails.env.production? ? 'era.library.ualberta.ca' : 'localhost',
+                 protocol: 'https' }
     {
       datacite_creator:  @item.authors.join('; '),
       datacite_publisher: PUBLISHER,
       datacite_publicationyear: @item.sort_year.present? ? @item.sort_year : '(:unav)',
       datacite_resourcetype: DATACITE_METADATA_SCHEME[@item.item_type_with_status_code],
       datacite_title:  @item.title,
-      target: Rails.application.routes.url_helpers.item_url(id: @item.id),
+      target: Rails.application.routes.url_helpers.item_url(url_opts),
       # Can only set status if been minted previously, else its public
       status: @item.private? && @item.doi.present? ? UNAVAILABLE_MESSAGE : Ezid::Status::PUBLIC,
       export: @item.private? ? 'no' : 'yes'

--- a/app/services/doi_service.rb
+++ b/app/services/doi_service.rb
@@ -80,17 +80,13 @@ class DOIService
   private
 
   def ezid_metadata
-    # deal with the fact that there's no request object when running under resque
-    url_opts = { id: @item.id,
-                 host: Rails.env.production? ? 'era.library.ualberta.ca' : 'localhost',
-                 protocol: 'https' }
     {
       datacite_creator:  @item.authors.join('; '),
       datacite_publisher: PUBLISHER,
       datacite_publicationyear: @item.sort_year.present? ? @item.sort_year : '(:unav)',
       datacite_resourcetype: DATACITE_METADATA_SCHEME[@item.item_type_with_status_code],
       datacite_title:  @item.title,
-      target: Rails.application.routes.url_helpers.item_url(url_opts),
+      target: Rails.application.routes.url_helpers.item_url(id: @item.id),
       # Can only set status if been minted previously, else its public
       status: @item.private? && @item.doi.present? ? UNAVAILABLE_MESSAGE : Ezid::Status::PUBLIC,
       export: @item.private? ? 'no' : 'yes'

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,3 +1,5 @@
+Rails.application.routes.default_url_options = { host: 'localhost' }
+
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,3 +1,5 @@
+Rails.application.routes.default_url_options = { host: 'era.library.ualberta.ca', port: 443, protocol: 'https' }
+
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -1,3 +1,5 @@
+Rails.application.routes.default_url_options = { host: 'localhost' }
+
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -22,9 +22,6 @@ end
 # just push all jobs to an array for verification
 Sidekiq::Testing.fake!
 
-# Required when using Rails.application.routes.url_helpers from outside the request/response life cycle (models, jobs, lib)
-Rails.application.routes.default_url_options = { host: 'localhost' }
-
 class ActiveSupport::TestCase
 
   def freeze_time(&block)


### PR DESCRIPTION
Necessary so that DOI background jobs can run properly under Resque.