### PR TITLE
Use ez.test.datacite.org for testing of doi minting code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and releases in Jupiter project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
+### Changed
+- use Datacite EZ API for tests [#911](https://github.com/ualbertalib/jupiter/issues/911)
 
 ## [1.2.6] - 2018-11-05
 ### Fixed

--- a/Gemfile
+++ b/Gemfile
@@ -60,7 +60,7 @@ gem 'sidekiq-cron'
 
 # Misc Utilities
 gem 'aasm' # state-machine management
-gem 'ezid-client'
+gem 'ezid-client', '~> 1.8.0'
 gem 'jbuilder' # generate JSON objects
 gem 'kaminari' # Pagination
 gem 'ransack' # ActiveRecord search/filter
@@ -85,6 +85,7 @@ group :development, :test do
   gem 'selenium-webdriver', require: false
 
   gem 'pry'
+  gem 'pry-byebug'
   gem 'pry-rails'
 
   gem 'rubocop', '~> 0.58.2', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -106,6 +106,7 @@ GEM
       sass (>= 3.5.2)
     brakeman (4.3.1)
     builder (3.2.3)
+    byebug (10.0.2)
     canonical-rails (0.2.4)
       rails (>= 4.1, < 5.3)
     capybara (3.11.1)
@@ -142,8 +143,9 @@ GEM
     et-orbi (1.1.4)
       tzinfo
     execjs (2.7.0)
-    ezid-client (1.7.1)
+    ezid-client (1.8.0)
       hashie (~> 3.4, >= 3.4.3)
+      nokogiri
     faker (1.9.1)
       i18n (>= 0.7)
     faraday (0.12.2)
@@ -274,6 +276,9 @@ GEM
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
+    pry-byebug (3.6.0)
+      byebug (~> 10.0)
+      pry (~> 0.10)
     pry-rails (0.3.7)
       pry (>= 0.10.4)
     public_suffix (3.0.3)
@@ -467,7 +472,7 @@ DEPENDENCIES
   clamby
   connection_pool
   dropzonejs-rails
-  ezid-client
+  ezid-client (~> 1.8.0)
   faker
   font-awesome-rails
   haikunator
@@ -485,6 +490,7 @@ DEPENDENCIES
   omniauth-saml
   pg (~> 1.1.3)
   pry
+  pry-byebug
   pry-rails
   puma (~> 3.12)
   pundit

--- a/app/services/doi_service.rb
+++ b/app/services/doi_service.rb
@@ -51,7 +51,12 @@ class DOIService
   def update
     return unless @item.doi_state.awaiting_update?
 
-    ezid_identifer = Ezid::Identifier.modify(@item.doi, ezid_metadata)
+    ezid_identifer = Ezid::Identifier.modify(
+      @item.doi,
+      # TODO: issue with datacite.resourcetype addressed by https://github.com/datacite/cheetoh/pull/21
+      # don't include resource type in metadata sent will work in 'most cases' ;)
+      ezid_metadata.except(:datacite_resourcetypegeneral, :datacite_resourcetype)
+    )
     return if ezid_identifer.blank?
 
     if @item.private?
@@ -76,7 +81,9 @@ class DOIService
   end
 
   def self.remove(doi)
-    Ezid::Identifier.modify(doi, status: "#{Ezid::Status::UNAVAILABLE} | withdrawn", export: 'no')
+    # TODO: issue with _export addressed by https://github.com/datacite/cheetoh/pull/21
+    # don't include _export in metadata
+    Ezid::Identifier.modify(doi, status: "#{Ezid::Status::UNAVAILABLE} | withdrawn")
   end
 
   private
@@ -87,11 +94,11 @@ class DOIService
       datacite_publisher: PUBLISHER,
       datacite_publicationyear: @item.sort_year.presence || '(:unav)',
       datacite_resourcetype: DATACITE_METADATA_SCHEME[@item.item_type_with_status_code],
+      datacite_resourcetypegeneral: DATACITE_METADATA_SCHEME[@item.item_type_with_status_code].split('/').first,
       datacite_title:  @item.title,
       target: Rails.application.routes.url_helpers.item_url(id: @item.id),
       # Can only set status if been minted previously, else its public
-      status: @item.private? && @item.doi.present? ? UNAVAILABLE_MESSAGE : Ezid::Status::PUBLIC,
-      export: @item.private? ? 'no' : 'yes'
+      status: @item.private? && @item.doi.present? ? UNAVAILABLE_MESSAGE : Ezid::Status::PUBLIC
     }
   end
 

--- a/config/initializers/ezid_client.rb
+++ b/config/initializers/ezid_client.rb
@@ -1,4 +1,5 @@
 Ezid::Client.configure do |config|
