### PR TITLE
chromedriver-helper is deprecated after 2019-03-31.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -114,7 +114,7 @@ group :test do
   gem 'launchy'
   gem 'vcr', require: false
   # Easy installation and use of chromedriver to run system tests with Chrome
-  gem 'chromedriver-helper'
+  gem 'webdrivers'
   gem 'webmock', require: false
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -85,8 +85,6 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.6.0)
       public_suffix (>= 2.0.2, < 4.0)
-    archive-zip (0.11.0)
-      io-like (~> 0.3.0)
     arel (9.0.0)
     ast (2.4.0)
     autoprefixer-rails (9.4.7)
@@ -120,9 +118,6 @@ GEM
       xpath (~> 3.2)
     childprocess (0.9.0)
       ffi (~> 1.0, >= 1.0.11)
-    chromedriver-helper (2.1.0)
-      archive-zip (~> 0.10)
-      nokogiri (~> 1.8)
     clamby (1.6.2)
     coderay (1.1.2)
     concurrent-ruby (1.1.5)
@@ -190,7 +185,6 @@ GEM
     image_processing (1.8.0)
       mini_magick (>= 4.9.3, < 5)
       ruby-vips (>= 2.0.13, < 3)
-    io-like (0.3.0)
     jaro_winkler (1.5.2)
     jbuilder (2.8.0)
       activesupport (>= 4.2.0)
@@ -254,6 +248,7 @@ GEM
     multi_json (1.13.1)
     multipart-post (2.0.0)
     mustermann (1.0.3)
+    net_http_ssl_fix (0.0.10)
     nio4r (2.3.1)
     nokogiri (1.10.1)
       mini_portile2 (~> 2.4.0)
@@ -446,6 +441,11 @@ GEM
       activemodel (>= 5.0)
       bindex (>= 0.4.0)
       railties (>= 5.0)
+    webdrivers (3.7.1)
+      net_http_ssl_fix
+      nokogiri (~> 1.6)
+      rubyzip (~> 1.0)
+      selenium-webdriver (~> 3.0)
     webmock (3.5.1)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
@@ -474,7 +474,6 @@ DEPENDENCIES
   bump
   canonical-rails
   capybara (>= 2.15, < 4.0)
-  chromedriver-helper
   clamby
   connection_pool
   dropzonejs-rails
@@ -527,6 +526,7 @@ DEPENDENCIES
   vcr
   voight_kampff
   web-console (>= 3.3.0)
+  webdrivers
   webmock
   wicked
 


### PR DESCRIPTION
Please update to use the 'webdrivers' gem instead.
See https://github.com/flavorjones/chromedriver-helper/issues/83

resolves #1052 