### PR TITLE
add current and future ruby to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,13 @@ addons:
   chrome: stable
 
 rvm:
-  - 2.4.1
+  - 2.4
+  - 2.5
 
 cache: bundler
 bundler_args: --without development production --jobs=3 --retry=3
+before_install:
+  - gem install bundler:1.17.3
 
 before_script:
   - bundle exec danger

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and releases in Jupiter project adheres to [Semantic Versioning](http://semver.o
 ### Security
 - bump nokogiri from 1.10.2 to 1.10.3 [PR#1098](https://github.com/ualbertalib/jupiter/pull/1098)
 
+### Added
+- Ruby 2.5 to travis ci testing matrix [PR#1040](https://github.com/ualbertalib/jupiter/pull/1040)
+
 ### Changed
 - i18n fallback to english (configuration change) [PR#1058](https://github.com/ualbertalib/jupiter/pull/1058)
 - pin rubocop version for hound [PR#1080](https://github.com/ualbertalib/jupiter/pull/1080)


### PR DESCRIPTION
This application currently runs in production with Ruby 2.4.  Some of our other application run with 2.5 and 2.6 is the newest.  We can use travis to smoke test whether or not the changes we make are future compatible.

The con of this is that we're more likely to be caught in the flapping tests.