+  config.host = Rails.application.secrets.ezid_host
   config.default_shoulder = Rails.application.secrets.ezid_default_shoulder
   config.user = Rails.application.secrets.ezid_user
   config.password = Rails.application.secrets.ezid_password

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -22,6 +22,7 @@ shared:
   active_storage_directory: <%= ENV['ACTIVE_STORAGE_DIRECTORY'] || Rails.root.join("storage") %>
   rollbar_token: <%= ENV['ROLLBAR_TOKEN'] %>
   doi_minting_enabled: <%= ENV['DOI_MINTING_ENABLED'] || false %>
+  ezid_host: <%= ENV['EZID_HOST'] %>
   ezid_default_shoulder: <%= ENV['EZID_DEFAULT_SHOULDER'] %>
   ezid_user: <%= ENV['EZID_USER'] %>
   ezid_password: <%= ENV['EZID_PASSWORD'] %>
@@ -34,8 +35,8 @@ shared:
 development:
   secret_key_base: c0a4bf2c5890d0fa86e1459dd189bc4c5a02f412067b610490885c8c312bf0cea5d988e075761ba7277a8291041c1b2e7cf6c373d4d6f43d4522bc48db76cc1a
 
-  ezid_default_shoulder: doi:10.5072/FK2
-  ezid_user: apitest
+  ezid_default_shoulder: doi:10.21967/FK2
+  ezid_user: CISTI.UAL
 
   saml_assertion_consumer_service_url: ''
   saml_issuer: ''
@@ -54,8 +55,9 @@ development:
 test:
   secret_key_base: 57caacef3de2f2367aee4d1ae099be5e149c0e821eaacf4c413798c931c82dc6e34a200f121316cb123b30ef3574a8acb82736a6bc76157132949233fd0340c5
 
-  ezid_default_shoulder: doi:10.5072/FK2
-  ezid_user: apitest
+  ezid_host: ez.test.datacite.org
+  ezid_default_shoulder: doi:10.21967/FK2
+  ezid_user: CISTI.UAL
 
   saml_assertion_consumer_service_url: ''
   saml_issuer: ''

--- a/test/services/doi_service_test.rb
+++ b/test/services/doi_service_test.rb
@@ -4,7 +4,7 @@ class DoiServiceTest < ActiveSupport::TestCase
 
   include ActiveJob::TestHelper
 
-  EXAMPLE_DOI = 'doi:10.5072/FK2JQ1005X'.freeze
+  EXAMPLE_DOI = 'doi:10.21967/fk2-7jm3-d229'.freeze
 
   test 'DOI state transitions' do
     assert_no_enqueued_jobs
@@ -46,7 +46,7 @@ class DoiServiceTest < ActiveSupport::TestCase
       assert_equal 'University of Alberta Libraries', ezid_identifer.datacite_publisher
       assert_equal 'Test Title', ezid_identifer.datacite_title
       assert_equal 'Text/Book', ezid_identifer.datacite_resourcetype
-      assert_equal '(:unav)', ezid_identifer.datacite_publicationyear
+      assert_equal '2017', ezid_identifer.datacite_publicationyear
       assert_equal Ezid::Status::PUBLIC, ezid_identifer.status
       assert_equal 'yes', ezid_identifer.export
 
@@ -87,8 +87,9 @@ class DoiServiceTest < ActiveSupport::TestCase
       ezid_identifer = DOIService.new(item).update
       assert_not_nil ezid_identifer
       assert_equal EXAMPLE_DOI, ezid_identifer.id
-      assert_equal 'unavailable | not publicly released', ezid_identifer.status
-      assert_equal 'no', ezid_identifer.export
+      # TODO: will be fixed by cheetoh release 0.10.2 by 'bug on concatenating reason' commit
+      # see https://github.com/datacite/cheetoh/commit/103699867478d5086a76bfe602efe21be02f2994#diff-4a07abe40929a2b2d94ac79e73c5a0a1
+      assert_equal 'unavailable | unavailable | not publicly released', ezid_identifer.status
       assert_equal 'not_available', item.doi_state.aasm_state
     end
 
@@ -102,8 +103,10 @@ class DoiServiceTest < ActiveSupport::TestCase
       ezid_identifer = DOIService.remove(item.doi)
       assert_not_nil ezid_identifer
       assert_equal EXAMPLE_DOI, ezid_identifer.id
-      assert_equal 'unavailable | withdrawn', ezid_identifer.status
-      assert_equal 'no', ezid_identifer.export
+      # TODO: will be fixed by cheetoh release 0.10.2 bug on concatenating reason
+      # see https://github.com/datacite/cheetoh/commit/103699867478d5086a76bfe602efe21be02f2994#diff-4a07abe40929a2b2d94ac79e73c5a0a1
+      assert_equal 'unavailable | unavailable | withdrawn', ezid_identifer.status
+      assert_equal 'yes', ezid_identifer.export
     end
 
     Rails.application.secrets.doi_minting_enabled = false

