### PR TITLE
Added javascript for thumbnail replacement on error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and releases in Jupiter project adheres to [Semantic Versioning](http://semver.o
 
 ### Added
 - Ruby 2.5 to travis ci testing matrix [PR#1040](https://github.com/ualbertalib/jupiter/pull/1040)
+- Added javascript for thumbnail replacement on error [#1228](https://github.com/ualbertalib/jupiter/issues/1228)
 
 ### Changed
 - i18n fallback to english (configuration change) [PR#1058](https://github.com/ualbertalib/jupiter/pull/1058)

--- a/app/assets/javascripts/jupiter/thumbnail.js
+++ b/app/assets/javascripts/jupiter/thumbnail.js
@@ -1,0 +1,8 @@
+// Replace thumbnail with default thumbnail on error
+function default_thumbnail($element) {
+  if ($element.parentElement.getElementsByClassName("img-thumbnail").length > 1) return;
+  $element.error = null;
+  $element.style.display = 'none';
+  $thumbnail_html = "<div class='text-muted text-center img-thumbnail p-3'><i class='fa fa-file-o fa-5x'></i></div>";
+  $element.insertAdjacentHTML('beforebegin', $thumbnail_html);
+}

--- a/app/views/admin/theses/draft/_thumbnail.html.erb
+++ b/app/views/admin/theses/draft/_thumbnail.html.erb
@@ -4,11 +4,11 @@ every file attached to an item via a JS callback rendering files/update_files_li
 whereas DraftItem#thumbnail specifically only deals with rendering the designated file for representing it as a
 thumbnail and is used on various other pages, like profiles, which use the application/_thumbnail partial.%>
   <% thumbnail = rails_representation_path(file.variant(resize: '100x100', auto_orient: true).processed) %>
-  <%= image_tag(thumbnail, class: 'j-thumbnail img-thumbnail', alt: '', title: file.filename, size: '100x100') %>
+  <%= image_tag(thumbnail, class: 'j-thumbnail img-thumbnail', alt: '', title: file.filename, size: '100x100', onerror: "default_thumbnail(this)") %>
 <% rescue  ActiveStorage::InvariableError %>
   <% begin %>
       <% thumbnail = rails_representation_path(file.preview(resize: '100x100', auto_orient: true).processed) %>
-      <%= image_tag(thumbnail, class: 'j-thumbnail img-thumbnail', alt: '', title: file.filename, size: '100x100') %>
+      <%= image_tag(thumbnail, class: 'j-thumbnail img-thumbnail', alt: '', title: file.filename, size: '100x100', onerror: "default_thumbnail(this)") %>
   <% rescue ActiveStorage::UnpreviewableError %>
     <div class="text-muted text-center img-thumbnail p-3">
       <%= fa_icon file_icon(file.content_type), class: 'fa-5x' %>

--- a/app/views/application/_feature_image.html.erb
+++ b/app/views/application/_feature_image.html.erb
@@ -1,6 +1,6 @@
 <% if policy(object).thumbnail? %>
   <% if object.thumbnail_url.present? %>
-    <%= image_tag(object.thumbnail_url(resize:'350x350', auto_orient: true), class: 'j-feature-image img-thumbnail', alt: '', size: '350x350') %>
+    <%= image_tag(object.thumbnail_url(resize:'350x350', auto_orient: true), class: 'j-feature-image img-thumbnail', alt: '', size: '350x350', onerror: "default_thumbnail(this)") %>
   <% else %>
     <div class="d-flex justify-content-center align-items-center img-thumbnail p-5">
       <%= fa_icon file_icon(object.thumbnail_file&.content_type), class: 'fa-5x text-muted' %>

--- a/app/views/application/_thumbnail.html.erb
+++ b/app/views/application/_thumbnail.html.erb
@@ -1,6 +1,6 @@
 <% if policy(object).thumbnail? %>
   <% if object.thumbnail_url.present? %>
-    <%= image_tag(object.thumbnail_url, class: 'j-thumbnail img-thumbnail', alt: '', title: object.title, size: '100x100') %>
+    <%= image_tag(object.thumbnail_url, class: 'j-thumbnail img-thumbnail', alt: '', title: object.title, size: '100x100', onerror: "default_thumbnail(this)") %>
   <% else %>
     <% if object.is_a? Community %>
       <%= image_tag('era-logo-without-text.png', class: 'j-thumbnail img-thumbnail', alt: '', title: object.title, size: '100x100') %>

--- a/app/views/items/draft/_thumbnail.html.erb
+++ b/app/views/items/draft/_thumbnail.html.erb
@@ -4,11 +4,11 @@ every file attached to an item via a JS callback rendering files/update_files_li
 whereas DraftItem#thumbnail specifically only deals with rendering the designated file for representing it as a
 thumbnail and is used on various other pages, like profiles, which use the application/_thumbnail partial.%>
   <% thumbnail = rails_representation_path(file.variant(resize: '100x100', auto_orient: true).processed) %>
-  <%= image_tag(thumbnail, class: 'j-thumbnail img-thumbnail', alt: '', title: file.filename, size: '100x100') %>
+  <%= image_tag(thumbnail, class: 'j-thumbnail img-thumbnail', alt: '', title: file.filename, size: '100x100', onerror: "default_thumbnail(this)") %>
 <% rescue  ActiveStorage::InvariableError %>
   <% begin %>
       <% thumbnail = rails_representation_path(file.preview(resize: '100x100', auto_orient: true).processed) %>
-      <%= image_tag(thumbnail, class: 'j-thumbnail img-thumbnail', alt: '', title: file.filename, size: '100x100') %>
+      <%= image_tag(thumbnail, class: 'j-thumbnail img-thumbnail', alt: '', title: file.filename, size: '100x100', onerror: "default_thumbnail(this)") %>
   <% rescue ActiveStorage::UnpreviewableError %>
     <div class="text-muted text-center img-thumbnail p-3">
       <%= fa_icon file_icon(file.content_type), class: 'fa-5x' %>


### PR DESCRIPTION
- Made generic thumbnail replace feature image and thumbnail on error (if broken or password protected file)
Fixes: #1228
Before:
![Screenshot from 2019-08-09 09-41-43](https://user-images.githubusercontent.com/14242562/62791332-36411980-ba8a-11e9-8730-2f1f597a8e82.png)
___
![Screenshot from 2019-08-09 09-41-37](https://user-images.githubusercontent.com/14242562/62791333-36411980-ba8a-11e9-970a-384a4d7fd695.png)
After:
![Screenshot from 2019-08-09 09-41-24](https://user-images.githubusercontent.com/14242562/62791334-36411980-ba8a-11e9-917c-64d0489c59db.png)
___
![Screenshot from 2019-08-09 09-41-14](https://user-images.githubusercontent.com/14242562/62791336-36411980-ba8a-11e9-8c33-bf7bf2ee39ce.png)
