### PR TITLE
Fix crasher when downloading certain files

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -22,16 +22,7 @@ class ApplicationController < ActionController::Base
   end
 
   def store_user_location!
-    uri = URI.parse(request.fullpath)
-    return unless uri
-
-    # We want to rebuild the url and preserve the full uri including query params and anchors
-    # remove domain from path and add query params
-    path = [uri.path.sub(/\A\/+/, '/'), uri.query].compact.join('?')
-    # add fragment back to path
-    path = [path, uri.fragment].compact.join('#')
-
-    session[:previous_user_location] = path
+    session[:previous_user_location] = request.fullpath
   end
 
   # Returns the current logged-in user (if any).


### PR DESCRIPTION
URL paths are not necessarily valid URIs. It turns out we have a bunch of files indexed in Google Scholar under old Hydranorth URLs (like https://era.library.ualberta.ca/files/p5547r413/Masumitsu_Kazuko_Fall_2012[3].pdf) that currently crash because they don't parse as valid URIs in `store_user_location!`

Moreorver, `store_user_location!` isn't actually doing much of anything. `request.fullpath` doesn't contain the domain name, so there was never a domain name to remove. `request.fullpath` doesn't contain fragments (fragments are never sent to the server), so by construction `uri.fragment` was always empty. `request.fullpath` already contained the query params, appended properly (it had to, otherwise `uri.query` wouldn't have), so parsing it into a URI and then adding them back was a no-op.

Closes #657.