--- a/test/vcr/ezid_minting.yml
+++ b/test/vcr/ezid_minting.yml
@@ -2,19 +2,15 @@
 http_interactions:
 - request:
     method: post
-    uri: https://ezid.cdlib.org/shoulder/doi:10.5072/FK2
+    uri: https://ez.test.datacite.org/shoulder/doi:10.21967/FK2
     body:
       encoding: UTF-8
       string: |-
         _status: public
         _profile: datacite
-        datacite.creator: John Doe
-        datacite.publisher: University of Alberta Libraries
-        datacite.publicationyear: (:unav)
-        datacite.resourcetype: Text/Book
-        datacite.title: Test Title
-        _target: http://localhost:3000/items/<%= id %>
+        _target: http://localhost/items/aab8cadd-3366-496a-bab5-2ebac3428c54
         _export: yes
+        datacite: <?xml version="1.0" encoding="UTF-8"?><resource xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://datacite.org/schema/kernel-4" xsi:schemaLocation="http://datacite.org/schema/kernel-4 http://schema.datacite.org/meta/kernel-4/metadata.xsd"><identifier identifierType="DOI"></identifier><creators><creator><creatorName>Joe Blow</creatorName></creator></creators><titles><title>Test Title</title></titles><publisher>University of Alberta Libraries</publisher><publicationYear>2017</publicationYear><resourceType resourceTypeGeneral="Text">Text/Book</resourceType><descriptions><description descriptionType="Abstract"></description></descriptions></resource>%0A
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -23,34 +19,37 @@ http_interactions:
       User-Agent:
       - Ruby
       Host:
-      - ezid.cdlib.org
+      - ez.test.datacite.org
       Content-Type:
       - text/plain; charset=UTF-8
   response:
     status:
-      code: 201
-      message: CREATED
+      code: 200
+      message: OK
     headers:
       Date:
-      - Fri, 04 Nov 2016 19:07:29 GMT
-      Server:
-      - Apache/2.2.17 (Unix) mod_ssl/2.2.17 OpenSSL/1.0.1k-fips mod_wsgi/4.4.9 Python/2.7.6
-      Content-Length:
-      - '55'
-      Vary:
-      - Accept-Language,Cookie
-      Content-Language:
-      - en
+      - Tue, 13 Nov 2018 19:52:03 GMT
       Content-Type:
-      - text/plain; charset=UTF-8
+      - text/plain; charset=utf-8
+      Server:
+      - nginx/1.14.0 + Phusion Passenger 5.3.6
     body:
-      encoding: UTF-8
-      string: 'success: doi:10.5072/FK2JQ1005X | ark:/b5072/fk2jq1005x'
+      encoding: ASCII-8BIT
+      string: |-
+        success: doi:10.21967/fk2-7jm3-d229
+        _target: http://localhost/items/aab8cadd-3366-496a-bab5-2ebac3428c54
+        datacite: <?xml version="1.0" encoding="UTF-8"?>%0A<resource xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://datacite.org/schema/kernel-4" xsi:schemaLocation="http://datacite.org/schema/kernel-4 http://schema.datacite.org/meta/kernel-4/metadata.xsd">%0A  <identifier identifierType="DOI">10.21967/FK2-7JM3-D229</identifier>%0A  <creators>%0A    <creator>%0A      <creatorName>Joe Blow</creatorName>%0A    </creator>%0A  </creators>%0A  <titles>%0A    <title>Test Title</title>%0A  </titles>%0A  <publisher>University of Alberta Libraries</publisher>%0A  <publicationYear>2017</publicationYear>%0A  <resourceType resourceTypeGeneral="Text">Text/Book</resourceType>%0A  <descriptions>%0A    <description descriptionType="Abstract"/>%0A  </descriptions>%0A</resource>
+        _profile: datacite
+        _datacenter: CISTI.UAL
+        _export: yes
+        _created: 1542138723
+        _updated: 1542138723
+        _status: public
     http_version:
-  recorded_at: Fri, 04 Nov 2016 19:07:30 GMT
+  recorded_at: Tue, 13 Nov 2018 19:52:03 GMT
 - request:
     method: get
-    uri: https://ezid.cdlib.org/id/doi:10.5072/FK2JQ1005X
+    uri: https://ez.test.datacite.org/id/doi:10.21967/fk2-7jm3-d229
     body:
       encoding: US-ASCII
       string: ''
@@ -62,7 +61,7 @@ http_interactions:
       User-Agent:
       - Ruby
       Host:
-      - ezid.cdlib.org
+      - ez.test.datacite.org
       Content-Type:
       - text/plain; charset=UTF-8
   response:
@@ -71,36 +70,25 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 04 Nov 2016 19:07:32 GMT
-      Server:
-      - Apache/2.2.17 (Unix) mod_ssl/2.2.17 OpenSSL/1.0.1k-fips mod_wsgi/4.4.9 Python/2.7.6
-      Content-Length:
-      - '435'
-      Vary:
-      - Accept-Language,Cookie
-      Content-Language:
-      - en
+      - Tue, 13 Nov 2018 19:52:03 GMT
       Content-Type:
