### PR TITLE
Disable Rack::Attack

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -39,7 +39,5 @@ module Jupiter
 
     config.redis_key_prefix = "jupiter.#{Rails.env}."
 
-    config.middleware.use Rack::Attack
-
   end
 end


### PR DESCRIPTION
We're seeing intermittent 429s in production that don't really make sense given the current Rack::Attack configuration, and the easiest way to rule out it mistriggering seems to be to take it out of production for the time being