### PR TITLE
refactor duplicates in tests

### DIFF
--- a/test/controllers/admin/collections_controller_test.rb
+++ b/test/controllers/admin/collections_controller_test.rb
@@ -4,13 +4,8 @@ class Admin::CollectionsControllerTest < ActionDispatch::IntegrationTest
 
   def before_all
     super
-    @community = Community.new_locked_ldp_object(title: 'Nice community',
-                                                 owner: 1)
-    @community.unlock_and_fetch_ldp_object(&:save!)
-    @collection = Collection.new_locked_ldp_object(community_id: @community.id,
-                                                   title: 'Nice collection',
-                                                   owner: 1)
-    @collection.unlock_and_fetch_ldp_object(&:save!)
+    @community = locked_ldp_fixture(Community, :nice).unlock_and_fetch_ldp_object(&:save!)
+    @collection = locked_ldp_fixture(Collection, :nice).unlock_and_fetch_ldp_object(&:save!)
   end
 
   def setup

--- a/test/controllers/collections_controller_test.rb
+++ b/test/controllers/collections_controller_test.rb
@@ -4,13 +4,8 @@ class CollectionsControllerTest < ActionDispatch::IntegrationTest
 
   def before_all
     super
-    @community = Community.new_locked_ldp_object(title: 'Nice community',
-                                                 owner: 1)
-    @community.unlock_and_fetch_ldp_object(&:save!)
-    @collection = Collection.new_locked_ldp_object(community_id: @community.id,
-                                                   title: 'Nice collection',
-                                                   owner: 1)
-    @collection.unlock_and_fetch_ldp_object(&:save!)
+    @community = locked_ldp_fixture(Community, :nice).unlock_and_fetch_ldp_object(&:save!)
+    @collection = locked_ldp_fixture(Collection, :nice).unlock_and_fetch_ldp_object(&:save!)
   end
 
   test 'should show collection' do

--- a/test/controllers/file_sets_controller_test.rb
+++ b/test/controllers/file_sets_controller_test.rb
@@ -4,22 +4,10 @@ class FileSetsControllerTest < ActionDispatch::IntegrationTest
 
   def before_all
     super
-    @community = Community.new_locked_ldp_object(title: 'Fancy Community', owner: 1)
-                          .unlock_and_fetch_ldp_object(&:save!)
-    @collection = Collection.new_locked_ldp_object(community_id: @community.id,
-                                                   title: 'Fancy Collection', owner: 1)
-                            .unlock_and_fetch_ldp_object(&:save!)
+    @community = locked_ldp_fixture(Community, :fancy).unlock_and_fetch_ldp_object(&:save!)
+    @collection = locked_ldp_fixture(Collection, :fancy).unlock_and_fetch_ldp_object(&:save!)
     @filename = 'text-sample.txt'
-    @item = Item.new_locked_ldp_object(visibility: JupiterCore::VISIBILITY_PUBLIC,
-                                       owner: 1, title: 'Fancy Item',
-                                       creators: ['Joe Blow'],
-                                       created: '1950',
-                                       languages: [CONTROLLED_VOCABULARIES[:language].english],
-                                       item_type: CONTROLLED_VOCABULARIES[:item_type].article,
-                                       publication_status: [CONTROLLED_VOCABULARIES[:publication_status].published],
-                                       license: CONTROLLED_VOCABULARIES[:license].attribution_4_0_international,
-                                       subject: ['Items'])
-                .unlock_and_fetch_ldp_object do |uo|
+    @item = locked_ldp_fixture(Item, :fancy).unlock_and_fetch_ldp_object do |uo|
       uo.add_to_path(@community.id, @collection.id)
       File.open(file_fixture(@filename), 'r') do |file|
         uo.add_files([file])

--- a/test/controllers/items/draft_controller_test.rb
+++ b/test/controllers/items/draft_controller_test.rb
@@ -3,11 +3,9 @@ require 'test_helper'
 class Items::DraftControllerTest < ActionDispatch::IntegrationTest
 
   def before_all