-      - text/plain; charset=UTF-8
+      - text/plain; charset=utf-8
+      Vary:
+      - Accept-Encoding
+      Server:
+      - nginx/1.14.0 + Phusion Passenger 5.3.6
     body:
-      encoding: UTF-8
-      string: |
-        success: doi:10.5072/FK2JQ1005X
-        datacite.publisher: University of Alberta Libraries
+      encoding: ASCII-8BIT
+      string: |-
+        success: doi:10.21967/fk2-7jm3-d229
+        _target: http://localhost/items/aab8cadd-3366-496a-bab5-2ebac3428c54
+        datacite: <?xml version="1.0" encoding="UTF-8"?>%0A<resource xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://datacite.org/schema/kernel-4" xsi:schemaLocation="http://datacite.org/schema/kernel-4 http://schema.datacite.org/meta/kernel-4/metadata.xsd">%0A  <identifier identifierType="DOI">10.21967/FK2-7JM3-D229</identifier>%0A  <creators>%0A    <creator>%0A      <creatorName>Joe Blow</creatorName>%0A    </creator>%0A  </creators>%0A  <titles>%0A    <title>Test Title</title>%0A  </titles>%0A  <publisher>University of Alberta Libraries</publisher>%0A  <publicationYear>2017</publicationYear>%0A  <resourceType resourceTypeGeneral="Text">Text/Book</resourceType>%0A  <descriptions>%0A    <description descriptionType="Abstract"/>%0A  </descriptions>%0A</resource>
         _profile: datacite
+        _datacenter: CISTI.UAL
         _export: yes
-        datacite.creator: John Doe
-        datacite.publicationyear: (:unav)
-        datacite.resourcetype: Text/Book
-        _datacenter: CDL.CDL
-        _updated: 1478286450
-        _target: http://localhost:3000/items/<%= id %>
-        datacite.title: Test Title
-        _ownergroup: apitest
-        _owner: apitest
-        _shadowedby: ark:/b5072/fk2jq1005x
-        _created: 1478286450
+        _created: 1542138723
+        _updated: 1542138723
         _status: public
     http_version:
-  recorded_at: Fri, 04 Nov 2016 19:07:32 GMT
-recorded_with: VCR 3.0.3
+  recorded_at: Tue, 13 Nov 2018 19:52:03 GMT
+recorded_with: VCR 4.0.0

--- a/test/vcr/ezid_removal.yml
+++ b/test/vcr/ezid_removal.yml
@@ -2,12 +2,10 @@
 http_interactions:
 - request:
     method: post
-    uri: https://ezid.cdlib.org/id/doi:10.5072/FK2JQ1005X
+    uri: https://ez.test.datacite.org/id/doi:10.21967/fk2-7jm3-d229
     body:
       encoding: UTF-8
-      string: |-
-        _status: unavailable | withdrawn
-        _export: no
+      string: '_status: unavailable | withdrawn'
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -16,7 +14,7 @@ http_interactions:
       User-Agent:
       - Ruby
       Host:
-      - ezid.cdlib.org
+      - ez.test.datacite.org
       Content-Type:
       - text/plain; charset=UTF-8
   response:
@@ -25,25 +23,30 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 04 Nov 2016 22:09:00 GMT
-      Server:
-      - Apache/2.2.17 (Unix) mod_ssl/2.2.17 OpenSSL/1.0.1k-fips mod_wsgi/4.4.9 Python/2.7.6
-      Content-Length:
-      - '31'
-      Vary:
-      - Accept-Language,Cookie
-      Content-Language:
-      - en
+      - Thu, 15 Nov 2018 22:18:04 GMT
       Content-Type:
-      - text/plain; charset=UTF-8
+      - text/plain; charset=utf-8
+      Vary:
+      - Accept-Encoding
+      Server:
+      - nginx/1.14.0 + Phusion Passenger 5.3.6
     body:
-      encoding: UTF-8
-      string: 'success: doi:10.5072/FK2JQ1005X'
+      encoding: ASCII-8BIT
+      string: |-
+        success: doi:10.21967/fk2-7jm3-d229
+        _target: http://localhost/items/03ef60fe-1a19-4cf4-a432-cb67348cb6eb
+        datacite: <?xml version="1.0" encoding="UTF-8"?>%0A<resource xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://datacite.org/schema/kernel-4" xsi:schemaLocation="http://datacite.org/schema/kernel-4 http://schema.datacite.org/meta/kernel-4/metadata.xsd">%0A  <identifier identifierType="DOI">10.21967/FK2-7JM3-D229</identifier>%0A  <creators>%0A    <creator>%0A      <creatorName>Joe Blow</creatorName>%0A    </creator>%0A  </creators>%0A  <titles>%0A    <title>Different Title</title>%0A  </titles>%0A  <publisher>University of Alberta Libraries</publisher>%0A  <publicationYear>2017</publicationYear>%0A  <resourceType resourceTypeGeneral="Text">Text/Chapter</resourceType>%0A  <dates>%0A    <date dateType="Issued">2017</date>%0A  </dates>%0A  <version/>%0A  <descriptions>%0A    <description descriptionType="Abstract"/>%0A  </descriptions>%0A</resource>%0A
+        _profile: datacite
+        _datacenter: CISTI.UAL
+        _export: yes
+        _created: 1542138723
+        _updated: 1542320284
+        _status: unavailable | unavailable | withdrawn
     http_version:
