### PR TITLE
use the file_download_item helper on download links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,10 @@ and releases in Jupiter project adheres to [Semantic Versioning](http://semver.o
 ## [Unreleased]
 
 ### Added
+- regression tests for downloading restricted items from search results [PR#1070](https://github.com/ualbertalib/jupiter/pull/1070)
 
-- regression tests for downloading restricted items from search results [PR#1070](https://github.com/ualbertalib/jupiter/pull/1069)
+### Fixed
+- use the download url helper on the search results page [PR#1079](https://github.com/ualbertalib/jupiter/pull/1079)
 
 ## [1.2.11] - 2019-04-05
 

--- a/app/views/application/_item.html.erb
+++ b/app/views/application/_item.html.erb
@@ -6,18 +6,19 @@
   <div class="media-body ml-3">
     <div class="d-flex flex-wrap flex-lg-nowrap align-items-start">
       <h3 class="mt-0 h5 mr-auto"><%= link_to item.title, item_path(item) %></h3>
-
-      <% primary_file = item.files.first %>
-      <% if policy(item).download? && primary_file.present?%>
-        <%= link_to url_for(primary_file),
-                    class: 'btn btn-secondary mr-2 mb-2 mb-md-0',
-                    rel: 'nofollow',
-                    download: primary_file.filename.to_s do %>
-          <%= fa_icon 'cloud-download' %>
-          <%= t('download') %>
+      <% if policy(item).download? %>
+        <% primary_file = item.files.first %>
+        <% if primary_file.present? && primary_file.fileset_uuid.present? %>
+          <%= link_to file_download_item_url(id: primary_file.record.owner.id,
+                                 file_set_id: primary_file.fileset_uuid),
+                      class: 'btn btn-secondary mr-2 mb-2 mb-md-0',
+                      rel: 'nofollow',
+                      download: primary_file.filename.to_s do %>
+            <%= fa_icon 'cloud-download' %>
+            <%= t('download') %>
+          <% end %>
         <% end %>
       <% end %>
-
       <% if policy(item).update? || policy(item).destroy? %>
         <div class="btn-group">
           <% if policy(item).update? %>

--- a/app/views/application/_thesis.html.erb
+++ b/app/views/application/_thesis.html.erb
@@ -6,14 +6,17 @@
     <div class="d-flex flex-wrap flex-lg-nowrap align-items-start">
       <h3 class="mt-0 h5 mr-auto"><%= link_to thesis.title, item_path(thesis) %></h3>
 
-      <% primary_file = thesis.files.first %>
-      <% if primary_file.present? %>
-        <%= link_to url_for(primary_file),
-                    class: 'btn btn-secondary mr-2 mb-2 mb-md-0',
-                    rel: 'nofollow',
-                    download: primary_file.filename.to_s do %>
-          <%= fa_icon 'cloud-download' %>
-          <%= t('download') %>
+      <% if policy(thesis).download? %>
+        <% primary_file = thesis.files.first %>
+        <% if primary_file.present? && primary_file.fileset_uuid.present? %>
+          <%= link_to file_download_item_url(id: primary_file.record.owner.id,
+                                 file_set_id: primary_file.fileset_uuid),
+                      class: 'btn btn-secondary mr-2 mb-2 mb-md-0',
+                      rel: 'nofollow',
+                      download: primary_file.filename.to_s do %>
+            <%= fa_icon 'cloud-download' %>
+            <%= t('download') %>
+          <% end %>
         <% end %>
       <% end %>
 

--- a/test/system/search_test.rb
+++ b/test/system/search_test.rb
@@ -361,6 +361,8 @@ class SearchTest < ApplicationSystemTestCase
     # Should see the download link for CCID item
     within '.list-group-item', text: 'Fancy CCID Item' do
       assert_selector 'a', text: 'Download'
+      assert_link href: /download/
+      assert_no_link href: /active_storage/
     end
 
     # A checkbox for the facet should be unchecked, and link should turn on facet


### PR DESCRIPTION
previously this would show the active storage blob url and not check for 
authorization or update the download count.