-    @community = Community.new_locked_ldp_object(title: 'Books', owner: 1).unlock_and_fetch_ldp_object(&:save!)
-    @collection = Collection.new_locked_ldp_object(title: 'Fantasy Books',
-                                                   owner: 1,
-                                                   community_id: @community.id)
-                            .unlock_and_fetch_ldp_object(&:save!)
+    super
+    @community = locked_ldp_fixture(Community, :books).unlock_and_fetch_ldp_object(&:save!)
+    @collection = locked_ldp_fixture(Collection, :books).unlock_and_fetch_ldp_object(&:save!)
   end
 
   setup do

--- a/test/controllers/items/files_controller_test.rb
+++ b/test/controllers/items/files_controller_test.rb
@@ -2,14 +2,10 @@ require 'test_helper'
 
 class Items::FilesControllerTest < ActionDispatch::IntegrationTest
 
-  # TODO: candidate for fixture
   def before_all
     super
-    @community = Community.new_locked_ldp_object(title: 'Books', owner: 1).unlock_and_fetch_ldp_object(&:save!)
-    @collection = Collection.new_locked_ldp_object(title: 'Fantasy Books',
-                                                   owner: 1,
-                                                   community_id: @community.id)
-                            .unlock_and_fetch_ldp_object(&:save!)
+    @community = locked_ldp_fixture(Community, :books).unlock_and_fetch_ldp_object(&:save!)
+    @collection = locked_ldp_fixture(Collection, :books).unlock_and_fetch_ldp_object(&:save!)
   end
 
   setup do

--- a/test/integration/collection_show_test.rb
+++ b/test/integration/collection_show_test.rb
@@ -8,13 +8,8 @@ class CollectionShowTest < ActionDispatch::IntegrationTest
   def before_all
     super
 