-  recorded_at: Fri, 04 Nov 2016 22:09:00 GMT
+  recorded_at: Thu, 15 Nov 2018 22:18:04 GMT
 - request:
     method: get
-    uri: https://ezid.cdlib.org/id/doi:10.5072/FK2JQ1005X
+    uri: https://ez.test.datacite.org/id/doi:10.21967/fk2-7jm3-d229
     body:
       encoding: US-ASCII
       string: ''
@@ -55,7 +58,7 @@ http_interactions:
       User-Agent:
       - Ruby
       Host:
-      - ezid.cdlib.org
+      - ez.test.datacite.org
       Content-Type:
       - text/plain; charset=UTF-8
   response:
@@ -64,36 +67,33 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 04 Nov 2016 22:09:01 GMT
-      Server:
-      - Apache/2.2.17 (Unix) mod_ssl/2.2.17 OpenSSL/1.0.1k-fips mod_wsgi/4.4.9 Python/2.7.6
-      Content-Length:
-      - '451'
-      Vary:
-      - Accept-Language,Cookie
-      Content-Language:
-      - en
+      - Thu, 15 Nov 2018 22:18:05 GMT
       Content-Type:
-      - text/plain; charset=UTF-8
+      - text/plain; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Vary:
+      - Accept-Encoding
+      Server:
+      - nginx/1.14.0 + Phusion Passenger 5.3.6
     body:
-      encoding: UTF-8
-      string: |
-        success: doi:10.5072/FK2JQ1005X
-        datacite.publisher: University of Alberta Libraries
+      encoding: ASCII-8BIT
+      string: |-
+        success: doi:10.21967/fk2-7jm3-d229
+        _target: http://localhost/items/03ef60fe-1a19-4cf4-a432-cb67348cb6eb
+        datacite: <?xml version="1.0" encoding="UTF-8"?>%0A<resource xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://datacite.org/schema/kernel-4" xsi:schemaLocation="http://datacite.org/schema/kernel-4 http://schema.datacite.org/meta/kernel-4/metadata.xsd">%0A  <identifier identifierType="DOI">10.21967/FK2-7JM3-D229</identifier>%0A  <creators>%0A    <creator>%0A      <creatorName>Joe Blow</creatorName>%0A    </creator>%0A  </creators>%0A  <titles>%0A    <title>Different Title</title>%0A  </titles>%0A  <publisher>University of Alberta Libraries</publisher>%0A  <publicationYear>2017</publicationYear>%0A  <resourceType resourceTypeGeneral="Text">Text/Chapter</resourceType>%0A  <dates>%0A    <date dateType="Issued">2017</date>%0A  </dates>%0A  <version/>%0A  <descriptions>%0A    <description descriptionType="Abstract"/>%0A  </descriptions>%0A</resource>%0A
         _profile: datacite
-        _datacenter: CDL.CDL
-        _target: http://localhost:3000/items/<%= id %>
-        _ownergroup: apitest
-        _shadowedby: ark:/b5072/fk2jq1003w
-        _status: unavailable | withdrawn
-        _export: no
-        datacite.creator: John Doe
-        datacite.publicationyear: (:unav)
-        datacite.resourcetype: Text/Book
-        _updated: 1478297340
-        datacite.title: Different Title
-        _owner: apitest
-        _created: 1478192177
+        _datacenter: CISTI.UAL
+        _export: yes
+        _created: 1542138723
+        _updated: 1542320284
+        _status: unavailable | unavailable | withdrawn
     http_version:
-  recorded_at: Fri, 04 Nov 2016 22:09:01 GMT
-recorded_with: VCR 3.0.3
+  recorded_at: Thu, 15 Nov 2018 22:18:05 GMT
+recorded_with: VCR 4.0.0

--- a/test/vcr/ezid_updating.yml
+++ b/test/vcr/ezid_updating.yml
@@ -2,16 +2,15 @@
 http_interactions:
 - request:
     method: post
-    uri: https://ezid.cdlib.org/id/doi:10.5072/FK2JQ1005X
+    uri: https://ez.test.datacite.org/id/doi:10.21967/fk2-7jm3-d229
     body:
       encoding: UTF-8
       string: |-
