### PR TITLE
make department and supervisor a facet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and releases in Jupiter project adheres to [Semantic Versioning](http://semver.o
 - Improvement on rack-attack configuration [#1247](https://github.com/ualbertalib/jupiter/issues/1247)
 - Lifting of embargo now stores item in embargo_history [#1219](https://github.com/ualbertalib/jupiter/issues/1219)
 - bump ruby from 2.4 to 2.6 in travis jobs [#1214](https://github.com/ualbertalib/jupiter/issues/1214)
+- Make supervisor and department facets to use existing functionality (requires reindex) [#1002](https://github.com/ualbertalib/jupiter/issues/1002)
 
 ### Fixed
 - bump faker from 1.9.6 to 2.1.0 and fix breaking changes to dev seed data [PR#1231](https://github.com/ualbertalib/jupiter/pull/1231)

--- a/app/models/thesis.rb
+++ b/app/models/thesis.rb
@@ -28,8 +28,8 @@ class Thesis < JupiterCore::LockedLdpObject
   has_attribute :unicorn, TERMS[:ual].unicorn, solrize_for: :exact_match
 
   has_attribute :specialization, TERMS[:ual].specialization, solrize_for: :search
-  has_attribute :departments, TERMS[:ual].department_list, type: :json_array, solrize_for: [:search]
-  has_attribute :supervisors, TERMS[:ual].supervisor_list, type: :json_array, solrize_for: [:search]
+  has_attribute :departments, TERMS[:ual].department_list, type: :json_array, solrize_for: [:search, :facet]
+  has_attribute :supervisors, TERMS[:ual].supervisor_list, type: :json_array, solrize_for: [:search, :facet]
   has_multival_attribute :committee_members, TERMS[:ual].committee_member, solrize_for: :exact_match
   has_multival_attribute :unordered_departments, TERMS[:ual].department, solrize_for: :search
   has_multival_attribute :unordered_supervisors, TERMS[:ual].supervisor, solrize_for: :exact_match

--- a/app/views/items/_thesis_more_information.html.erb
+++ b/app/views/items/_thesis_more_information.html.erb
@@ -49,7 +49,7 @@
         <dd>
           <ul class="list-unstyled">
             <% @item.departments.each do |department| %>
-              <li><%= search_link_for(@item, :departments, facet: :search, value: department) %></li>
+              <li><%= search_link_for(@item, :departments, value: department) %></li>
             <% end %>
           </ul>
         </dd>
@@ -77,7 +77,7 @@
         <dd>
           <ul class="list-unstyled">
             <% @item.supervisors.each do |supervisor| %>
-              <li><%= search_link_for(@item, :supervisors, facet: :search, value: supervisor) %></li>
+              <li><%= search_link_for(@item, :supervisors, value: supervisor) %></li>
             <% end %>
           </ul>
         </dd>


### PR DESCRIPTION
Requires reindex (I used `bundle exec rake jupiter:reindex` but perhaps there is a better way?)

Then the links to search can be treated the same as others.
![Screenshot from 2019-03-29 12-48-07](https://user-images.githubusercontent.com/1220762/55255721-ebcca800-5220-11e9-955f-cd5a163a0ede.png)
![Screenshot from 2019-03-29 12-44-24](https://user-images.githubusercontent.com/1220762/55255604-a90ad000-5220-11e9-95b8-bb7e817e6dea.png)


![Screenshot from 2019-04-04 12-03-22](https://user-images.githubusercontent.com/1220762/55577841-b5d06d80-56d1-11e9-8412-3b4cbee34f87.png)

#1002 
