### PR TITLE
delete the list node and indirect container proxy when you purge a fileset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and releases in Jupiter project adheres to [Semantic Versioning](http://semver.o
 
 ## [Unreleased]
 
+### Fixed
+- delete the list node and indirect container proxy when you purge a fileset [#1354](https://github.com/ualbertalib/jupiter/issues/1354)
+
 ## [1.2.18] - 2019-10-22
 - Removed Rack Attack
 

--- a/app/models/concerns/item_properties.rb
+++ b/app/models/concerns/item_properties.rb
@@ -206,10 +206,15 @@ module ItemProperties
 
       def purge_filesets
         FileSet.where(item: id).each do |fs|
-          fs.unlock_and_fetch_ldp_object(&:delete)
+          fs.unlock_and_fetch_ldp_object do |fileset|
+            self.ordered_members.delete(fs) # delete the list node
+            self.members.delete(fs) # delete the indirect container proxy
+            fileset.delete # delete the fileset
+          end
         end
 
-        self.ordered_members = []
+
+        self.save
       end
 
       def push_item_id_for_preservation

--- a/lib/tasks/jupiter.rake
+++ b/lib/tasks/jupiter.rake
@@ -29,6 +29,28 @@ namespace :jupiter do
     puts 'Reindex completed!'
   end
 
+  desc 'cleanup orphaned proxies'
+  task cleanup_proxies: :environment do
+    puts 'Visiting all Items and Theses...'
+    (Item.all + Thesis.all).each do |item|
+      item.unlock_and_fetch_ldp_object do |uo|
+        changed = false
+        uo.ordered_member_proxies.each_with_index do |proxy, index|
+          unless proxy.proxy_for
+            uo.ordered_member_proxies.delete_at(index)
+            binding.pry
+            puts "#{item.id} has a nil proxy"
+            changed = true
+          else
+            puts "#{item.id} does not have a nil proxy"
+          end
+        end
+        uo.save! if changed
+      end
+    end
+    puts 'Reindex completed!'
+  end
+
   desc 'queue all items and theses in the system for preservation'
   task preserve_all_items_and_theses: :environment do
     puts 'Adding all Items and Theses to preservation queue...'


### PR DESCRIPTION
Our current application isn't cleaning up all the proxies when you purge
a fileset.  This results in an `owning_class` error when trying to
perform a FileAttachementJob. `unlocked_obj.ordered_members.to_a` is `[nil]`

Hydra-works is confusing.  I can see why this might have been missed the
first time around

#1354 