-        datacite.creator: John Doe
+        datacite.creator: Joe Blow
         datacite.publisher: University of Alberta Libraries
-        datacite.publicationyear: (:unav)
-        datacite.resourcetype: Text/Book
+        datacite.publicationyear: 2017
         datacite.title: Different Title
-        _target: http://localhost:3000/items/<%= id %>
+        _target: http://localhost/items/66a8c005-57e6-4bbf-9d78-1d1d4fb8736f
         _status: public
         _export: yes
     headers:
@@ -22,7 +21,7 @@ http_interactions:
       User-Agent:
       - Ruby
       Host:
-      - ezid.cdlib.org
+      - ez.test.datacite.org
       Content-Type:
       - text/plain; charset=UTF-8
   response:
@@ -31,25 +30,38 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 04 Nov 2016 19:07:50 GMT
-      Server:
-      - Apache/2.2.17 (Unix) mod_ssl/2.2.17 OpenSSL/1.0.1k-fips mod_wsgi/4.4.9 Python/2.7.6
-      Content-Length:
-      - '31'
-      Vary:
-      - Accept-Language,Cookie
-      Content-Language:
-      - en
+      - Tue, 13 Nov 2018 20:03:24 GMT
       Content-Type:
-      - text/plain; charset=UTF-8
+      - text/plain; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Vary:
+      - Accept-Encoding
+      Server:
+      - nginx/1.14.0 + Phusion Passenger 5.3.6
     body:
-      encoding: UTF-8
-      string: 'success: doi:10.5072/FK2JQ1003W'
+      encoding: ASCII-8BIT
+      string: |-
+        success: doi:10.21967/fk2-7jm3-d229
+        _target: http://localhost/items/66a8c005-57e6-4bbf-9d78-1d1d4fb8736f
+        datacite: <?xml version="1.0" encoding="UTF-8"?>%0A<resource xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://datacite.org/schema/kernel-4" xsi:schemaLocation="http://datacite.org/schema/kernel-4 http://schema.datacite.org/meta/kernel-4/metadata.xsd">%0A  <identifier identifierType="DOI">10.21967/FK2-7JM3-D229</identifier>%0A  <creators>%0A    <creator>%0A      <creatorName>Joe Blow</creatorName>%0A    </creator>%0A  </creators>%0A  <titles>%0A    <title>Different Title</title>%0A  </titles>%0A  <publisher>University of Alberta Libraries</publisher>%0A  <publicationYear>2017</publicationYear>%0A  <resourceType resourceTypeGeneral="Text">Text/Book</resourceType>%0A  <dates>%0A    <date dateType="Issued">2017</date>%0A  </dates>%0A  <version/>%0A  <descriptions>%0A    <description descriptionType="Abstract"/>%0A  </descriptions>%0A</resource>%0A
+        _profile: datacite
+        _datacenter: CISTI.UAL
+        _export: yes
+        _created: 1542138723
+        _updated: 1542139404
+        _status: public
     http_version:
-  recorded_at: Fri, 04 Nov 2016 19:07:51 GMT
+  recorded_at: Tue, 13 Nov 2018 20:03:24 GMT
 - request:
     method: get
-    uri: https://ezid.cdlib.org/id/doi:10.5072/FK2JQ1005X
+    uri: https://ez.test.datacite.org/id/doi:10.21967/fk2-7jm3-d229
     body:
       encoding: US-ASCII
       string: ''
@@ -61,7 +73,7 @@ http_interactions:
       User-Agent:
       - Ruby
       Host:
-      - ezid.cdlib.org
+      - ez.test.datacite.org
       Content-Type:
       - text/plain; charset=UTF-8
   response:
@@ -70,36 +82,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 04 Nov 2016 19:07:52 GMT
-      Server:
-      - Apache/2.2.17 (Unix) mod_ssl/2.2.17 OpenSSL/1.0.1k-fips mod_wsgi/4.4.9 Python/2.7.6
-      Content-Length:
-      - '440'
-      Vary:
-      - Accept-Language,Cookie
-      Content-Language:
-      - en
+      - Tue, 13 Nov 2018 20:03:24 GMT
       Content-Type:
-      - text/plain; charset=UTF-8
+      - text/plain; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
+      X-Anonymous-Consumer:
+      - 'true'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Vary:
+      - Accept-Encoding
+      Server:
+      - nginx/1.14.0 + Phusion Passenger 5.3.6
     body:
