### PR TITLE
tell travis to use current (2.5) and future (2.6) Ruby

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,8 @@ addons:
   chrome: stable
 
 rvm:
-  - 2.4
   - 2.5
+  - 2.6
 
 cache: bundler
 bundler_args: --without development production --jobs=3 --retry=3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and releases in Jupiter project adheres to [Semantic Versioning](http://semver.o
 ### Changed
 - bump rubocop-performance from 1.4.0 to 1.4.1 and use match? instead of =~ [PR#1226](https://github.com/ualbertalib/jupiter/pull/1226)
 - display graduation date in season year format [#1003](https://github.com/ualbertalib/jupiter/issues/1003)
+- bump ruby from 2.4 to 2.6 in travis jobs [#1214](https://github.com/ualbertalib/jupiter/issues/1214)
 
 ### Fixed
 - bump faker from 1.9.6 to 2.1.0 and fix breaking changes to dev seed data [PR#1231](https://github.com/ualbertalib/jupiter/pull/1231)


### PR DESCRIPTION
Modify .travis.yml so that travis doesn't run jobs on ruby 2.4 as production is now on 2.5.
Replace with 2.6 so that we're looking toward the future.

#1214