### PR TITLE
Rename sort to order, and change arguments to it and find_by

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,8 @@ and releases in Jupiter project adheres to [Semantic Versioning](http://semver.o
 
 ### Changed
 - DeferredSimpleSolrQuery#sort renamed to 'order' and its two arguments replaced with a key-value, to better align with ActiveRecord
-  API and ease removal of ActiveFedora
+  API and ease removal of ActiveFedora.
+- Change LockedLDPObject#find_by to take a named 'id:' parameter, to better align callers with ActiveRecord
 - i18n fallback to english (configuration change) [PR#1058](https://github.com/ualbertalib/jupiter/pull/1058)
 - pin rubocop version for hound [PR#1080](https://github.com/ualbertalib/jupiter/pull/1080)
 - Replaced use of ActiveFedora's Solr connection with a direct connection to Solr setup locally.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and releases in Jupiter project adheres to [Semantic Versioning](http://semver.o
 - DraftCollection and DraftCommunity models for further migration work
 
 ### Changed
+- DeferredSimpleSolrQuery#sort renamed to 'order' and its two arguments replaced with a key-value, to better align with ActiveRecord
+  API and ease removal of ActiveFedora
 - i18n fallback to english (configuration change) [PR#1058](https://github.com/ualbertalib/jupiter/pull/1058)
 - pin rubocop version for hound [PR#1080](https://github.com/ualbertalib/jupiter/pull/1080)
 - Replaced use of ActiveFedora's Solr connection with a direct connection to Solr setup locally.

--- a/app/controllers/admin/communities_controller.rb
+++ b/app/controllers/admin/communities_controller.rb
@@ -5,7 +5,7 @@ class Admin::CommunitiesController < Admin::AdminController
   def index
     respond_to do |format|
       format.html do
-        @communities = Community.sort(params[:sort], params[:direction]).page params[:page]
+        @communities = Community.order(params[:sort] => params[:direction]).page params[:page]
         @title = t('.header')
         render template: 'communities/index'
       end
@@ -29,11 +29,11 @@ class Admin::CommunitiesController < Admin::AdminController
     respond_to do |format|
       format.js do
         # Used for the collapsable dropdown to show member collections
-        @collections = @community.member_collections.sort(params[:sort], params[:direction])
+        @collections = @community.member_collections.order(params[:sort] => params[:direction])
         render template: 'communities/show'
       end
       format.html do
-        @collections = @community.member_collections.sort(params[:sort], params[:direction]).page params[:page]
+        @collections = @community.member_collections.order(params[:sort] => params[:direction]).page params[:page]
         render template: 'communities/show'
       end
     end

--- a/app/controllers/admin/dashboard_controller.rb
+++ b/app/controllers/admin/dashboard_controller.rb
@@ -1,7 +1,7 @@
 class Admin::DashboardController < Admin::AdminController
 
   def index
-    @items = Item.limit(10).sort(:record_created_at, :desc)
+    @items = Item.limit(10).order(record_created_at: :desc)
     @users = User.where.not(last_seen_at: nil).limit(10).order(last_seen_at: :desc)
   end
 

--- a/app/controllers/communities_controller.rb
+++ b/app/controllers/communities_controller.rb
@@ -4,7 +4,7 @@ class CommunitiesController < ApplicationController
     authorize Community
     respond_to do |format|
       format.html do
-        @communities = Community.sort(params[:sort], params[:direction]).page params[:page]
+        @communities = Community.order(params[:sort] => params[:direction]).page params[:page]
         @title = t('.header')
       end
       format.json do
@@ -28,16 +28,16 @@ class CommunitiesController < ApplicationController
     authorize @community
     respond_to do |format|
       format.html do
-        @collections = @community.member_collections.sort(params[:sort], params[:direction]).page params[:page]
+        @collections = @community.member_collections.order(params[:sort] => params[:direction]).page params[:page]
       end
       format.js do
         # Used for the collapsable dropdown to show member collections
-        @collections = @community.member_collections.sort(params[:sort], params[:direction])
+        @collections = @community.member_collections.order(params[:sort] => params[:direction])
       end
 
       format.json do
         # Used in item_draft.js
-        collections = @community.member_collections.sort(:title, :asc)
+        collections = @community.member_collections.order(title: :asc)
         collections = collections.select { |c| c.restricted.blank? } unless current_user&.admin?
         render json: @community.attributes.merge(collections: collections)
       end

--- a/app/controllers/concerns/draft_actions.rb
+++ b/app/controllers/concerns/draft_actions.rb
@@ -145,6 +145,6 @@ module DraftActions
   end
 
   def initialize_communities
-    @communities = Community.all.sort(:title, :desc)
+    @communities = Community.all.order(title: :desc)
   end
 end

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -70,7 +70,7 @@ class Collection < JupiterCore::LockedLdpObject
     def community_validations
       return unless community_id
 
-      community = Community.find_by(community_id)
+      community = Community.find_by(id: community_id)
       errors.add(:community_id, :community_not_found, id: community_id) if community.blank?
     end
   end

--- a/app/models/concerns/draft_properties.rb
+++ b/app/models/concerns/draft_properties.rb
@@ -116,10 +116,10 @@ module DraftProperties
 
       member_of_paths['community_id'].each_with_index do |community_id, idx|
         collection_id = member_of_paths['collection_id'][idx]
-        community = Community.find_by(community_id)
+        community = Community.find_by(id: community_id)
         errors.add(:member_of_paths, :community_not_found) if community.blank?
 
-        collection = Collection.find_by(collection_id)
+        collection = Collection.find_by(id: collection_id)
         if collection.blank?
           errors.add(:member_of_paths, :collection_not_found)
         elsif collection.community_id != community.id

--- a/app/models/concerns/item_properties.rb
+++ b/app/models/concerns/item_properties.rb
@@ -109,9 +109,9 @@ module ItemProperties
 
         member_of_paths.each do |path|
           community_id, collection_id = path.split('/')
-          community = Community.find_by(community_id)
+          community = Community.find_by(id: community_id)
           errors.add(:member_of_paths, :community_not_found, id: community_id) if community.blank?
-          collection = Collection.find_by(collection_id)
+          collection = Collection.find_by(id: collection_id)
           errors.add(:member_of_paths, :collection_not_found, id: collection_id) if collection.blank?
         end
       end
@@ -129,7 +129,7 @@ module ItemProperties
           self.member_of_collections = []
           member_of_paths.each do |path|
             _community_id, collection_id = path.split('/')
-            collection = Collection.find_by(collection_id)
+            collection = Collection.find_by(id: collection_id)
 
             # This sets `memberOf`
             # TODO: can this be streamlined so that a fetch from Fedora isn't needed?

--- a/app/models/draft_item.rb
+++ b/app/models/draft_item.rb
@@ -303,7 +303,7 @@ class DraftItem < ApplicationRecord
 
     member_of_paths['community_id'].each_with_index do |_community_id, idx|
       collection_id = member_of_paths['collection_id'][idx]
-      collection = Collection.find_by(collection_id)
+      collection = Collection.find_by(id: collection_id)
       next if collection.blank?
 
       errors.add(:member_of_paths, :collection_restricted) if collection.restricted && !user.admin?

--- a/app/models/draft_thesis.rb
+++ b/app/models/draft_thesis.rb
@@ -198,7 +198,7 @@ class DraftThesis < ApplicationRecord
 
     member_of_paths['community_id'].each_with_index do |_community_id, idx|
       collection_id = member_of_paths['collection_id'][idx]
-      collection = Collection.find_by(collection_id)
+      collection = Collection.find_by(id: collection_id)
       next if collection.blank?
       next if collection.restricted && user.admin?
 

--- a/app/models/jupiter_core/deferred_simple_solr_query.rb
+++ b/app/models/jupiter_core/deferred_simple_solr_query.rb
@@ -31,7 +31,16 @@ class JupiterCore::DeferredSimpleSolrQuery
     self
   end
 
-  def sort(attr, order = nil)
+  def order(attrs = {})
+    ord = nil
+    attr = if attrs.is_a? Hash
+             a = attrs.keys.first
+             ord = attrs[a]
+             a
+           else
+             attrs
+           end
+
     if attr.present?
       solr_name = begin
                     criteria[:model].solr_name_for(attr.to_sym, role: :sort)
@@ -41,8 +50,8 @@ class JupiterCore::DeferredSimpleSolrQuery
       criteria[:sort] = [solr_name] if solr_name.present?
     end
     criteria[:sort] = criteria[:model].default_sort_indexes if criteria[:sort].blank?
-    criteria[:sort_order] = if order.present? && [:asc, :desc].include?(order.to_sym)
-                              [order]
+    criteria[:sort_order] = if ord.present? && [:asc, :desc].include?(ord.to_sym)
+                              [ord]
                             else
                               criteria[:model].default_sort_direction
                             end

--- a/app/models/jupiter_core/locked_ldp_object.rb
+++ b/app/models/jupiter_core/locked_ldp_object.rb
@@ -357,11 +357,7 @@ class JupiterCore::LockedLdpObject
     all.offset(num)
   end
 
-  # attr, a string attribute name and sort order
-  # def self.sort(attr, order = :asc)
-  #   all.order(attr => order)
-  # end
-
+  # attrs, a Hash name => sort order key value pair
   def self.order(attrs)
     all.order(attrs)
   end

--- a/app/models/jupiter_core/locked_ldp_object.rb
+++ b/app/models/jupiter_core/locked_ldp_object.rb
@@ -320,7 +320,7 @@ class JupiterCore::LockedLdpObject
   # find with "return nil if no object with that ID is found" semantics
   # Note: This behaves differently then AR find_by.
   # As it can only take a single argument which is an ID (which is a limitation from ActiveFedora)
-  def self.find_by(id)
+  def self.find_by(id:)
     self.find(id)
   rescue JupiterCore::ObjectNotFound
     nil
@@ -358,18 +358,22 @@ class JupiterCore::LockedLdpObject
   end
 
   # attr, a string attribute name and sort order
-  def self.sort(attr, order = :asc)
-    all.sort(attr, order)
+  # def self.sort(attr, order = :asc)
+  #   all.order(attr => order)
+  # end
+
+  def self.order(attrs)
+    all.order(attrs)
   end
 
   # the least recently created record in Solr, as determined by the record_created_at timestamp
   def self.first
-    all.limit(1).sort(:record_created_at, :asc).first
+    all.limit(1).order(record_created_at: :asc).first
   end
 
   # the most recently created record in Solr, as determined by the record_created_at timestamp
   def self.last
-    all.limit(1).sort(:record_created_at, :desc).first
+    all.limit(1).order(record_created_at: :desc).first
   end
 
   def self.valid_visibilities

--- a/app/views/admin/theses/draft/_community_collection_input.html.erb
+++ b/app/views/admin/theses/draft/_community_collection_input.html.erb
@@ -7,7 +7,7 @@
 
     <%= select_tag 'draft_thesis[community_id][]',
                     options_for_select(
-                      Collection.where(restricted: true).sort(:title, :asc)
+                      Collection.where(restricted: true).order(:title => :asc)
                                 .map { |collection| [collection.community.title, collection.community.id] }
                                 .uniq,
                       community.present? ? community.id : nil ),

--- a/app/views/items/draft/_community_collection_input.html.erb
+++ b/app/views/items/draft/_community_collection_input.html.erb
@@ -7,7 +7,7 @@
 
     <%= select_tag 'draft_item[community_id][]',
                     options_from_collection_for_select(
-                      Community.all.sort(:title, :asc),
+                      Community.all.order(:title => :asc),
                       :id,
                       :title,
                       community.present? ? community.id : nil ),

--- a/test/ldp_fixtures/collection.yml
+++ b/test/ldp_fixtures/collection.yml
@@ -9,4 +9,5 @@ fancy:
 books:
   Community: books
   title: 'Fantasy Books'
+  description: 'some fantasy books'
   owner: 1

--- a/test/ldp_fixtures/community.yml
+++ b/test/ldp_fixtures/community.yml
@@ -6,6 +6,7 @@ nice:
   owner: 1
 books:
   title: 'Books'
+  description: 'a bunch of books'
   owner: 1
 foo:
   title: 'Community'

--- a/test/models/jupiter_core/deferred_solr_query_test.rb
+++ b/test/models/jupiter_core/deferred_solr_query_test.rb
@@ -22,7 +22,7 @@ class DeferredSimpleSolrQueryTest < ActiveSupport::TestCase
     assert_equal @@klass.all.total_count, 0
 
     assert @@klass.where(title: 'foo').is_a?(JupiterCore::DeferredSimpleSolrQuery)
-    assert @@klass.sort(:title).is_a?(JupiterCore::DeferredSimpleSolrQuery)
+    assert @@klass.order(:title).is_a?(JupiterCore::DeferredSimpleSolrQuery)
     assert @@klass.limit(5).is_a?(JupiterCore::DeferredSimpleSolrQuery)
     assert @@klass.offset(5).is_a?(JupiterCore::DeferredSimpleSolrQuery)
 
@@ -41,7 +41,7 @@ class DeferredSimpleSolrQueryTest < ActiveSupport::TestCase
     assert_equal @@klass.all.total_count, 3
     assert @@klass.where(title: 'foo').first.id == obj.id
 
-    assert_equal @@klass.sort(:title, :desc).map(&:id), [another_obj.id, obj.id, private_obj.id]
+    assert_equal @@klass.order(title: :desc).map(&:id), [another_obj.id, obj.id, private_obj.id]
 
     # visibility constraints
     assert_equal 2, @@klass.where(visibility: JupiterCore::VISIBILITY_PUBLIC).count
@@ -63,7 +63,7 @@ class DeferredSimpleSolrQueryTest < ActiveSupport::TestCase
   end
 
   test 'sorting by unknown attributes falls back to defaults' do
-    items = @@klass.sort(:blergh, :foobar)
+    items = @@klass.order(blergh: :foobar)
     assert_equal :creator, items.used_sort_index
     assert_equal :desc, items.used_sort_order
   end

--- a/test/models/jupiter_core/locked_ldp_object_test.rb
+++ b/test/models/jupiter_core/locked_ldp_object_test.rb
@@ -292,7 +292,7 @@ class LockedLdpObjectTest < ActiveSupport::TestCase
       @@klass.find(generate_random_string)
     end
 
-    assert_nil @@klass.find_by(generate_random_string)
+    assert_nil @@klass.find_by(id: generate_random_string)
 
     assert @@klass.find(obj.id).present?
 


### PR DESCRIPTION
This allows us to better align calling code with the ActiveRecord API, easing replacement.