### PR TITLE
Refactor System Tests to Eliminate Order-Dependence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and releases in Jupiter project adheres to [Semantic Versioning](http://semver.o
 
 ### Fixed
 - fixed error in dangerfile [#1109](https://github.com/ualbertalib/jupiter/issues/1109)
+- Fixed order-dependence in system tests regarding test data bleeding into other tests [#1286](https://github.com/ualbertalib/jupiter/issues/1286)
 
 ## [1.2.14] - 2019-04-15
 

--- a/test/system/admin_communities_index_test.rb
+++ b/test/system/admin_communities_index_test.rb
@@ -2,8 +2,7 @@ require 'application_system_test_case'
 
 class AdminCommunitiesIndexTest < ApplicationSystemTestCase
 
-  def before_all
-    super
+  def setup
     admin = User.find_by(email: 'administrator@example.com')
     @community = Community.create!(title: 'Community', owner_id: admin.id)
     2.times do |i|

--- a/test/system/collections_pagination_and_sort_test.rb
+++ b/test/system/collections_pagination_and_sort_test.rb
@@ -2,8 +2,7 @@ require 'application_system_test_case'
 
 class CollectionsPaginationAndSortTest < ApplicationSystemTestCase
 
-  def before_all
-    super
+  def setup
     admin = User.find_by(email: 'administrator@example.com')
     @community = Community.create!(title: 'Community', owner_id: admin.id)
     # For sorting, creation order is 'Fancy Collection 00', 'Nice Collection 01', 'Fancy Collection 02', etc. ...

--- a/test/system/communities_pagination_and_sort_test.rb
+++ b/test/system/communities_pagination_and_sort_test.rb
@@ -2,8 +2,7 @@ require 'application_system_test_case'
 
 class CommunitiesPaginationAndSortTest < ApplicationSystemTestCase
 
-  def before_all
-    super
+  def setup
     @admin = User.find_by(email: 'administrator@example.com')
     (0..10).each do |i|
       Community.new(title: format("#{['Fancy', 'Nice'][i % 2]} Community %02i", i), owner_id: @admin.id).save!
@@ -12,12 +11,9 @@ class CommunitiesPaginationAndSortTest < ApplicationSystemTestCase
 
   # TODO: Slow test
   test 'anybody should be able to sort and paginate communities' do
-    # for some runs/seeds (like SEED=1099), stale Communities are left over from other tests. We can't assume the
-    # communities created here are the only ones! This test needs to be re-written
     # For sorting, creation order is 'Fancy Community 00', 'Nice Community 01', 'Fancy Community 02', etc. ...
     #
     # Try SEED=8921
-    skip 'This test makes a number of bad assumptions that cause it to regularly flap'
 
     visit communities_path
 

--- a/test/system/communities_typeahead_test.rb
+++ b/test/system/communities_typeahead_test.rb
@@ -2,8 +2,7 @@ require 'application_system_test_case'
 
 class CommunitiesTypeaheadTest < ApplicationSystemTestCase
 
-  def before_all
-    super
+  def setup
     admin = User.find_by(email: 'administrator@example.com')
     @community = Community.create!(title: 'Department of thing', owner_id: admin.id)
     @community2 = Community.create!(title: 'Other community', owner_id: admin.id)

--- a/test/system/deposit_item_test.rb
+++ b/test/system/deposit_item_test.rb
@@ -2,8 +2,7 @@ require 'application_system_test_case'
 
 class DepositItemTest < ApplicationSystemTestCase
 
-  def before_all
-    super
+  def setup
     admin = User.find_by(email: 'administrator@example.com')
     # Setup a community/collection pair for respective dropdowns
     @community = Community.create!(title: 'Books', owner_id: admin.id)

--- a/test/system/deposit_thesis_test.rb
+++ b/test/system/deposit_thesis_test.rb
@@ -2,8 +2,7 @@ require 'application_system_test_case'
 
 class DepositThesisTest < ApplicationSystemTestCase
 
-  def before_all
-    super
+  def setup
     admin = User.find_by(email: 'administrator@example.com')
     # Setup a community/collection pair for respective dropdowns
     @community = Community.create!(title: 'Theses', owner_id: admin.id)

--- a/test/system/item_show_test.rb
+++ b/test/system/item_show_test.rb
@@ -2,8 +2,7 @@ require 'application_system_test_case'
 
 class ItemShowTest < ApplicationSystemTestCase
 
-  def before_all
-    super
+  def setup
     @user = User.find_by(email: 'john_snow@example.com')
     admin = User.find_by(email: 'administrator@example.com')
     @community = Community.create!(title: 'Fancy Community', owner_id: admin.id)

--- a/test/system/search_test.rb
+++ b/test/system/search_test.rb
@@ -2,8 +2,7 @@ require 'application_system_test_case'
 
 class SearchTest < ApplicationSystemTestCase
 
-  def before_all
-    super
+  def setup
     admin = User.find_by(email: 'administrator@example.com')
     @community = Community.create!(title: 'Fancy Community', owner_id: admin.id)
     @collections = 2.times.map do |i|


### PR DESCRIPTION
- Replaced all instances of before_all with setup which cleans up after itself
Fixes: #1286

There still appears to be flapping tests even with this change. Order-dependence in system tests regarding test data bleeding into other tests has been resolved, one way to test this is running:
```
rails test test/system/collections_pagination_and_sort_test.rb test/system/communities_pagination_and_sort_test.rb
```
This test used to fail inside "communities_pagination_and_sort_test.rb" because it expects 11 communities but gets 12 because the previous test created one. Now each test cleans up after itself and it gets the expected 11 communities when those tests are ran.