### PR TITLE
remove ruby 2.6 from travis matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ addons:
 
 rvm:
   - 2.5
-  - 2.6
 
 cache: bundler
 bundler_args: --without development production --jobs=3 --retry=3


### PR DESCRIPTION
Ruby 2.6 in the travis matrix is causing issues with vcr. See #1284 for more details.  Let's remove it for now and add addressing the problem to our backlog.