### PR TITLE
Leverage annotations to annotate draft classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and releases in Jupiter project adheres to [Semantic Versioning](http://semver.o
 ### Added
 - Ruby 2.5 to travis ci testing matrix [PR#1040](https://github.com/ualbertalib/jupiter/pull/1040)
 - Added missing contoller tests [#865](https://github.com/ualbertalib/jupiter/issues/865)
+- Dependency on ActsAsRdfable for annotating ActiveRecord classes with RDF predicates
+- DraftCollection and DraftCommunity models for further migration work
 
 ### Changed
 - i18n fallback to english (configuration change) [PR#1058](https://github.com/ualbertalib/jupiter/pull/1058)
@@ -19,7 +21,7 @@ and releases in Jupiter project adheres to [Semantic Versioning](http://semver.o
 - Replaced use of ActiveFedora's Solr connection with a direct connection to Solr setup locally.
 - Replaced all calls to `Solrizer.solr_name` with simplified local code to map Solr types/roles to wildcard stems.
 - Removed Solrizer usage from the process of indexing ActiveFedora objects for Solr entirely. Replaced with Solr Exporter pattern for serialization of Solr data.
-
+- DraftItem and DraftThesis have basic RDF annotations
 
 
 ### Fixed

--- a/Gemfile
+++ b/Gemfile
@@ -37,6 +37,9 @@ gem 'hydra-works', '0.17.0'
 gem 'rdf-vocab'
 gem 'solrizer', github: 'ualbertalib/solrizer', branch: 'literally_types'
 
+# RDF stuff
+gem 'acts_as_rdfable', github: 'mbarnett/acts_as_rdfable', tag: 'v0.01'
+
 # Database stuff
 gem 'connection_pool'
 gem 'pg', '~> 1.1.4'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,12 @@
 GIT
+  remote: https://github.com/mbarnett/acts_as_rdfable.git
+  revision: d1d3b79cab1f074976407e42f9e28d24de5131c8
+  tag: v0.01
+  specs:
+    acts_as_rdfable (0.1.0)
+      rails (~> 5.2.3)
+
+GIT
   remote: https://github.com/ualbertalib/active_fedora.git
   revision: 8e94346e6ed98df46c994726749542075e11ecd0
   branch: backport_rails52_fixes
@@ -504,6 +512,7 @@ DEPENDENCIES
   aasm
   active-fedora!
   active_link_to
+  acts_as_rdfable!
   addressable (~> 2.6.0)
   better_errors (>= 2.3.0)
   binding_of_caller
@@ -573,4 +582,4 @@ DEPENDENCIES
   wicked
 
 BUNDLED WITH
-   1.17.3
+   2.0.2

--- a/app/models/draft_collection.rb
+++ b/app/models/draft_collection.rb
@@ -7,7 +7,7 @@ class DraftCollection < ApplicationRecord
     config.creators has_predicate: ::RDF::Vocab::DC.creator
   end
 
-  def update_from_fedora_collection(collection, for_user)
+  def update_from_fedora_collection(collection, _for_user)
     draft_attributes = {
       collection_id: collection.id,
       visibility: collection.visibility,

--- a/app/models/draft_collection.rb
+++ b/app/models/draft_collection.rb
@@ -1,0 +1,38 @@
+class DraftCollection < ApplicationRecord
+
+  acts_as_rdfable do |config|
+    config.community_id has_predicate: ::TERMS[:ual].path
+    config.description has_predicate: ::RDF::Vocab::DC.description
+    config.restricted has_predicate: ::TERMS[:ual].restricted_collection
+    config.creators has_predicate: ::RDF::Vocab::DC.creator
+  end
+
+  def update_from_fedora_collection(collection, for_user)
+    draft_attributes = {
+      collection_id: collection.id,
+      visibility: collection.visibility,
+      owner_id: collection.owner,
+      record_created_at: collection.record_created_at,
+      hydra_noid: collection.hydra_noid,
+      date_ingested: collection.date_ingested,
+      title: collection.title,
+      fedora3_uuid: collection.fedora3_uuid,
+      depositor_id: collection.depositor,
+      community_id: collection.community_id,
+      description: collection.description,
+      creators: collection.creators,
+      restricted: (collection.restricted || false)
+    }
+    assign_attributes(draft_attributes)
+    save(validate: false)
+  end
+
+  def self.from_collection(collection, for_user:)
+    draft = DraftCollection.find_by(collection_id: collection.id)
+    draft ||= DraftCollection.new(collection_id: collection.id)
+
+    draft.update_from_fedora_collection(collection, for_user)
+    draft
+  end
+
+end

--- a/app/models/draft_community.rb
+++ b/app/models/draft_community.rb
@@ -1,0 +1,33 @@
+class DraftCommunity < ApplicationRecord
+
+  acts_as_rdfable do |config|
+    config.description has_predicate: ::RDF::Vocab::DC.description
+    config.creators has_predicate: ::RDF::Vocab::DC.creator
+  end
+
+  def update_from_fedora_community(community, for_user)
+    draft_attributes = {
+      community_id: community.id,
+      visibility: community.visibility,
+      owner_id: community.owner,
+      record_created_at: community.record_created_at,
+      hydra_noid: community.hydra_noid,
+      date_ingested: community.date_ingested,
+      title: community.title,
+      fedora3_uuid: community.fedora3_uuid,
+      depositor_id: community.depositor,
+      description: community.description,
+      creators: community.creators,
+    }
+    assign_attributes(draft_attributes)
+    save(validate: false)
+  end
+
+  def self.from_community(community, for_user:)
+    draft = DraftCommunity.find_by(community_id: community.id)
+    draft ||= DraftCommunity.new(community_id: community.id)
+
+    draft.update_from_fedora_community(community, for_user)
+    draft
+  end
+end

--- a/app/models/draft_community.rb
+++ b/app/models/draft_community.rb
@@ -5,7 +5,7 @@ class DraftCommunity < ApplicationRecord
     config.creators has_predicate: ::RDF::Vocab::DC.creator
   end
 
-  def update_from_fedora_community(community, for_user)
+  def update_from_fedora_community(community, _for_user)
     draft_attributes = {
       community_id: community.id,
       visibility: community.visibility,
@@ -17,7 +17,7 @@ class DraftCommunity < ApplicationRecord
       fedora3_uuid: community.fedora3_uuid,
       depositor_id: community.depositor,
       description: community.description,
-      creators: community.creators,
+      creators: community.creators
     }
     assign_attributes(draft_attributes)
     save(validate: false)
@@ -30,4 +30,5 @@ class DraftCommunity < ApplicationRecord
     draft.update_from_fedora_community(community, for_user)
     draft
   end
+
 end

--- a/app/models/draft_item.rb
+++ b/app/models/draft_item.rb
@@ -86,6 +86,25 @@ class DraftItem < ApplicationRecord
   validates :license_text_area, presence: true, if: :validate_if_license_is_text?
   validate :license_not_unselected, if: :validate_choose_license_and_visibility?
 
+  acts_as_rdfable do |config|
+    config.title has_predicate: ::RDF::Vocab::DC.title
+    config.creators has_predicate: RDF::Vocab::BIBO.authorList
+    config.contributors has_predicate: ::RDF::Vocab::DC11.contributor
+    config.date_created has_predicate: ::RDF::Vocab::DC.created
+    config.time_periods has_predicate: ::RDF::Vocab::DC.temporal
+    config.places has_predicate: ::RDF::Vocab::DC.spatial
+    config.description has_predicate: ::RDF::Vocab::DC.description
+    # TODO add
+    # config.publisher has_predicate: ::RDF::Vocab::DC.publisher
+    # TODO join table
+    #config.languages has_predicate: ::RDF::Vocab::DC.language
+    config.license has_predicate: ::RDF::Vocab::DC.license
+    config.type_id has_predicate: ::RDF::Vocab::DC.type
+    config.source has_predicate: ::RDF::Vocab::DC.source
+    config.related_item has_predicate: ::RDF::Vocab::DC.relation
+    config.status has_predicate: ::RDF::Vocab::BIBO.status
+  end
+
   # rubocop:disable Rails/TimeZone
   def update_from_fedora_item(item, for_user)
     # I suspect this will become some kind of string field, but for now, using UTC
@@ -161,6 +180,10 @@ class DraftItem < ApplicationRecord
 
     draft.update_from_fedora_item(item, for_user)
     draft
+  end
+
+  def self.foo
+    binding.pry
   end
 
   # Control Vocab Conversions

--- a/app/models/draft_item.rb
+++ b/app/models/draft_item.rb
@@ -94,10 +94,10 @@ class DraftItem < ApplicationRecord
     config.time_periods has_predicate: ::RDF::Vocab::DC.temporal
     config.places has_predicate: ::RDF::Vocab::DC.spatial
     config.description has_predicate: ::RDF::Vocab::DC.description
-    # TODO add
+    # TODO: add
     # config.publisher has_predicate: ::RDF::Vocab::DC.publisher
     # TODO join table
-    #config.languages has_predicate: ::RDF::Vocab::DC.language
+    # config.languages has_predicate: ::RDF::Vocab::DC.language
     config.license has_predicate: ::RDF::Vocab::DC.license
     config.type_id has_predicate: ::RDF::Vocab::DC.type
     config.source has_predicate: ::RDF::Vocab::DC.source
@@ -180,10 +180,6 @@ class DraftItem < ApplicationRecord
 
     draft.update_from_fedora_item(item, for_user)
     draft
-  end
-
-  def self.foo
-    binding.pry
   end
 
   # Control Vocab Conversions

--- a/app/models/draft_thesis.rb
+++ b/app/models/draft_thesis.rb
@@ -38,27 +38,27 @@ class DraftThesis < ApplicationRecord
   validates :rights, :visibility, presence: true, if: :validate_choose_license_and_visibility?
 
   acts_as_rdfable do |config|
-      config.description has_predicate: ::RDF::Vocab::DC.abstract
-      config.language_id has_predicate: ::RDF::Vocab::DC.language
-      config.date_accepted has_predicate: ::RDF::Vocab::DC.dateAccepted
-      config.date_submitted has_predicate: ::RDF::Vocab::DC.dateSubmitted
-      config.degree has_predicate: ::RDF::Vocab::BIBO.degree
-      config.institution_id has_predicate: ::TERMS[:swrc].institution
-      config.creator has_predicate: ::TERMS[:ual].dissertant
-      # TODO add graduation date column
-      #config.graduation_date has_predicate: ::TERMS[:ual].graduation_date
-      # TODO add
-      #config.thesis_level has_predicate: ::TERMS[:ual].thesis_level
-      #TODO add
-      # config.proquest has_predicate: ::TERMS[:ual].proquest
-      # TODO add
-      # config.unicorn has_predicate: ::TERMS[:ual].unicorn
-      config.specialization has_predicate: ::TERMS[:ual].specialization
-      config.departments has_predicate: ::TERMS[:ual].department_list
-      config.supervisors has_predicate: ::TERMS[:ual].supervisor_list
-      config.committee_members has_predicate: ::TERMS[:ual].committee_member
-      config.departments has_predicate: ::TERMS[:ual].department
-      config.supervisors has_predicate: ::TERMS[:ual].supervisor
+    config.description has_predicate: ::RDF::Vocab::DC.abstract
+    config.language_id has_predicate: ::RDF::Vocab::DC.language
+    config.date_accepted has_predicate: ::RDF::Vocab::DC.dateAccepted
+    config.date_submitted has_predicate: ::RDF::Vocab::DC.dateSubmitted
+    config.degree has_predicate: ::RDF::Vocab::BIBO.degree
+    config.institution_id has_predicate: ::TERMS[:swrc].institution
+    config.creator has_predicate: ::TERMS[:ual].dissertant
+    # TODO: add graduation date column
+    # config.graduation_date has_predicate: ::TERMS[:ual].graduation_date
+    # TODO add
+    # config.thesis_level has_predicate: ::TERMS[:ual].thesis_level
+    # TODO add
+    # config.proquest has_predicate: ::TERMS[:ual].proquest
+    # TODO add
+    # config.unicorn has_predicate: ::TERMS[:ual].unicorn
+    config.specialization has_predicate: ::TERMS[:ual].specialization
+    config.departments has_predicate: ::TERMS[:ual].department_list
+    config.supervisors has_predicate: ::TERMS[:ual].supervisor_list
+    config.committee_members has_predicate: ::TERMS[:ual].committee_member
+    config.departments has_predicate: ::TERMS[:ual].department
+    config.supervisors has_predicate: ::TERMS[:ual].supervisor
   end
 
   def update_from_fedora_thesis(thesis, for_user)

--- a/app/models/draft_thesis.rb
+++ b/app/models/draft_thesis.rb
@@ -37,6 +37,30 @@ class DraftThesis < ApplicationRecord
 
   validates :rights, :visibility, presence: true, if: :validate_choose_license_and_visibility?
 
+  acts_as_rdfable do |config|
+      config.description has_predicate: ::RDF::Vocab::DC.abstract
+      config.language_id has_predicate: ::RDF::Vocab::DC.language
+      config.date_accepted has_predicate: ::RDF::Vocab::DC.dateAccepted
+      config.date_submitted has_predicate: ::RDF::Vocab::DC.dateSubmitted
+      config.degree has_predicate: ::RDF::Vocab::BIBO.degree
+      config.institution_id has_predicate: ::TERMS[:swrc].institution
+      config.creator has_predicate: ::TERMS[:ual].dissertant
+      # TODO add graduation date column
+      #config.graduation_date has_predicate: ::TERMS[:ual].graduation_date
+      # TODO add
+      #config.thesis_level has_predicate: ::TERMS[:ual].thesis_level
+      #TODO add
+      # config.proquest has_predicate: ::TERMS[:ual].proquest
+      # TODO add
+      # config.unicorn has_predicate: ::TERMS[:ual].unicorn
+      config.specialization has_predicate: ::TERMS[:ual].specialization
+      config.departments has_predicate: ::TERMS[:ual].department_list
+      config.supervisors has_predicate: ::TERMS[:ual].supervisor_list
+      config.committee_members has_predicate: ::TERMS[:ual].committee_member
+      config.departments has_predicate: ::TERMS[:ual].department
+      config.supervisors has_predicate: ::TERMS[:ual].supervisor
+  end
+
   def update_from_fedora_thesis(thesis, for_user)
     draft_attributes = {
       user_id: for_user.id,

--- a/db/migrate/20190806193807_add_draft_community.rb
+++ b/db/migrate/20190806193807_add_draft_community.rb
@@ -1,0 +1,18 @@
+class AddDraftCommunity < ActiveRecord::Migration[5.2]
+  def change
+    create_table :draft_communities do |t|
+      t.uuid :community_id
+      t.integer :visibility, default: 0, null: false
+      t.references :owner, null: false, index: true, foreign_key: {to_table: :users, column: :id}
+      t.date :record_created_at
+      t.string :hydra_noid
+      t.date :date_ingested
+      t.string :title
+      t.string :fedora3_uuid
+      t.references :depositor, index: true, foreign_key: {to_table: :users, column: :id}
+      t.text :description
+      t.json :creators, array: true
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20190806193857_add_draft_collection.rb
+++ b/db/migrate/20190806193857_add_draft_collection.rb
@@ -1,0 +1,22 @@
+class AddDraftCollection < ActiveRecord::Migration[5.2]
+  def change
+    create_table :draft_collections do |t|
+      t.uuid :collection_id
+      t.integer :visibility, default: 0, null: false
+      t.references :owner, null: false, index: true, foreign_key: {to_table: :users, column: :id}
+      t.date :record_created_at
+      t.string :hydra_noid
+      t.date :date_ingested
+      t.string :title
+      t.string :fedora3_uuid
+      t.references :depositor, index: true, foreign_key: {to_table: :users, column: :id}
+      t.uuid :community_id
+      t.text :description
+      t.json :creators, array: true
+      t.boolean :restricted, default: false, null: false
+
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_06_20_203953) do
+ActiveRecord::Schema.define(version: 2019_08_06_193857) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -52,6 +52,44 @@ ActiveRecord::Schema.define(version: 2018_06_20_203953) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "logo_id"
+  end
+
+  create_table "draft_collections", force: :cascade do |t|
+    t.uuid "collection_id"
+    t.integer "visibility", default: 0, null: false
+    t.bigint "owner_id", null: false
+    t.date "record_created_at"
+    t.string "hydra_noid"
+    t.date "date_ingested"
+    t.string "title"
+    t.string "fedora3_uuid"
+    t.bigint "depositor_id"
+    t.uuid "community_id"
+    t.text "description"
+    t.json "creators", array: true
+    t.boolean "restricted", default: false, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["depositor_id"], name: "index_draft_collections_on_depositor_id"
+    t.index ["owner_id"], name: "index_draft_collections_on_owner_id"
+  end
+
+  create_table "draft_communities", force: :cascade do |t|
+    t.uuid "community_id"
+    t.integer "visibility", default: 0, null: false
+    t.bigint "owner_id", null: false
+    t.date "record_created_at"
+    t.string "hydra_noid"
+    t.date "date_ingested"
+    t.string "title"
+    t.string "fedora3_uuid"
+    t.bigint "depositor_id"
+    t.text "description"
+    t.json "creators", array: true
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["depositor_id"], name: "index_draft_communities_on_depositor_id"
+    t.index ["owner_id"], name: "index_draft_communities_on_owner_id"
   end
 
   create_table "draft_items", force: :cascade do |t|
@@ -157,6 +195,14 @@ ActiveRecord::Schema.define(version: 2018_06_20_203953) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "rdf_annotations", force: :cascade do |t|
+    t.string "table"
+    t.string "column"
+    t.string "predicate"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   create_table "types", force: :cascade do |t|
     t.string "name", null: false
     t.datetime "created_at", null: false
@@ -181,6 +227,10 @@ ActiveRecord::Schema.define(version: 2018_06_20_203953) do
   end
 
   add_foreign_key "announcements", "users"
+  add_foreign_key "draft_collections", "users", column: "depositor_id"
+  add_foreign_key "draft_collections", "users", column: "owner_id"
+  add_foreign_key "draft_communities", "users", column: "depositor_id"
+  add_foreign_key "draft_communities", "users", column: "owner_id"
   add_foreign_key "draft_items", "users"
   add_foreign_key "draft_theses", "institutions"
   add_foreign_key "draft_theses", "languages"

--- a/test/models/draft_collection_test.rb
+++ b/test/models/draft_collection_test.rb
@@ -1,0 +1,22 @@
+require 'test_helper'
+
+class DraftCollectionTest < ActiveSupport::TestCase
+
+  def before_all
+    super
+    @community = locked_ldp_fixture(Community, :books).unlock_and_fetch_ldp_object(&:save!)
+    @collection = locked_ldp_fixture(Collection, :books).unlock_and_fetch_ldp_object(&:save!)
+  end
+
+  test 'can be made into a draft' do
+    # foreign key constraints won't allow invalid user IDs to own this collection
+    User.new(id: @collection.owner, email: 'fake@1234.com', name: 'fake').save(validate: false)
+
+    draft_collection = DraftCollection.from_collection(@collection, for_user: users(:admin))
+
+    assert draft_collection.persisted?
+    assert_equal @collection.id, draft_collection.collection_id
+    assert_equal @collection.community.id, draft_collection.community_id
+    assert_equal @collection.description, draft_collection.description
+  end
+end

--- a/test/models/draft_collection_test.rb
+++ b/test/models/draft_collection_test.rb
@@ -19,4 +19,5 @@ class DraftCollectionTest < ActiveSupport::TestCase
     assert_equal @collection.community.id, draft_collection.community_id
     assert_equal @collection.description, draft_collection.description
   end
+
 end

--- a/test/models/draft_community_test.rb
+++ b/test/models/draft_community_test.rb
@@ -1,0 +1,21 @@
+require 'test_helper'
+
+class DraftCommunityTest < ActiveSupport::TestCase
+
+  def before_all
+    super
+    @community = locked_ldp_fixture(Community, :books).unlock_and_fetch_ldp_object(&:save!)
+    @collection = locked_ldp_fixture(Collection, :books).unlock_and_fetch_ldp_object(&:save!)
+  end
+
+  test 'can be made into a draft' do
+    # foreign key constraints won't allow invalid user IDs to own this collection
+    User.new(id: @community.owner, email: 'fake@1234.com', name: 'fake').save(validate: false)
+
+    draft_community = DraftCommunity.from_community(@community, for_user: users(:admin))
+
+    assert draft_community.persisted?
+    assert_equal @community.id, draft_community.community_id
+    assert_equal @community.description, draft_community.description
+  end
+end

--- a/test/models/draft_community_test.rb
+++ b/test/models/draft_community_test.rb
@@ -18,4 +18,5 @@ class DraftCommunityTest < ActiveSupport::TestCase
     assert_equal @community.id, draft_community.community_id
     assert_equal @community.description, draft_community.description
   end
+
 end


### PR DESCRIPTION
Also adds a DraftCollection and DraftCommunity model to facilitate further migration work.

Some columns on drafts have TODOs on annotations at this time, as further ActsAsRdfable gem work is required to make certain scenarios like join tables work well. This PR constitutes the basis for further work to support changes to the controllers and views to remove ActiveFedora support.