### PR TITLE
Modify Jupiter to use new ActsAsRDFable migration API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,6 @@ and releases in Jupiter project adheres to [Semantic Versioning](http://semver.o
 - Dependency on ActsAsRdfable for annotating ActiveRecord classes with RDF predicates
 - Collection, Community Item, and Thesis ActiveRecord models
 - jupiter:get_me_off_of_fedora rake task to perform data migration
-- drafts scope for DraftItem/DraftThesis
-
 
 ### Changed
 - DeferredSimpleSolrQuery#sort renamed to 'order' and its two arguments replaced with a key-value, to better align with ActiveRecord
@@ -27,8 +25,8 @@ and releases in Jupiter project adheres to [Semantic Versioning](http://semver.o
 - Replaced use of ActiveFedora's Solr connection with a direct connection to Solr setup locally.
 - Replaced all calls to `Solrizer.solr_name` with simplified local code to map Solr types/roles to wildcard stems.
 - Removed Solrizer usage from the process of indexing ActiveFedora objects for Solr entirely. Replaced with Solr Exporter pattern for serialization of Solr data.
-- DraftItem and DraftThesis have basic RDF annotations
 - Removed: ActiveFedora
+- Items, Theses, Collections, and Communities now have RDF predicates defined for their PostgreSQL columns via migration
 
 ### Fixed
 - fixed error in dangerfile [#1109](https://github.com/ualbertalib/jupiter/issues/1109)

--- a/Gemfile
+++ b/Gemfile
@@ -31,7 +31,7 @@ gem 'simple_form'
 gem 'canonical-rails'
 
 # RDF stuff
-gem 'acts_as_rdfable', github: 'mbarnett/acts_as_rdfable', tag: 'v0.01'
+gem 'acts_as_rdfable', github: 'mbarnett/acts_as_rdfable', ref: '3f8471b93f943ed48cff644c70f8a603645ba441'
 gem 'rdf-vocab'
 
 # Database stuff

--- a/Gemfile
+++ b/Gemfile
@@ -31,7 +31,7 @@ gem 'simple_form'
 gem 'canonical-rails'
 
 # RDF stuff
-gem 'acts_as_rdfable', github: 'mbarnett/acts_as_rdfable', ref: '3f8471b93f943ed48cff644c70f8a603645ba441'
+gem 'acts_as_rdfable', github: 'mbarnett/acts_as_rdfable', tag: 'v0.2'
 gem 'rdf-vocab'
 
 # Database stuff

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/mbarnett/acts_as_rdfable.git
-  revision: 3f8471b93f943ed48cff644c70f8a603645ba441
-  ref: 3f8471b93f943ed48cff644c70f8a603645ba441
+  revision: 9ef84dc6a57ec280a5785e21ba146345f6b88e95
+  tag: v0.2
   specs:
-    acts_as_rdfable (0.1.0)
+    acts_as_rdfable (0.2.0)
       rails (~> 5.2.3)
 
 GEM

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/mbarnett/acts_as_rdfable.git
-  revision: d1d3b79cab1f074976407e42f9e28d24de5131c8
-  tag: v0.01
+  revision: 3f8471b93f943ed48cff644c70f8a603645ba441
+  ref: 3f8471b93f943ed48cff644c70f8a603645ba441
   specs:
     acts_as_rdfable (0.1.0)
       rails (~> 5.2.3)

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -1,4 +1,5 @@
 class Collection < JupiterCore::Depositable
+  acts_as_rdfable
 
   scope :drafts, -> { where(is_published_in_era: false).or(where(is_published_in_era: nil)) }
 
@@ -16,15 +17,7 @@ class Collection < JupiterCore::Depositable
     self.visibility = JupiterCore::VISIBILITY_PUBLIC
   end
 
-  acts_as_rdfable do |config|
-    config.title has_predicate: ::RDF::Vocab::DC.title
-    config.fedora3_uuid has_predicate: ::TERMS[:ual].fedora3_uuid
-    config.depositor has_predicate: ::TERMS[:ual].depositor
-    config.community_id has_predicate: ::TERMS[:ual].path
-    config.description has_predicate: ::RDF::Vocab::DC.description
-    config.restricted has_predicate: ::TERMS[:ual].restricted_collection
-    config.creators has_predicate: ::RDF::Vocab::DC.creator
-  end
+  acts_as_rdfable
 
   def path
     "#{community_id}/#{id}"

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -18,8 +18,6 @@ class Collection < JupiterCore::Depositable
     self.visibility = JupiterCore::VISIBILITY_PUBLIC
   end
 
-  acts_as_rdfable
-
   def path
     "#{community_id}/#{id}"
   end

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -1,4 +1,5 @@
 class Collection < JupiterCore::Depositable
+
   acts_as_rdfable
 
   scope :drafts, -> { where(is_published_in_era: false).or(where(is_published_in_era: nil)) }

--- a/app/models/community.rb
+++ b/app/models/community.rb
@@ -1,4 +1,5 @@
 class Community < JupiterCore::Depositable
+
   acts_as_rdfable
 
   scope :drafts, -> { where(is_published_in_era: false).or(where(is_published_in_era: nil)) }

--- a/app/models/community.rb
+++ b/app/models/community.rb
@@ -1,4 +1,5 @@
 class Community < JupiterCore::Depositable
+  acts_as_rdfable
 
   scope :drafts, -> { where(is_published_in_era: false).or(where(is_published_in_era: nil)) }
 
@@ -20,14 +21,6 @@ class Community < JupiterCore::Depositable
 
   before_validation do
     self.visibility = JupiterCore::VISIBILITY_PUBLIC
-  end
-
-  acts_as_rdfable do |config|
-    config.title has_predicate: ::RDF::Vocab::DC.title
-    config.fedora3_uuid has_predicate: ::TERMS[:ual].fedora3_uuid
-    config.depositor has_predicate: ::TERMS[:ual].depositor
-    config.description has_predicate: ::RDF::Vocab::DC.description
-    config.creators has_predicate: ::RDF::Vocab::DC.creator
   end
 
   # this method can be used on the SolrCached object OR the ActiveFedora object

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,4 +1,5 @@
 class Item < JupiterCore::Doiable
+  acts_as_rdfable
 
   has_solr_exporter Exporters::Solr::ItemExporter
 
@@ -7,39 +8,6 @@ class Item < JupiterCore::Doiable
   has_many_attached :files, dependent: false
 
   scope :public_items, -> { where(visibility: JupiterCore::VISIBILITY_PUBLIC) }
-
-  acts_as_rdfable do |config|
-    config.title has_predicate: ::RDF::Vocab::DC.title
-    config.fedora3_uuid has_predicate: ::TERMS[:ual].fedora3_uuid
-    config.depositor has_predicate: ::TERMS[:ual].depositor
-    config.alternative_title has_predicate: ::RDF::Vocab::DC.alternative
-    config.doi has_predicate: ::TERMS[:prism].doi
-    config.embargo_end_date has_predicate: ::RDF::Vocab::DC.available
-    config.fedora3_handle has_predicate: ::TERMS[:ual].fedora3_handle
-    config.ingest_batch has_predicate: ::TERMS[:ual].ingest_batch
-    config.northern_north_america_filename has_predicate: ::TERMS[:ual].northern_north_america_filename
-    config.northern_north_america_item_id has_predicate: ::TERMS[:ual].northern_north_america_item_id
-    config.rights has_predicate: ::RDF::Vocab::DC11.rights
-    config.sort_year has_predicate: ::TERMS[:ual].sort_year
-    config.visibility_after_embargo has_predicate: ::TERMS[:acl].visibility_after_embargo
-    config.embargo_history has_predicate: ::TERMS[:acl].embargo_history
-    config.is_version_of has_predicate: ::RDF::Vocab::DC.isVersionOf
-    config.member_of_paths has_predicate: ::TERMS[:ual].path
-    config.subject has_predicate: ::RDF::Vocab::DC11.subject
-    config.creators has_predicate: RDF::Vocab::BIBO.authorList
-    config.contributors has_predicate: ::RDF::Vocab::DC11.contributor
-    config.created has_predicate: ::RDF::Vocab::DC.created
-    config.temporal_subjects has_predicate: ::RDF::Vocab::DC.temporal
-    config.spatial_subjects has_predicate: ::RDF::Vocab::DC.spatial
-    config.description has_predicate: ::RDF::Vocab::DC.description
-    config.publisher has_predicate: ::RDF::Vocab::DC.publisher
-    config.languages has_predicate: ::RDF::Vocab::DC.language
-    config.license has_predicate: ::RDF::Vocab::DC.license
-    config.item_type has_predicate: ::RDF::Vocab::DC.type
-    config.source has_predicate: ::RDF::Vocab::DC.source
-    config.related_link has_predicate: ::RDF::Vocab::DC.relation
-    config.publication_status has_predicate: ::RDF::Vocab::BIBO.status
-  end
 
   before_validation :populate_sort_year
   after_save :push_item_id_for_preservation

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,4 +1,5 @@
 class Item < JupiterCore::Doiable
+
   acts_as_rdfable
 
   has_solr_exporter Exporters::Solr::ItemExporter

--- a/app/models/thesis.rb
+++ b/app/models/thesis.rb
@@ -1,4 +1,5 @@
 class Thesis < JupiterCore::Doiable
+  acts_as_rdfable
 
   has_solr_exporter Exporters::Solr::ThesisExporter
 
@@ -24,41 +25,6 @@ class Thesis < JupiterCore::Doiable
   validates :member_of_paths, presence: true
   validate :communities_and_collections_must_exist
   validate :visibility_after_embargo_must_be_valid
-
-  acts_as_rdfable do |config|
-    config.title has_predicate: ::RDF::Vocab::DC.title
-    config.fedora3_uuid has_predicate: ::TERMS[:ual].fedora3_uuid
-    config.depositor has_predicate: ::TERMS[:ual].depositor
-    config.alternative_title has_predicate: ::RDF::Vocab::DC.alternative
-    config.doi has_predicate: ::TERMS[:prism].doi
-    config.embargo_end_date has_predicate: ::RDF::Vocab::DC.available
-    config.fedora3_handle has_predicate: ::TERMS[:ual].fedora3_handle
-    config.ingest_batch has_predicate: ::TERMS[:ual].ingest_batch
-    config.northern_north_america_filename has_predicate: ::TERMS[:ual].northern_north_america_filename
-    config.northern_north_america_item_id has_predicate: ::TERMS[:ual].northern_north_america_item_id
-    config.rights has_predicate: ::RDF::Vocab::DC11.rights
-    config.sort_year has_predicate: ::TERMS[:ual].sort_year
-    config.visibility_after_embargo has_predicate: ::TERMS[:acl].visibility_after_embargo
-    config.embargo_history has_predicate: ::TERMS[:acl].embargo_history
-    config.is_version_of has_predicate: ::RDF::Vocab::DC.isVersionOf
-    config.member_of_paths has_predicate: ::TERMS[:ual].path
-    config.subject has_predicate: ::RDF::Vocab::DC11.subject
-    config.abstract has_predicate: ::RDF::Vocab::DC.abstract
-    config.language has_predicate: ::RDF::Vocab::DC.language
-    config.date_accepted has_predicate: ::RDF::Vocab::DC.dateAccepted
-    config.date_submitted has_predicate: ::RDF::Vocab::DC.dateSubmitted
-    config.degree has_predicate: ::RDF::Vocab::BIBO.degree
-    config.institution has_predicate: TERMS[:swrc].institution
-    config.dissertant has_predicate: TERMS[:ual].dissertant
-    config.graduation_date has_predicate: TERMS[:ual].graduation_date
-    config.thesis_level has_predicate: TERMS[:ual].thesis_level
-    config.proquest has_predicate: TERMS[:ual].proquest
-    config.unicorn has_predicate: TERMS[:ual].unicorn
-    config.specialization has_predicate: TERMS[:ual].specialization
-    config.departments has_predicate: TERMS[:ual].department_list
-    config.supervisors has_predicate: TERMS[:ual].supervisor_list
-    config.committee_members has_predicate: TERMS[:ual].committee_member
-  end
 
   # Present a consistent interface with Item#item_type_with_status_code
   def item_type_with_status_code

--- a/app/models/thesis.rb
+++ b/app/models/thesis.rb
@@ -1,4 +1,5 @@
 class Thesis < JupiterCore::Doiable
+
   acts_as_rdfable
 
   has_solr_exporter Exporters::Solr::ThesisExporter

--- a/db/migrate/20190926213733_annotate_tables_with_rdf.rb
+++ b/db/migrate/20190926213733_annotate_tables_with_rdf.rb
@@ -1,0 +1,89 @@
+class AnnotateTablesWithRdf < ActiveRecord::Migration[5.2]
+  def change
+    add_rdf_table_annotations for_table: :items do |t|
+      t.title has_predicate: ::RDF::Vocab::DC.title
+      t.fedora3_uuid has_predicate: ::TERMS[:ual].fedora3_uuid
+      t.depositor has_predicate: ::TERMS[:ual].depositor
+      t.alternative_title has_predicate: ::RDF::Vocab::DC.alternative
+      t.doi has_predicate: ::TERMS[:prism].doi
+      t.embargo_end_date has_predicate: ::RDF::Vocab::DC.available
+      t.fedora3_handle has_predicate: ::TERMS[:ual].fedora3_handle
+      t.ingest_batch has_predicate: ::TERMS[:ual].ingest_batch
+      t.northern_north_america_filename has_predicate: ::TERMS[:ual].northern_north_america_filename
+      t.northern_north_america_item_id has_predicate: ::TERMS[:ual].northern_north_america_item_id
+      t.rights has_predicate: ::RDF::Vocab::DC11.rights
+      t.sort_year has_predicate: ::TERMS[:ual].sort_year
+      t.visibility_after_embargo has_predicate: ::TERMS[:acl].visibility_after_embargo
+      t.embargo_history has_predicate: ::TERMS[:acl].embargo_history
+      t.is_version_of has_predicate: ::RDF::Vocab::DC.isVersionOf
+      t.member_of_paths has_predicate: ::TERMS[:ual].path
+      t.subject has_predicate: ::RDF::Vocab::DC11.subject
+      t.creators has_predicate: RDF::Vocab::BIBO.authorList
+      t.contributors has_predicate: ::RDF::Vocab::DC11.contributor
+      t.created has_predicate: ::RDF::Vocab::DC.created
+      t.temporal_subjects has_predicate: ::RDF::Vocab::DC.temporal
+      t.spatial_subjects has_predicate: ::RDF::Vocab::DC.spatial
+      t.description has_predicate: ::RDF::Vocab::DC.description
+      t.publisher has_predicate: ::RDF::Vocab::DC.publisher
+      t.languages has_predicate: ::RDF::Vocab::DC.language
+      t.license has_predicate: ::RDF::Vocab::DC.license
+      t.item_type has_predicate: ::RDF::Vocab::DC.type
+      t.source has_predicate: ::RDF::Vocab::DC.source
+      t.related_link has_predicate: ::RDF::Vocab::DC.relation
+      t.publication_status has_predicate: ::RDF::Vocab::BIBO.status
+    end
+
+    add_rdf_table_annotations for_table: :theses do |t|
+      t.title has_predicate: ::RDF::Vocab::DC.title
+      t.fedora3_uuid has_predicate: ::TERMS[:ual].fedora3_uuid
+      t.depositor has_predicate: ::TERMS[:ual].depositor
+      t.alternative_title has_predicate: ::RDF::Vocab::DC.alternative
+      t.doi has_predicate: ::TERMS[:prism].doi
+      t.embargo_end_date has_predicate: ::RDF::Vocab::DC.available
+      t.fedora3_handle has_predicate: ::TERMS[:ual].fedora3_handle
+      t.ingest_batch has_predicate: ::TERMS[:ual].ingest_batch
+      t.northern_north_america_filename has_predicate: ::TERMS[:ual].northern_north_america_filename
+      t.northern_north_america_item_id has_predicate: ::TERMS[:ual].northern_north_america_item_id
+      t.rights has_predicate: ::RDF::Vocab::DC11.rights
+      t.sort_year has_predicate: ::TERMS[:ual].sort_year
+      t.visibility_after_embargo has_predicate: ::TERMS[:acl].visibility_after_embargo
+      t.embargo_history has_predicate: ::TERMS[:acl].embargo_history
+      t.is_version_of has_predicate: ::RDF::Vocab::DC.isVersionOf
+      t.member_of_paths has_predicate: ::TERMS[:ual].path
+      t.subject has_predicate: ::RDF::Vocab::DC11.subject
+      t.abstract has_predicate: ::RDF::Vocab::DC.abstract
+      t.language has_predicate: ::RDF::Vocab::DC.language
+      t.date_accepted has_predicate: ::RDF::Vocab::DC.dateAccepted
+      t.date_submitted has_predicate: ::RDF::Vocab::DC.dateSubmitted
+      t.degree has_predicate: ::RDF::Vocab::BIBO.degree
+      t.institution has_predicate: TERMS[:swrc].institution
+      t.dissertant has_predicate: TERMS[:ual].dissertant
+      t.graduation_date has_predicate: TERMS[:ual].graduation_date
+      t.thesis_level has_predicate: TERMS[:ual].thesis_level
+      t.proquest has_predicate: TERMS[:ual].proquest
+      t.unicorn has_predicate: TERMS[:ual].unicorn
+      t.specialization has_predicate: TERMS[:ual].specialization
+      t.departments has_predicate: TERMS[:ual].department_list
+      t.supervisors has_predicate: TERMS[:ual].supervisor_list
+      t.committee_members has_predicate: TERMS[:ual].committee_member
+    end
+
+    add_rdf_table_annotations for_table: :collections do |t|
+      t.title has_predicate: ::RDF::Vocab::DC.title
+      t.fedora3_uuid has_predicate: ::TERMS[:ual].fedora3_uuid
+      t.depositor has_predicate: ::TERMS[:ual].depositor
+      t.community_id has_predicate: ::TERMS[:ual].path
+      t.description has_predicate: ::RDF::Vocab::DC.description
+      t.restricted has_predicate: ::TERMS[:ual].restricted_collection
+      t.creators has_predicate: ::RDF::Vocab::DC.creator
+    end
+
+    add_rdf_table_annotations for_table: :communities do |t|
+      t.title has_predicate: ::RDF::Vocab::DC.title
+      t.fedora3_uuid has_predicate: ::TERMS[:ual].fedora3_uuid
+      t.depositor has_predicate: ::TERMS[:ual].depositor
+      t.description has_predicate: ::RDF::Vocab::DC.description
+      t.creators has_predicate: ::RDF::Vocab::DC.creator
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_08_26_235029) do
+ActiveRecord::Schema.define(version: 2019_09_26_213733) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -165,6 +165,9 @@ ActiveRecord::Schema.define(version: 2019_08_26_235029) do
     t.index ["institution_id"], name: "index_draft_theses_on_institution_id"
     t.index ["language_id"], name: "index_draft_theses_on_language_id"
     t.index ["user_id"], name: "index_draft_theses_on_user_id"
+  end
+
+  create_table "foo", force: :cascade do |t|
   end
 
   create_table "identities", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -167,9 +167,6 @@ ActiveRecord::Schema.define(version: 2019_09_26_213733) do
     t.index ["user_id"], name: "index_draft_theses_on_user_id"
   end
 
-  create_table "foo", force: :cascade do |t|
-  end
-
   create_table "identities", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.string "uid", null: false


### PR DESCRIPTION
Changes Jupiter to use the new ActsAsRDFable migration API from https://github.com/mbarnett/acts_as_rdfable/pull/1.

(Note that the Jupiter Gemfile in this PR currently points at the last commit on that PR – this should be updated prior to merging once that PR is merged).