### PR TITLE
Fix floppy tests with regards to VCR

### DIFF
--- a/test/services/doi_service_test.rb
+++ b/test/services/doi_service_test.rb
@@ -105,6 +105,8 @@ class DoiServiceTest < ActiveSupport::TestCase
       assert_equal 'unavailable | withdrawn', ezid_identifer.status
       assert_equal 'no', ezid_identifer.export
     end
+
+    Rails.application.secrets.doi_minting_enabled = false
   end
 
 end


### PR DESCRIPTION
Seemed to be an issue with doi_minting_enabled option being left on and thus item model tests were trying to create a DOI via external api requests

Fixes most of the broken builds for the current PRs. Example: 
https://travis-ci.org/ualbertalib/jupiter/builds/404520114
![image](https://user-images.githubusercontent.com/1930474/42901180-13202578-8a88-11e8-8b24-edb88d0b1b6b.png)
