### PR TITLE
Remove some hardcoded solr names that crept in

### DIFF
--- a/app/models/jupiter_core/deferred_faceted_solr_query.rb
+++ b/app/models/jupiter_core/deferred_faceted_solr_query.rb
@@ -110,12 +110,15 @@ class JupiterCore::DeferredFacetedSolrQuery
 
   def reify_result_set
     model = criteria[:restrict_to_model].first.owning_class
+    model_has_sort_year = model.attribute_names.include?(:sort_year)
+    sort_year_facet = model.solr_name_for(:sort_year, role: :range_facet) if model_has_sort_year
+
     return @results if @results.present?
     @count_cache, @results, facet_data = JupiterCore::Search.perform_solr_query(
       search_args_with_limit(criteria[:limit])
     )
     @facets = facet_data['facet_fields'].map do |k, v|
-      if model.attribute_names.include?(:sort_year) && (k == model.solr_name_for(:sort_year, role: :range_facet))
+      if model_has_sort_year && (k == sort_year_facet)
         JupiterCore::RangeFacetResult.new(
           criteria[:facet_map], k,
           criteria[:ranges].fetch(k, begin: 1880, end: Time.current.year).to_h

--- a/app/models/jupiter_core/deferred_faceted_solr_query.rb
+++ b/app/models/jupiter_core/deferred_faceted_solr_query.rb
@@ -109,12 +109,13 @@ class JupiterCore::DeferredFacetedSolrQuery
   end
 
   def reify_result_set
+    model = criteria[:restrict_to_model].first.owning_class
     return @results if @results.present?
     @count_cache, @results, facet_data = JupiterCore::Search.perform_solr_query(
       search_args_with_limit(criteria[:limit])
     )
     @facets = facet_data['facet_fields'].map do |k, v|
-      if k == criteria[:restrict_to_model].first.owning_class.solr_name_for(:sort_year, role: :range_facet)
+      if model.respond_to?(:sort_year) && (k == model.solr_name_for(:sort_year, role: :range_facet))
         JupiterCore::RangeFacetResult.new(
           criteria[:facet_map], k,
           criteria[:ranges].fetch(k, begin: 1880, end: Time.current.year).to_h

--- a/app/models/jupiter_core/deferred_faceted_solr_query.rb
+++ b/app/models/jupiter_core/deferred_faceted_solr_query.rb
@@ -109,20 +109,20 @@ class JupiterCore::DeferredFacetedSolrQuery
   end
 
   def reify_result_set
+    return @results if @results.present?
+
     model = criteria[:restrict_to_model].first.owning_class
     model_has_sort_year = model.attribute_names.include?(:sort_year)
     sort_year_facet = model.solr_name_for(:sort_year, role: :range_facet) if model_has_sort_year
 
-    return @results if @results.present?
     @count_cache, @results, facet_data = JupiterCore::Search.perform_solr_query(
       search_args_with_limit(criteria[:limit])
     )
     @facets = facet_data['facet_fields'].map do |k, v|
       if model_has_sort_year && (k == sort_year_facet)
-        JupiterCore::RangeFacetResult.new(
-          criteria[:facet_map], k,
-          criteria[:ranges].fetch(k, begin: 1880, end: Time.current.year).to_h
-        )
+        JupiterCore::RangeFacetResult.new(criteria[:facet_map], k, criteria[:ranges].fetch(k,
+                                                                                           begin: 1880,
+                                                                                           end: Time.current.year).to_h)
       elsif v.present?
         JupiterCore::FieldValueFacetResult.new(criteria[:facet_map], k, v)
       end

--- a/app/models/jupiter_core/deferred_faceted_solr_query.rb
+++ b/app/models/jupiter_core/deferred_faceted_solr_query.rb
@@ -113,9 +113,8 @@ class JupiterCore::DeferredFacetedSolrQuery
     @count_cache, @results, facet_data = JupiterCore::Search.perform_solr_query(
       search_args_with_limit(criteria[:limit])
     )
-
     @facets = facet_data['facet_fields'].map do |k, v|
-      if k == 'sort_year_isi'
+      if k == criteria[:restrict_to_model].first.owning_class.solr_name_for(:sort_year, role: :range_facet)
         JupiterCore::RangeFacetResult.new(
           criteria[:facet_map], k,
           criteria[:ranges].fetch(k, begin: 1880, end: Time.current.year).to_h

--- a/app/models/jupiter_core/deferred_faceted_solr_query.rb
+++ b/app/models/jupiter_core/deferred_faceted_solr_query.rb
@@ -115,7 +115,7 @@ class JupiterCore::DeferredFacetedSolrQuery
       search_args_with_limit(criteria[:limit])
     )
     @facets = facet_data['facet_fields'].map do |k, v|
-      if model.respond_to?(:sort_year) && (k == model.solr_name_for(:sort_year, role: :range_facet))
+      if model.attribute_names.include?(:sort_year) && (k == model.solr_name_for(:sort_year, role: :range_facet))
         JupiterCore::RangeFacetResult.new(
           criteria[:facet_map], k,
           criteria[:ranges].fetch(k, begin: 1880, end: Time.current.year).to_h

--- a/test/models/jupiter_core/search_test.rb
+++ b/test/models/jupiter_core/search_test.rb
@@ -97,18 +97,19 @@ class SearchTest < ActiveSupport::TestCase
     assert_equal search_results.first.id, another_obj.id
 
     # test for range
+    sort_year_facet = @@klass.solr_name_for(:sort_year, role: :range_facet)
     search_results = JupiterCore::Search.faceted_search(
-      models: @@klass, q: '', ranges: { 'sort_year_isi' => { begin: 1880, end: 2018 } }
+      models: @@klass, q: '', ranges: { sort_year_facet => { begin: 1880, end: 2018 } }
     )
     assert search_results.count == 2
 
     search_results = JupiterCore::Search.faceted_search(
-      models: @@klass, q: '', ranges: { 'sort_year_isi' => { begin: 1989, end: 1989 } }
+      models: @@klass, q: '', ranges: { sort_year_facet => { begin: 1989, end: 1989 } }
     )
     assert search_results.count == 1
 
     search_results = JupiterCore::Search.faceted_search(
-      models: @@klass, q: '', ranges: { 'sort_year_isi' => { begin: 1880, end: 1980 } }
+      models: @@klass, q: '', ranges: { sort_year_facet => { begin: 1880, end: 1980 } }
     )
     assert search_results.count == 0
   end

--- a/test/system/search_test.rb
+++ b/test/system/search_test.rb
@@ -114,8 +114,9 @@ class SearchTest < ApplicationSystemTestCase
       assert_selector 'li a', text: '3 Fancy Community/Fancy Collection 0'
       assert_selector 'li a', text: '2 Fancy Community/Fancy Collection 1'
       assert_selector 'div.card-header', text: 'Sort Year'
-      assert_selector '#ranges_sort_year_isi_begin'
-      assert_selector '#ranges_sort_year_isi_end'
+      sort_year_facet = Item.solr_name_for(:sort_year, role: :range_facet)
+      assert_selector "#ranges_#{sort_year_facet}_begin"
+      assert_selector "#ranges_#{sort_year_facet}_end"
       assert_selector 'input.btn'
 
       # Exactly 5 items shown


### PR DESCRIPTION
Any time we hardcode names with specific Solrizer junk appended to them, we make it harder to move away from this stack in the future.