### PR TITLE
783: Fix wrong orientation in thumbnails for portrait mode images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and releases in Jupiter project adheres to [Semantic Versioning](http://semver.o
 
 ## [Unreleased]
 ### Fixed
+- Fix wrong orientation in thumbnails for portrait mode images [PR#783](https://github.com/ualbertalib/jupiter/pull/783)
 - workarounds for Datacite EZ API for tests [PR#945](https://github.com/ualbertalib/jupiter/pull/945)
 
 ### Changed

--- a/app/models/community.rb
+++ b/app/models/community.rb
@@ -30,7 +30,7 @@ class Community < JupiterCore::LockedLdpObject
   end
 
   # compatibility with item thumbnail API
-  def thumbnail_url(args = { resize: '100x100' })
+  def thumbnail_url(args = { resize: '100x100', auto_orient: true })
     return nil if logo_attachment.blank?
 
     Rails.application.routes.url_helpers.rails_representation_path(logo_attachment.variant(args).processed)

--- a/app/models/concerns/draft_properties.rb
+++ b/app/models/concerns/draft_properties.rb
@@ -46,7 +46,7 @@ module DraftProperties
     end
 
     # compatibility with the thumbnail API used in Items/Theses and Communities
-    def thumbnail_url(args = { resize: '100x100' })
+    def thumbnail_url(args = { resize: '100x100', auto_orient: true })
       return nil unless thumbnail.present? && thumbnail.blob.present?
 
       Rails.application.routes.url_helpers.rails_representation_path(thumbnail.variant(args).processed)

--- a/app/models/concerns/item_properties.rb
+++ b/app/models/concerns/item_properties.rb
@@ -59,7 +59,7 @@ module ItemProperties
       files_attachment_shim.save!
     end
 
-    def thumbnail_url(args = { resize: '100x100' })
+    def thumbnail_url(args = { resize: '100x100', auto_orient: true })
       logo = files_attachment_shim.logo_file
       return nil if logo.blank?
 

--- a/app/views/admin/theses/draft/_thumbnail.html.erb
+++ b/app/views/admin/theses/draft/_thumbnail.html.erb
@@ -3,11 +3,11 @@
 every file attached to an item via a JS callback rendering files/update_files_list.js.erb calling _files_list.html.erb
 whereas DraftItem#thumbnail specifically only deals with rendering the designated file for representing it as a
 thumbnail and is used on various other pages, like profiles, which use the application/_thumbnail partial.%>
-  <% thumbnail = rails_representation_path(file.variant(resize: '100x100').processed) %>
+  <% thumbnail = rails_representation_path(file.variant(resize: '100x100', auto_orient: true).processed) %>
   <%= image_tag(thumbnail, class: 'j-thumbnail img-thumbnail', alt: '', title: file.filename, size: '100x100') %>
 <% rescue  ActiveStorage::InvariableError %>
   <% begin %>
-      <% thumbnail = rails_representation_path(file.preview(resize: '100x100').processed) %>
+      <% thumbnail = rails_representation_path(file.preview(resize: '100x100', auto_orient: true).processed) %>
       <%= image_tag(thumbnail, class: 'j-thumbnail img-thumbnail', alt: '', title: file.filename, size: '100x100') %>
   <% rescue ActiveStorage::UnpreviewableError %>
     <div class="text-muted text-center img-thumbnail p-3">

--- a/app/views/application/_feature_image.html.erb
+++ b/app/views/application/_feature_image.html.erb
@@ -1,6 +1,6 @@
 <% if policy(object).thumbnail? %>
   <% if object.thumbnail_url.present? %>
-    <%= image_tag(object.thumbnail_url(resize:'350x350'), class: 'j-feature-image img-thumbnail', alt: '', size: '350x350') %>
+    <%= image_tag(object.thumbnail_url(resize:'350x350', auto_orient: true), class: 'j-feature-image img-thumbnail', alt: '', size: '350x350') %>
   <% else %>
     <div class="d-flex justify-content-center align-items-center img-thumbnail p-5">
       <%= fa_icon file_icon(object.thumbnail_file&.content_type), class: 'fa-5x text-muted' %>

--- a/app/views/items/draft/_thumbnail.html.erb
+++ b/app/views/items/draft/_thumbnail.html.erb
@@ -3,11 +3,11 @@
 every file attached to an item via a JS callback rendering files/update_files_list.js.erb calling _files_list.html.erb
 whereas DraftItem#thumbnail specifically only deals with rendering the designated file for representing it as a
 thumbnail and is used on various other pages, like profiles, which use the application/_thumbnail partial.%>
-  <% thumbnail = rails_representation_path(file.variant(resize: '100x100').processed) %>
+  <% thumbnail = rails_representation_path(file.variant(resize: '100x100', auto_orient: true).processed) %>
   <%= image_tag(thumbnail, class: 'j-thumbnail img-thumbnail', alt: '', title: file.filename, size: '100x100') %>
 <% rescue  ActiveStorage::InvariableError %>
   <% begin %>
-      <% thumbnail = rails_representation_path(file.preview(resize: '100x100').processed) %>
+      <% thumbnail = rails_representation_path(file.preview(resize: '100x100', auto_orient: true).processed) %>
       <%= image_tag(thumbnail, class: 'j-thumbnail img-thumbnail', alt: '', title: file.filename, size: '100x100') %>
   <% rescue ActiveStorage::UnpreviewableError %>
     <div class="text-muted text-center img-thumbnail p-3">


### PR DESCRIPTION
#783 

Solved by passing in `auto_orient` flag (https://www.imagemagick.org/script/command-line-options.php#auto-orient)  into the thumbnail generation

### Fix on deposit:
![image](https://user-images.githubusercontent.com/1930474/51209814-6480c100-18ce-11e9-9b7c-f1c8dda0c680.png)

### Fix on item detail:
![image](https://user-images.githubusercontent.com/1930474/51209831-6f3b5600-18ce-11e9-949f-df2576b0da51.png)

### Fix on search list:
![image](https://user-images.githubusercontent.com/1930474/51209845-7498a080-18ce-11e9-9676-ae58a46ee811.png)



Some refactors could be had...I'll create an issue for this. We repeating a ton of the same code everywhere for handling the thumbnail generation (trying variant, then falling back to preview, otherwise showing nothing)

Issue for refactor created here: https://github.com/ualbertalib/jupiter/issues/983