### PR TITLE
Direct solr connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and releases in Jupiter project adheres to [Semantic Versioning](http://semver.o
 ### Changed
 - i18n fallback to english (configuration change) [PR#1058](https://github.com/ualbertalib/jupiter/pull/1058)
 - pin rubocop version for hound [PR#1080](https://github.com/ualbertalib/jupiter/pull/1080)
+- Replaced use of ActiveFedora's Solr connection with a direct connection to Solr setup locally.
 
 ### Fixed
 - fixed error in dangerfile [#1109](https://github.com/ualbertalib/jupiter/issues/1109)

--- a/app/models/jupiter_core/search.rb
+++ b/app/models/jupiter_core/search.rb
@@ -81,7 +81,7 @@ class JupiterCore::Search
     response = ActiveSupport::Notifications.instrument(JUPITER_SOLR_NOTIFICATION,
                                                        name: 'solr select',
                                                        query: params) do
-      ActiveFedora::SolrService.instance.conn.get('select', params: params)
+      JupiterCore::SolrClient.instance.connection.get('select', params: params)
     end
 
     raise SearchFailed unless response['responseHeader']['status'] == 0

--- a/app/models/jupiter_core/solr_client.rb
+++ b/app/models/jupiter_core/solr_client.rb
@@ -1,9 +1,12 @@
 class JupiterCore::SolrClient
+
   include Singleton
 
-  SOLR_CONFIG = YAML.safe_load(ERB.new(File.read("#{Rails.root}/config/solr.yml")).result, [], [], true)[Rails.env].symbolize_keys
+  SOLR_CONFIG = YAML.safe_load(ERB.new(File.read(Rails.root.join('config', 'solr.yml'))).result,
+                               [], [], true)[Rails.env].symbolize_keys
 
   def connection
-    @solr_connection ||= RSolr.connect :url => SOLR_CONFIG[:url]
+    @connection ||= RSolr.connect url: SOLR_CONFIG[:url]
   end
+
 end

--- a/app/models/jupiter_core/solr_client.rb
+++ b/app/models/jupiter_core/solr_client.rb
@@ -1,0 +1,9 @@
+class JupiterCore::SolrClient
+  include Singleton
+
+  SOLR_CONFIG = YAML.safe_load(ERB.new(File.read("#{Rails.root}/config/solr.yml")).result, [], [], true)[Rails.env].symbolize_keys
+
+  def connection
+    @solr_connection ||= RSolr.connect :url => SOLR_CONFIG[:url]
+  end
+end

--- a/config/solr.yml
+++ b/config/solr.yml
@@ -1,4 +1,4 @@
-# Needed and used by active fedora, to specify where to find solr
+# Needed and used by active fedora and JupiterCore::SolrClient, to specify where to find solr
 default: &default
   url: <%= Rails.application.secrets.solr_url %>
 development:

--- a/lib/tasks/recover.rake
+++ b/lib/tasks/recover.rake
@@ -60,6 +60,6 @@ namespace :jupiter do
 
     solr_data = {}
     object.unlock_and_fetch_ldp_object { |uo| solr_data = uo.to_solr }
-    ActiveFedora::SolrService.add(solr_data, 'softCommit' => true)
+    JupiterCore::SolrClient.instance.connection.add(solr_data, 'softCommit' => true)
   end
 end


### PR DESCRIPTION
Changes the way Jupiter connects to Solr -- instead of letting ActiveFedora establish a connection to Solr and then piggybacking on that, this creates a dedicated Solr connection directly based on the configuration in `solr.yml`