### PR TITLE
Add version file, put version file in meta tag, add tool for release management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and releases in Jupiter project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add proper version file, meta generator tag and tool for managing releases [#55](https://github.com/ualbertalib/jupiter/issues/55)
+
 ### Fixed
 - workarounds for Datacite EZ API for tests [PR#945](https://github.com/ualbertalib/jupiter/pull/945)
 

--- a/Gemfile
+++ b/Gemfile
@@ -94,6 +94,8 @@ group :development, :test do
 end
 
 group :development do
+  gem 'bump', require: false
+
   gem 'better_errors', '>= 2.3.0'
   gem 'binding_of_caller'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -106,6 +106,7 @@ GEM
       sassc-rails (>= 2.0.0)
     brakeman (4.3.1)
     builder (3.2.3)
+    bump (0.7.0)
     byebug (10.0.2)
     canonical-rails (0.2.4)
       rails (>= 4.1, < 5.3)
@@ -476,6 +477,7 @@ DEPENDENCIES
   bootsnap (>= 1.1.0)
   bootstrap (~> 4.2.1)
   brakeman
+  bump
   canonical-rails
   capybara (>= 2.15, < 4.0)
   chromedriver-helper
@@ -535,4 +537,4 @@ DEPENDENCIES
   wicked
 
 BUNDLED WITH
-   1.17.2
+   1.17.3

--- a/app/models/jupiter_core.rb
+++ b/app/models/jupiter_core.rb
@@ -12,7 +12,4 @@ module JupiterCore
   VISIBILITY_AUTHENTICATED = CONTROLLED_VOCABULARIES[:visibility].authenticated.freeze
 
   VISIBILITIES = [VISIBILITY_PUBLIC, VISIBILITY_PRIVATE, VISIBILITY_AUTHENTICATED].freeze
-
-  # This'll do for the time being I suppose ¯\_(ツ)_/¯
-  VERSION = '1.2.7'.freeze
 end

--- a/app/views/admin/dashboard/index.html.erb
+++ b/app/views/admin/dashboard/index.html.erb
@@ -79,7 +79,7 @@
     <p>
       <%= t('.jupiter') %>
       <span class="badge badge-primary">
-        <%= JupiterCore::VERSION %>
+        <%= Jupiter::VERSION %>
       </span>
     </p>
   </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -15,6 +15,7 @@
 
     <title><%= page_title(t('site_name')) %></title>
     <meta name="description" content="<%= page_description %>">
+    <meta name="generator" content="<%= "Jupiter #{Jupiter::VERSION} - https://github.com/ualbertalib/jupiter" %>">
 
     <%# Open Graph - http://ogp.me/ %>
     <meta property="og:type"         content="<%= page_type %>">

--- a/config/application.rb
+++ b/config/application.rb
@@ -12,6 +12,8 @@ require 'action_view/railtie'
 require 'sprockets/railtie'
 require 'rails/test_unit/railtie'
 
+require_relative '../lib/jupiter/version'
+
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, :staging, or :production.
 Bundler.require(*Rails.groups)

--- a/lib/jupiter/version.rb
+++ b/lib/jupiter/version.rb
@@ -1,0 +1,3 @@
+module Jupiter
+  VERSION = '1.2.7'.freeze
+end


### PR DESCRIPTION
https://github.com/ualbertalib/jupiter/issues/55

- [x] Move version to a separate file and update code
- [x] Add version to meta generator tag
- [x] Figure better process for bumping versions and cutting tags
  - Using a gem called `bump` (https://github.com/gregorym/bump): 

```
bump --help
Bump your gem version.

Usage:
    bump current    # show current version
    bump file       # show version file path
    bump pre        # increase prerelease version of your gem (1.0.0-X) [alpha, beta, rc, ]
    bump patch      # increase patch version of your gem (1.0.X)
    bump minor      # increase minor version of your gem (1.X.0)
    bump major      # increase major version of your gem (X.0.0)
    bump set 1.2.3  # set the version number to the given value

Options:
        --no-commit                  Do not make a commit.
    -m, --commit-message MSG         Append MSG to the commit message.
        --no-bundle                  Do not bundle.
        --tag                        Create git tag from version (only if commit is true).
        --replace-in FILE            Replace old version with the new version additionally in this file
    -h, --help                       Show this.
```

So think all we need to do is....for example if doing a minor patch update....run `bump patch --tag` and it will bump the version, commit it, and tag a release all at once.

Can test this and maybe add proper documentation to README when we cut the next release for jupiter