### PR TITLE
remove locked bundler version for travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ before_script:
 
   - RAILS_ENV=test bundle exec rails db:create
   - RAILS_ENV=test bundle exec rails db:migrate
+  - bundle --version
 
 script:
   - bundle exec rails test

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,6 @@ rvm:
 
 cache: bundler
 bundler_args: --without development production --jobs=3 --retry=3
-before_install:
-  - gem install bundler:1.17.3
 
 before_script:
   - bundle exec danger


### PR DESCRIPTION
A passing travis build will indicate if we can move past the issue we were having with bundler. This will help with the case of updating bundler on our UNIX team's build server.

#1086