-      encoding: UTF-8
-      string: |
-        success: doi:10.5072/FK2JQ1005X
-        datacite.publisher: University of Alberta Libraries
+      encoding: ASCII-8BIT
+      string: |-
+        success: doi:10.21967/fk2-7jm3-d229
+        _target: http://localhost/items/66a8c005-57e6-4bbf-9d78-1d1d4fb8736f
+        datacite: <?xml version="1.0" encoding="UTF-8"?>%0A<resource xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://datacite.org/schema/kernel-4" xsi:schemaLocation="http://datacite.org/schema/kernel-4 http://schema.datacite.org/meta/kernel-4/metadata.xsd">%0A  <identifier identifierType="DOI">10.21967/FK2-7JM3-D229</identifier>%0A  <creators>%0A    <creator>%0A      <creatorName>Joe Blow</creatorName>%0A    </creator>%0A  </creators>%0A  <titles>%0A    <title>Different Title</title>%0A  </titles>%0A  <publisher>University of Alberta Libraries</publisher>%0A  <publicationYear>2017</publicationYear>%0A  <resourceType resourceTypeGeneral="Text">Text/Book</resourceType>%0A  <dates>%0A    <date dateType="Issued">2017</date>%0A  </dates>%0A  <version/>%0A  <descriptions>%0A    <description descriptionType="Abstract"/>%0A  </descriptions>%0A</resource>%0A
         _profile: datacite
+        _datacenter: CISTI.UAL
         _export: yes
-        datacite.creator: John Doe
-        datacite.publicationyear: (:unav)
-        datacite.resourcetype: Text/Book
-        _datacenter: CDL.CDL
-        _updated: 1478286470
-        _target: http://localhost:3000/items/<%= id %>
-        datacite.title: Different Title
-        _ownergroup: apitest
-        _owner: apitest
-        _shadowedby: ark:/b5072/fk2jq1005x
-        _created: 1478192177
+        _created: 1542138723
+        _updated: 1542139404
         _status: public
     http_version:
-  recorded_at: Fri, 04 Nov 2016 19:07:52 GMT
-recorded_with: VCR 3.0.3
+  recorded_at: Tue, 13 Nov 2018 20:03:24 GMT
+recorded_with: VCR 4.0.0

--- a/test/vcr/ezid_updating_unavailable.yml
+++ b/test/vcr/ezid_updating_unavailable.yml
@@ -2,18 +2,16 @@
 http_interactions:
 - request:
     method: post
-    uri: https://ezid.cdlib.org/id/doi:10.5072/FK2JQ1005X
+    uri: https://ez.test.datacite.org/id/doi:10.21967/fk2-7jm3-d229
     body:
       encoding: UTF-8
       string: |-
-        datacite.creator: John Doe
+        datacite.creator: Joe Blow
         datacite.publisher: University of Alberta Libraries
-        datacite.publicationyear: (:unav)
-        datacite.resourcetype: Text/Book
+        datacite.publicationyear: 2017
         datacite.title: Different Title
-        _target: http://localhost:3000/items/<%= id %>
+        _target: http://localhost/items/03ef60fe-1a19-4cf4-a432-cb67348cb6eb
         _status: unavailable | not publicly released
-        _export: no
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -22,7 +20,7 @@ http_interactions:
       User-Agent:
       - Ruby
       Host:
-      - ezid.cdlib.org
+      - ez.test.datacite.org
       Content-Type:
       - text/plain; charset=UTF-8
   response:
@@ -31,25 +29,38 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 04 Nov 2016 19:07:57 GMT
-      Server:
-      - Apache/2.2.17 (Unix) mod_ssl/2.2.17 OpenSSL/1.0.1k-fips mod_wsgi/4.4.9 Python/2.7.6
-      Content-Length:
-      - '31'
-      Vary:
-      - Accept-Language,Cookie
-      Content-Language:
-      - en
+      - Thu, 15 Nov 2018 22:18:03 GMT
       Content-Type:
-      - text/plain; charset=UTF-8
+      - text/plain; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Vary:
+      - Accept-Encoding
+      Server:
+      - nginx/1.14.0 + Phusion Passenger 5.3.6
     body:
-      encoding: UTF-8
-      string: 'success: doi:10.5072/FK2JQ1005X'
+      encoding: ASCII-8BIT
+      string: |-
+        success: doi:10.21967/fk2-7jm3-d229
+        _target: http://localhost/items/03ef60fe-1a19-4cf4-a432-cb67348cb6eb
+        datacite: <?xml version="1.0" encoding="UTF-8"?>%0A<resource xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://datacite.org/schema/kernel-4" xsi:schemaLocation="http://datacite.org/schema/kernel-4 http://schema.datacite.org/meta/kernel-4/metadata.xsd">%0A  <identifier identifierType="DOI">10.21967/FK2-7JM3-D229</identifier>%0A  <creators>%0A    <creator>%0A      <creatorName>Joe Blow</creatorName>%0A    </creator>%0A  </creators>%0A  <titles>%0A    <title>Different Title</title>%0A  </titles>%0A  <publisher>University of Alberta Libraries</publisher>%0A  <publicationYear>2017</publicationYear>%0A  <resourceType resourceTypeGeneral="Text">Text/Chapter</resourceType>%0A  <dates>%0A    <date dateType="Issued">2017</date>%0A  </dates>%0A  <version/>%0A  <descriptions>%0A    <description descriptionType="Abstract"/>%0A  </descriptions>%0A</resource>%0A
+        _profile: datacite
+        _datacenter: CISTI.UAL
+        _export: yes
+        _created: 1542138723
+        _updated: 1542320283
+        _status: unavailable | unavailable | not publicly released
     http_version:
