### PR TITLE
Solr name mangling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and releases in Jupiter project adheres to [Semantic Versioning](http://semver.o
 - i18n fallback to english (configuration change) [PR#1058](https://github.com/ualbertalib/jupiter/pull/1058)
 - pin rubocop version for hound [PR#1080](https://github.com/ualbertalib/jupiter/pull/1080)
 - Replaced use of ActiveFedora's Solr connection with a direct connection to Solr setup locally.
+- Replaced all calls to `Solrizer.solr_name` with simplified local code to map Solr types/roles to wildcard stems.
 
 ### Fixed
 - fixed error in dangerfile [#1109](https://github.com/ualbertalib/jupiter/issues/1109)

--- a/app/models/jupiter_core.rb
+++ b/app/models/jupiter_core.rb
@@ -6,6 +6,7 @@ module JupiterCore
   class MultipleIdViolationError < StandardError; end
   class AlreadyDefinedError < StandardError; end
   class LockedInstanceError < StandardError; end
+  class SolrNameManglingError < StandardError; end
 
   VISIBILITY_PUBLIC = CONTROLLED_VOCABULARIES[:visibility].public.freeze
   VISIBILITY_PRIVATE = CONTROLLED_VOCABULARIES[:visibility].private.freeze

--- a/app/models/jupiter_core/locked_ldp_object.rb
+++ b/app/models/jupiter_core/locked_ldp_object.rb
@@ -799,8 +799,8 @@ class JupiterCore::LockedLdpObject
       # add a reader to the locked object
       define_cached_reader(as_name, multiple: multiple, type: :string,
                                     canonical_solr_name: JupiterCore::SolrNameMangler.mangled_name_for(as_name,
-                                                                            role: :search,
-                                                                            type: :string),
+                                                                                                       role: :search,
+                                                                                                       type: :string),
                                     specialized_ldp_reader: lambda {
                                                               self.send(association)&.map do |member|
                                                                 member.id
@@ -880,7 +880,9 @@ class JupiterCore::LockedLdpObject
       facet_name = if solrize_for.include?(:facet)
                      JupiterCore::SolrNameMangler.mangled_name_for(name, role: :facet, type: solr_type)
                    elsif solrize_for.include?(:range_facet)
-                     range_name = JupiterCore::SolrNameMangler.mangled_name_for(name, role: :range_facet, type: solr_type)
+                     range_name = JupiterCore::SolrNameMangler.mangled_name_for(name,
+                                                                                role: :range_facet,
+                                                                                type: solr_type)
                      self.ranges << range_name
                      range_name
                    elsif solrize_for.include?(:pathing)

--- a/app/models/jupiter_core/solr_client.rb
+++ b/app/models/jupiter_core/solr_client.rb
@@ -1,9 +1,15 @@
 class JupiterCore::SolrClient
-
   include Singleton
+
+  SOLR_ROLES = [:search, :sort, :facet, :exact_match, :pathing, :range_facet].freeze
+  SOLR_TYPES =  [:string, :text, :path, :boolean, :date, :integer, :float, :json_array].freeze
 
   SOLR_CONFIG = YAML.safe_load(ERB.new(File.read(Rails.root.join('config', 'solr.yml'))).result,
                                [], [], true)[Rails.env].symbolize_keys
+
+  def self.valid_solr_type?(type)
+    SOLR_TYPES.include?(type)
+  end
 
   def connection
     @connection ||= RSolr.connect url: SOLR_CONFIG[:url]

--- a/app/models/jupiter_core/solr_client.rb
+++ b/app/models/jupiter_core/solr_client.rb
@@ -1,4 +1,5 @@
 class JupiterCore::SolrClient
+
   include Singleton
 
   SOLR_ROLES = [:search, :sort, :facet, :exact_match, :pathing, :range_facet].freeze

--- a/app/models/jupiter_core/solr_name_mangler.rb
+++ b/app/models/jupiter_core/solr_name_mangler.rb
@@ -1,35 +1,36 @@
 module JupiterCore::SolrNameMangler
-
   SOLR_MANGLED_STEMS_BY_TYPE = {
-    :path => {:pathing => 'dpsim'},
-    :boolean => {:exact_match => 'ssim'},
-    :date => {
-      :sort => 'dtsi',
-      :exact_match => 'ssim'
+    path: { pathing: 'dpsim' },
+    boolean: { exact_match: 'ssim' },
+    date: {
+      sort: 'dtsi',
+      exact_match: 'ssim'
     },
-    :integer => {
-      :search => 'isim',
-      :sort => 'isi',
-      :range_facet => 'isi',
-      :exact_match => 'ssim'
+    integer: {
+      search: 'isim',
+      sort: 'isi',
+      range_facet: 'isi',
+      exact_match: 'ssim'
     },
-    :string => {
-      :pathing => 'dpsim',
-      :facet => 'sim',
-      :search => 'tesim',
-      :sort => 'ssi',
-      :exact_match => 'ssim'
+    string: {
+      pathing: 'dpsim',
+      facet: 'sim',
+      search: 'tesim',
+      sort: 'ssi',
+      exact_match: 'ssim'
     },
-    :text => {
-        :search => 'tesim'
+    text: {
+      search: 'tesim'
     }
-  }
+  }.freeze
 
   def self.mangled_name_for(name, type:, role:)
     stem = SOLR_MANGLED_STEMS_BY_TYPE.dig(type, role)
-    raise JupiterCore::SolrNameManglingError, "Unmapped type/role combination for requested mangle of #{name}: type: #{type}, role: #{role}" unless stem.present?
+    if stem.blank?
+      raise JupiterCore::SolrNameManglingError,
+            "Unmapped type/role combination for requested mangle of #{name}: type: #{type}, role: #{role}"
+    end
 
     "#{name}_#{stem}"
   end
-
 end

--- a/app/models/jupiter_core/solr_name_mangler.rb
+++ b/app/models/jupiter_core/solr_name_mangler.rb
@@ -1,0 +1,35 @@
+module JupiterCore::SolrNameMangler
+
+  SOLR_MANGLED_STEMS_BY_TYPE = {
+    :path => {:pathing => 'dpsim'},
+    :boolean => {:exact_match => 'ssim'},
+    :date => {
+      :sort => 'dtsi',
+      :exact_match => 'ssim'
+    },
+    :integer => {
+      :search => 'isim',
+      :sort => 'isi',
+      :range_facet => 'isi',
+      :exact_match => 'ssim'
+    },
+    :string => {
+      :pathing => 'dpsim',
+      :facet => 'sim',
+      :search => 'tesim',
+      :sort => 'ssi',
+      :exact_match => 'ssim'
+    },
+    :text => {
+        :search => 'tesim'
+    }
+  }
+
+  def self.mangled_name_for(name, type:, role:)
+    stem = SOLR_MANGLED_STEMS_BY_TYPE.dig(type, role)
+    raise JupiterCore::SolrNameManglingError, "Unmapped type/role combination for requested mangle of #{name}: type: #{type}, role: #{role}" unless stem.present?
+
+    "#{name}_#{stem}"
+  end
+
+end


### PR DESCRIPTION
Replaces all calls into `Solrizer.solr_name` with Jupiter-internal code to handle mapping Solr type/role to stem mappings.