-    # TODO: setup proper fixtures for LockedLdpObjects
-
-    # A community with a collection
-    @community = Community.new_locked_ldp_object(title: 'Two collection community', owner: 1)
-                          .unlock_and_fetch_ldp_object(&:save!)
-    @collection = Collection.new_locked_ldp_object(community_id: @community.id, title: 'Nice collection', owner: 1)
-                            .unlock_and_fetch_ldp_object(&:save!)
+    @community = locked_ldp_fixture(Community, :nice).unlock_and_fetch_ldp_object(&:save!)
+    @collection = locked_ldp_fixture(Collection, :nice).unlock_and_fetch_ldp_object(&:save!)
     @items = ['Fancy', 'Nice'].map do |adjective|
       Item.new_locked_ldp_object(visibility: JupiterCore::VISIBILITY_PUBLIC,
                                  owner: 1,

--- a/test/integration/community_edit_test.rb
+++ b/test/integration/community_edit_test.rb
@@ -9,7 +9,7 @@ class CommunityEditTest < ActionDispatch::IntegrationTest
 
     # A community with a logo
     @community1 = Community
-                  .new_locked_ldp_object(title: 'Two collection community', owner: 1)
+                  .new_locked_ldp_object(title: 'Logo Community', owner: 1)
                   .unlock_and_fetch_ldp_object(&:save!)
     @community1.logo.attach io: File.open(file_fixture('image-sample.jpeg')),
                             filename: 'image-sample.jpeg', content_type: 'image/jpeg'

--- a/test/integration/item_show_test.rb
+++ b/test/integration/item_show_test.rb
@@ -19,23 +19,7 @@ class ItemShowTest < ActionDispatch::IntegrationTest
                    .new_locked_ldp_object(community_id: @community1.id,
                                           title: 'Another collection', owner: 1)
                    .unlock_and_fetch_ldp_object(&:save!)
-    @item1 = Item.new_locked_ldp_object.unlock_and_fetch_ldp_object do |uo|
-      uo.title = 'Fantastic item'
-      uo.owner = 1
-      uo.creators = ['Joe Blow']
-      uo.visibility = JupiterCore::VISIBILITY_PUBLIC
-      uo.created = '1999-09-09'
-      uo.languages = [CONTROLLED_VOCABULARIES[:language].english]
-      uo.license = CONTROLLED_VOCABULARIES[:license].attribution_4_0_international
-      uo.item_type = CONTROLLED_VOCABULARIES[:item_type].article
-      uo.publication_status = [CONTROLLED_VOCABULARIES[:publication_status].draft,
-                               CONTROLLED_VOCABULARIES[:publication_status].submitted]
-      uo.subject = ['Items']
-      uo.add_to_path(@community1.id, @collection1.id)
-      uo.add_to_path(@community1.id, @collection2.id)
-      uo.save!
-    end
-    @item1 = Item.new_locked_ldp_object.unlock_and_fetch_ldp_object do |uo|
+    @item = Item.new_locked_ldp_object.unlock_and_fetch_ldp_object do |uo|
       uo.title = 'Fantastic item'
       uo.owner = 1
       uo.creators = ['Joe Blow']
@@ -56,7 +40,7 @@ class ItemShowTest < ActionDispatch::IntegrationTest
   test 'visiting the show page for an item with two collections as an admin' do
     user = users(:admin)
     sign_in_as user
-    get item_url(@item1)
+    get item_url(@item)
 
     # Shows two sets of paths to the two collections
     # Both collections are in same community

--- a/test/integration/sitemap_test.rb
+++ b/test/integration/sitemap_test.rb
@@ -9,27 +9,18 @@ class SitemapTest < ActionDispatch::IntegrationTest
     @collection = Collection.new_locked_ldp_object(community_id: @community.id,
                                                    title: 'Fancy Collection', owner: 1)
                             .unlock_and_fetch_ldp_object(&:save!)
-    @item = Item.new_locked_ldp_object(visibility: JupiterCore::VISIBILITY_PUBLIC,
-                                       owner: 1, title: 'Fancy Item',
-                                       creators: ['Joe Blow'],
-                                       created: '1938-01-02',
-                                       languages: [CONTROLLED_VOCABULARIES[:language].english],
-                                       item_type: CONTROLLED_VOCABULARIES[:item_type].article,
-                                       publication_status: [CONTROLLED_VOCABULARIES[:publication_status].published],
-                                       license: CONTROLLED_VOCABULARIES[:license].attribution_4_0_international,
-                                       subject: ['Items'])
-                .unlock_and_fetch_ldp_object do |uo|
-                  uo.add_to_path(@community.id, @collection.id)
-                  uo.save!
-                  # Attach a file to the item so that it has attributes to check for
-                  File.open(file_fixture('image-sample.jpeg'), 'r') do |file|
-                    # Bit of a hack to fake a file name with characters that require escaping ...
-                    def file.original_filename
-                      "ü&<>'\".jpeg"
-                    end
-                    uo.add_files([file])
-                  end
-                end
+    @item = locked_ldp_fixture(Item, :fancy).unlock_and_fetch_ldp_object do |uo|
+      uo.add_to_path(@community.id, @collection.id)
+      uo.save!
+      # Attach a file to the item so that it has attributes to check for
+      File.open(file_fixture('image-sample.jpeg'), 'r') do |file|
+        # Bit of a hack to fake a file name with characters that require escaping ...
+        def file.original_filename
+          "ü&<>'\".jpeg"
+        end
+        uo.add_files([file])
+      end
+    end
     @thesis = Thesis.new_locked_ldp_object(visibility: JupiterCore::VISIBILITY_PUBLIC,
                                            owner: 1, title: 'Fancy Item',
                                            dissertant: 'Joe Blow',

--- a/test/ldp_fixtures/README.md
+++ b/test/ldp_fixtures/README.md
@@ -1,0 +1,4 @@
+ActiveFedora stuff will not work with fixtures. The Testing with Rails guide describes fixtures as a
+> way of organizing test data
+
+These 'fixtures' capture stock test data (in YML) for these objects rather than re-inventing the wheel every time (or copy/pasting as the case may be) even if we still have to clean up fedora after every test.

--- a/test/ldp_fixtures/collection.yml
+++ b/test/ldp_fixtures/collection.yml
@@ -1,0 +1,12 @@
+nice:
+  Community: nice
+  title: 'Nice collection'
+  owner: 1
+fancy:
+  Community: fancy
+  title: 'Fancy collection'
+  owner: 1
+books:
+  Community: books
+  title: 'Fantasy Books'
+  owner: 1

--- a/test/ldp_fixtures/community.yml
+++ b/test/ldp_fixtures/community.yml
@@ -1,0 +1,12 @@
+fancy:
+  title: 'Fancy Community'
+  owner: 1
+nice:
+  title: 'Nice community'
+  owner: 1
+books:
+  title: 'Books'
+  owner: 1
+foo:
+  title: 'Community'
+  owner: 1

--- a/test/ldp_fixtures/item.yml
+++ b/test/ldp_fixtures/item.yml
@@ -1,0 +1,21 @@
+random:
+  title: <%= Haikunator.haikunate %>
+  creators: <%= [Haikunator.haikunate] %>
+  visibility: <%= JupiterCore::VISIBILITY_PUBLIC %>
+  created: '1978-01-01'
+  owner: 1
+  item_type: <%= CONTROLLED_VOCABULARIES[:item_type].report %>
+  languages: <%= [CONTROLLED_VOCABULARIES[:language].english] %>
+  license: <%= CONTROLLED_VOCABULARIES[:license].attribution_4_0_international %>
+  subject: ['Randomness']
+fancy:
+  visibility: <%= JupiterCore::VISIBILITY_PUBLIC %>
+  owner: 1
+  title: 'Fancy Item'
+  creators: ['Joe Blow']
+  created: '1938-01-02'
+  languages: <%= [CONTROLLED_VOCABULARIES[:language].english] %>
+  item_type: <%= CONTROLLED_VOCABULARIES[:item_type].article %>
+  publication_status: <%= [CONTROLLED_VOCABULARIES[:publication_status].published] %>
+  license: <%= CONTROLLED_VOCABULARIES[:license].attribution_4_0_international %>
+  subject: ['Items']

--- a/test/models/draft_item_test.rb
+++ b/test/models/draft_item_test.rb
@@ -3,11 +3,9 @@ require 'test_helper'
 class DraftItemTest < ActiveSupport::TestCase
 
   def before_all
-    @community = Community.new_locked_ldp_object(title: 'Books', owner: 1).unlock_and_fetch_ldp_object(&:save!)
-    @collection = Collection.new_locked_ldp_object(title: 'Fantasy Books',
-                                                   owner: 1,
-                                                   community_id: @community.id)
-                            .unlock_and_fetch_ldp_object(&:save!)
+    super
+    @community = locked_ldp_fixture(Community, :books).unlock_and_fetch_ldp_object(&:save!)
+    @collection = locked_ldp_fixture(Collection, :books).unlock_and_fetch_ldp_object(&:save!)
   end
 
   test 'enums' do

--- a/test/models/file_set_test.rb
+++ b/test/models/file_set_test.rb
@@ -28,20 +28,11 @@ class FileSetTest < ActiveSupport::TestCase
 
     # It seems unfortunate as a side-effect of improved item validations, we need to create these in tests that
     # don't care about them...
-    community = Community.new_locked_ldp_object(title: 'Community', owner: 1).unlock_and_fetch_ldp_object(&:save!)
+    community = locked_ldp_fixture(Community, :foo).unlock_and_fetch_ldp_object(&:save!)
     collection = Collection.new_locked_ldp_object(title: 'foo', owner: users(:regular).id,
                                                   community_id: community.id).unlock_and_fetch_ldp_object(&:save!)
 
-    item = Item.new_locked_ldp_object(title: generate_random_string,
-                                      creators: [generate_random_string],
-                                      visibility: JupiterCore::VISIBILITY_PUBLIC,
-                                      created: '1978-01-01',
-                                      owner: 1,
-                                      item_type: CONTROLLED_VOCABULARIES[:item_type].report,
-                                      languages: [CONTROLLED_VOCABULARIES[:language].english],
-                                      license: CONTROLLED_VOCABULARIES[:license].attribution_4_0_international,
-                                      subject: ['Randomness'])
-
+    item = locked_ldp_fixture(Item, :random)
     item.unlock_and_fetch_ldp_object do |unlocked_item|
       unlocked_item.add_to_path(community.id, collection.id)
       unlocked_item.save!

--- a/test/models/item_test.rb
+++ b/test/models/item_test.rb
@@ -324,20 +324,11 @@ class ItemTest < ActiveSupport::TestCase
 
   test 'add_files maintains correct order and correctly creates list_source proxies' do
     # Doing a lot of I/O with Fedora, so I don't want to break this long test into pieces
-    community = Community.new_locked_ldp_object(title: 'Community', owner: 1).unlock_and_fetch_ldp_object(&:save!)
+    community = locked_ldp_fixture(Community, :foo).unlock_and_fetch_ldp_object(&:save!)
     collection = Collection.new_locked_ldp_object(title: 'foo', owner: users(:regular).id,
                                                   community_id: community.id).unlock_and_fetch_ldp_object(&:save!)
 
-    item = Item.new_locked_ldp_object(title: generate_random_string,
-                                      creators: [generate_random_string],
-                                      visibility: JupiterCore::VISIBILITY_PUBLIC,
-                                      created: '1978-01-01',
-                                      owner: 1,
-                                      item_type: CONTROLLED_VOCABULARIES[:item_type].report,
-                                      languages: [CONTROLLED_VOCABULARIES[:language].english],
-                                      license: CONTROLLED_VOCABULARIES[:license].attribution_4_0_international,
-                                      subject: ['Randomness'])
-
+    item = locked_ldp_fixture(Item, :random)
     fedora_item_url = nil
     item.unlock_and_fetch_ldp_object do |unlocked_item|
       unlocked_item.add_to_path(community.id, collection.id)

--- a/test/system/authentication_test.rb
+++ b/test/system/authentication_test.rb
@@ -2,19 +2,20 @@ require 'application_system_test_case'
 
 class AuthenticationTest < ApplicationSystemTestCase
 
+  JOHNDOE_AUTH_HASH = OmniAuth::AuthHash.new(
+    provider: 'saml',
+    uid: 'johndoe',
+    info: {
+      email: 'johndoe@ualberta.ca',
+      name: 'John Doe'
+    }
+  )
+
   test 'should log in and log out work with correct credentials' do
     visit root_url
 
     Rails.application.env_config['omniauth.auth'] =
-      OmniAuth.config.mock_auth[:saml] =
-        OmniAuth::AuthHash.new(
-          provider: 'saml',
-          uid: 'johndoe',
-          info: {
-            email: 'johndoe@ualberta.ca',
-            name: 'John Doe'
-          }
-        )
+      OmniAuth.config.mock_auth[:saml] = JOHNDOE_AUTH_HASH
 
     click_on I18n.t('application.navbar.links.login')
 
@@ -50,15 +51,7 @@ class AuthenticationTest < ApplicationSystemTestCase
     assert_text I18n.t('authorization.user_not_authorized_try_logging_in')
 
     Rails.application.env_config['omniauth.auth'] =
-      OmniAuth.config.mock_auth[:saml] =
-        OmniAuth::AuthHash.new(
-          provider: 'saml',
-          uid: 'johndoe',
-          info: {
-            email: 'johndoe@ualberta.ca',
-            name: 'John Doe'
-          }
-        )
+      OmniAuth.config.mock_auth[:saml] = JOHNDOE_AUTH_HASH
 
     click_link I18n.t('application.navbar.links.login')
 
@@ -78,15 +71,7 @@ class AuthenticationTest < ApplicationSystemTestCase
     assert_selector 'h2', text: I18n.t('welcome.index.welcome_lead')
 
     Rails.application.env_config['omniauth.auth'] =
-      OmniAuth.config.mock_auth[:saml] =
-        OmniAuth::AuthHash.new(
-          provider: 'saml',
-          uid: 'johndoe',
-          info: {
-            email: 'johndoe@ualberta.ca',
-            name: 'John Doe'
-          }
-        )
+      OmniAuth.config.mock_auth[:saml] = JOHNDOE_AUTH_HASH
 
     click_link I18n.t('application.navbar.links.login')
 
@@ -102,15 +87,7 @@ class AuthenticationTest < ApplicationSystemTestCase
     assert_selector 'h1', text: I18n.t('communities.index.header')
 
     Rails.application.env_config['omniauth.auth'] =
-      OmniAuth.config.mock_auth[:saml] =
-        OmniAuth::AuthHash.new(
-          provider: 'saml',
-          uid: 'johndoe',
-          info: {
-            email: 'johndoe@ualberta.ca',
-            name: 'John Doe'
-          }
-        )
+      OmniAuth.config.mock_auth[:saml] = JOHNDOE_AUTH_HASH
 
     click_link I18n.t('application.navbar.links.login')
 

--- a/test/system/item_show_test.rb
+++ b/test/system/item_show_test.rb
@@ -5,23 +5,12 @@ class ItemShowTest < ApplicationSystemTestCase
   def before_all
     super
     @user = User.find_by(email: 'john_snow@example.com')
-    @community = Community.new_locked_ldp_object(title: 'Fancy Community', owner: 1)
-                          .unlock_and_fetch_ldp_object(&:save!)
-    @collection = Collection.new_locked_ldp_object(community_id: @community.id,
-                                                   title: 'Fancy Collection', owner: 1)
-                            .unlock_and_fetch_ldp_object(&:save!)
+
+    @community = locked_ldp_fixture(Community, :fancy).unlock_and_fetch_ldp_object(&:save!)
+    @collection = locked_ldp_fixture(Collection, :fancy).unlock_and_fetch_ldp_object(&:save!)
 
     # Half items have 'Fancy' in title, others have 'Nice', distributed between the two collections
-    @item = Item.new_locked_ldp_object(visibility: JupiterCore::VISIBILITY_PUBLIC,
-                                       owner: @user.id, title: 'Fancy Item',
-                                       creators: ['Joe Blow'],
-                                       created: '2011-11-11',
-                                       languages: [CONTROLLED_VOCABULARIES[:language].english],
-                                       license: CONTROLLED_VOCABULARIES[:license].attribution_4_0_international,
-                                       item_type: CONTROLLED_VOCABULARIES[:item_type].article,
-                                       publication_status: [CONTROLLED_VOCABULARIES[:publication_status].published],
-                                       subject: ['Fancy things'])
-                .unlock_and_fetch_ldp_object do |uo|
+    @item = locked_ldp_fixture(Item, :fancy).unlock_and_fetch_ldp_object do |uo|
       uo.add_to_path(@community.id, @collection.id)
       uo.add_to_path(@community.id, @collection.id)
       uo.save!

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -73,6 +73,31 @@ class ActiveSupport::TestCase
     session[:user_id].present?
   end
 
+  def locked_ldp_fixture(class_name, fixture_name)
+    find_or_create_locked_ldp_fixture(class_name, fixture_name)
+  end
+
+  # uses :title as a lookup so must be unique
+  # TODO: it would be groovy if this could do
+  # @item, @community, @collection = find_or_create_locked_ldp_fixture(Item, :item_with_collection_and_community_dependencies)
+  def find_or_create_locked_ldp_fixture(class_name, fixture_name)
+    fixtures = YAML.safe_load(ERB.new(
+      File.read(Rails.root.join('test', 'ldp_fixtures', "#{class_name.to_s.underscore}.yml"))
+    ).result).symbolize_keys!
+    options = fixtures[fixture_name]
+    options = resolve_fixture_dependencies(options)
+    class_name.where(title: options[:title]).first || class_name.new_locked_ldp_object(options)
+  end
+
+  def resolve_fixture_dependencies(options)
+    options.slice('Collection', 'Community', 'Item').each do |class_name, fixture_name|
+      object = find_or_create_locked_ldp_fixture(class_name.constantize, fixture_name.to_sym)
+      options[class_name.underscore + '_id'] = object.id
+      options.delete(class_name)
+    end
+    options
+  end
+
   # turn on test mode for omniauth
   OmniAuth.config.test_mode = true
 


### PR DESCRIPTION
Closes #417 for now.

From `gem install flay && flay test > duplicates.txt`

- [x] JOHNDOE_AUTH_HASH
- [x] removed second @item1
- [x] Random Item Fixture
  test/models/file_set_test.rb:35
  test/models/item_test.rb:331
- [x] Fancy Item Fixture
  test/controllers/file_sets_controller_test.rb:13
  test/integration/sitemap_test.rb:12
  test/integration/sitemap_test.rb:43
- [x] Nice Community and Collection fixture
  test/controllers/admin/collections_controller_test.rb:5
  test/controllers/collections_controller_test.rb:5
- [x] Books Community and Collection fixture
  test/controllers/items/files_controller_test.rb:6
  test/system/deposit_item_test.rb:5
- [x] Books Community and Collection fixture
  test/controllers/items/draft_controller_test.rb:5
  test/models/draft_item_test.rb:5
- [x] Fancy Community & Collection fixture, maybe Fancy Item fixture
  test/system/item_show_test.rb:15
  test/system/item_show_test.rb:36
- [x] Community and foo Collection fixture, maybe Random Item fixture?
  test/models/file_set_test.rb:32
  test/models/item_test.rb:328