-  recorded_at: Fri, 04 Nov 2016 19:07:58 GMT
+  recorded_at: Thu, 15 Nov 2018 22:18:03 GMT
 - request:
     method: get
-    uri: https://ezid.cdlib.org/id/doi:10.5072/FK2JQ1005X
+    uri: https://ez.test.datacite.org/id/doi:10.21967/fk2-7jm3-d229
     body:
       encoding: US-ASCII
       string: ''
@@ -61,7 +72,7 @@ http_interactions:
       User-Agent:
       - Ruby
       Host:
-      - ezid.cdlib.org
+      - ez.test.datacite.org
       Content-Type:
       - text/plain; charset=UTF-8
   response:
@@ -70,36 +81,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 04 Nov 2016 19:07:59 GMT
-      Server:
-      - Apache/2.2.17 (Unix) mod_ssl/2.2.17 OpenSSL/1.0.1k-fips mod_wsgi/4.4.9 Python/2.7.6
-      Content-Length:
-      - '463'
-      Vary:
-      - Accept-Language,Cookie
-      Content-Language:
-      - en
+      - Thu, 15 Nov 2018 22:18:03 GMT
       Content-Type:
-      - text/plain; charset=UTF-8
+      - text/plain; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
+      X-Anonymous-Consumer:
+      - 'true'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Vary:
+      - Accept-Encoding
+      Server:
+      - nginx/1.14.0 + Phusion Passenger 5.3.6
     body:
-      encoding: UTF-8
-      string: |
-        success: doi:10.5072/FK2JQ1005X
-        datacite.publisher: University of Alberta Libraries
+      encoding: ASCII-8BIT
+      string: |-
+        success: doi:10.21967/fk2-7jm3-d229
+        _target: http://localhost/items/03ef60fe-1a19-4cf4-a432-cb67348cb6eb
+        datacite: <?xml version="1.0" encoding="UTF-8"?>%0A<resource xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://datacite.org/schema/kernel-4" xsi:schemaLocation="http://datacite.org/schema/kernel-4 http://schema.datacite.org/meta/kernel-4/metadata.xsd">%0A  <identifier identifierType="DOI">10.21967/FK2-7JM3-D229</identifier>%0A  <creators>%0A    <creator>%0A      <creatorName>Joe Blow</creatorName>%0A    </creator>%0A  </creators>%0A  <titles>%0A    <title>Different Title</title>%0A  </titles>%0A  <publisher>University of Alberta Libraries</publisher>%0A  <publicationYear>2017</publicationYear>%0A  <resourceType resourceTypeGeneral="Text">Text/Chapter</resourceType>%0A  <dates>%0A    <date dateType="Issued">2017</date>%0A  </dates>%0A  <version/>%0A  <descriptions>%0A    <description descriptionType="Abstract"/>%0A  </descriptions>%0A</resource>%0A
         _profile: datacite
-        _datacenter: CDL.CDL
-        _target: http://localhost:3000/items/<%= id %>
-        _ownergroup: apitest
-        _shadowedby: ark:/b5072/fk2jq1005x
-        _status: unavailable | not publicly released
-        _export: no
-        datacite.creator: John Doe
-        datacite.publicationyear: (:unav)
-        datacite.resourcetype: Text/Book
-        _updated: 1478286477
-        datacite.title: Different Title
-        _owner: apitest
-        _created: 1478192177
+        _datacenter: CISTI.UAL
+        _export: yes
+        _created: 1542138723
+        _updated: 1542320283
+        _status: unavailable | unavailable | not publicly released
     http_version:
-  recorded_at: Fri, 04 Nov 2016 19:07:59 GMT
-recorded_with: VCR 3.0.3
+  recorded_at: Thu, 15 Nov 2018 22:18:04 GMT
+recorded_with: VCR 4.0.0


### PR DESCRIPTION
closes #911 
closes #861
- upgrades ezid-client gem which includes Datacite compatibility
- `Ezid::Client.configure.host` points at 'ez.test.datacite.org'
- added `datacite_resourcetypegeneral` to accomodate required field for minting
- removed `datacite_resourcetype*` from updates (causes error)
- removed `_export` from identifiers being made unavailable. Datacite doesn't really have this concept.
- add comments with TODOs when fixes available https://github.com/datacite/cheetoh/pull/21 and ez.test.datacite.org

TODO:
- [x] why does update complain about 'Ezid::Error: :resource_type_general' as an unpermitted param?
- [x] why is `_status` 'unavailable' duplicated
- [x] why is `_export` change not respected