### PR TITLE
index truncation happens in between tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and releases in Jupiter project adheres to [Semantic Versioning](http://semver.o
 
 ## [Unreleased]
 
+### Fixed
+- failing tests [#1376](https://github.com/ualbertalib/jupiter/issues/1376)
+
 ## [1.2.18] - 2019-10-22
 - Removed Rack Attack
 

--- a/test/system/item_show_test.rb
+++ b/test/system/item_show_test.rb
@@ -70,7 +70,6 @@ class ItemShowTest < ApplicationSystemTestCase
   end
 
   test 'massive test because index truncation happens in between tests' do
-
     # test 'unauthed users should be able to download all files from a public item' do
     visit item_path @item
     assert_selector '.js-download', count: 2

--- a/test/system/item_show_test.rb
+++ b/test/system/item_show_test.rb
@@ -69,33 +69,31 @@ class ItemShowTest < ApplicationSystemTestCase
     end
   end
 
-  test 'unauthed users should be able to download all files from a public item' do
+  test 'massive test because index truncation happens in between tests' do
+
+    # test 'unauthed users should be able to download all files from a public item' do
     visit item_path @item
     assert_selector '.js-download', count: 2
     assert_selector '.js-download-all'
     # TODO: test that the files are downloaded via js successfully without making the suite brittle
-  end
 
-  test 'Search faceting on item values is not broken' do
+    # test 'Search faceting on item values is not broken' do
     visit item_path @item
     click_link 'Joe Blow'
     assert_selector "a[href='/search?tab=item']", count: 1
-  end
 
-  test 'Visiting authenticated items as an unauthenticated user works' do
+    # test 'Visiting authenticated items as an unauthenticated user works' do
     visit item_path @item2
     assert_selector 'h1', text: 'CCID Item', count: 1
-  end
 
-  test 'Theses are working correctly' do
+    #  test 'Theses are working correctly' do
     visit item_path @thesis
 
     assert_selector 'h1', text: 'Thesis about the effects of missing regression tests', count: 1
     assert_selector 'dt', text: 'Type of Item', count: 1
     assert_selector 'dd a', text: 'Thesis', count: 1
-  end
 
-  test 'Item statistics are present' do
+    #  test 'Item statistics are present' do
     visit item_path @thesis
     assert_selector "div[class='card-header']", text: 'Usage', count: 1
     assert_selector 'div ul li', text: 'No download information available'

--- a/test/system/search_test.rb
+++ b/test/system/search_test.rb
@@ -264,7 +264,6 @@ class SearchTest < ApplicationSystemTestCase
     # Again, only 6 collections/communities should be shown
     assert_selector 'li a', text: /Extra Community/, count: 6
 
-
     # test 'anybody should be able to sort results' do
     skip 'This test continues to flap on CI that should be investigated ASAP' if ENV['TRAVIS']
 

--- a/test/system/search_test.rb
+++ b/test/system/search_test.rb
@@ -109,7 +109,9 @@ class SearchTest < ApplicationSystemTestCase
     end
   end
 
-  test 'anybody should be able to filter the public items' do
+  # TODO: JupiterCore::SolrServices::Client.instance.truncate_index in test_helper truncates the index and subsequent tests fail
+  test 'massive test because index truncation happens in between tests' do
+    # test 'anybody should be able to filter the public items' do
     visit root_path
     fill_in name: 'search', with: 'Fancy'
     click_button 'Search'
@@ -192,9 +194,8 @@ class SearchTest < ApplicationSystemTestCase
     badges = find('div.jupiter-facet-badges')
     badge = badges.find_link('a', text: 'Fancy Collection 1', href: search_path(search: 'Fancy'))
     badge.assert_selector 'span.badge', text: 'Fancy Collection 1'
-  end
 
-  test 'anybody should be able to view community/collection hits via tabs' do
+    # test 'anybody should be able to view community/collection hits via tabs' do
     visit root_path
     fill_in name: 'search', with: 'Fancy'
     click_button 'Search'
@@ -233,9 +234,8 @@ class SearchTest < ApplicationSystemTestCase
     assert_selector 'div.jupiter-results-list h3 a', text: 'Item', count: 0
     assert_selector 'div.jupiter-results-list a', text: 'Community', count: 0
     assert_selector 'div.jupiter-results-list a', text: 'Collection', count: 2
-  end
 
-  test 'anybody should only see some facet results by default, with a "show more" button' do
+    # test 'anybody should only see some facet results by default, with a "show more" button' do
     skip 'This test continues to flap on CI that should be investigated ASAP' if ENV['TRAVIS']
 
     visit root_path
@@ -263,9 +263,9 @@ class SearchTest < ApplicationSystemTestCase
 
     # Again, only 6 collections/communities should be shown
     assert_selector 'li a', text: /Extra Community/, count: 6
-  end
 
-  test 'anybody should be able to sort results' do
+
+    # test 'anybody should be able to sort results' do
     skip 'This test continues to flap on CI that should be investigated ASAP' if ENV['TRAVIS']
 
     visit root_path
@@ -314,10 +314,8 @@ class SearchTest < ApplicationSystemTestCase
                                                                  sort: 'sort_year', direction: 'asc')
     assert_selector 'button', text: 'Date (oldest first)'
     assert_match(/Fancy Item 0.*Fancy Item 2.*Fancy Item 4.*Fancy Item 6.*Fancy Item 8/m, page.text)
-  end
 
-  # TODO: Slow Test, consistently around ~8-9 seconds
-  test 'admin should be able to filter the public and private items' do
+    # test 'admin should be able to filter the public and private items' do
     admin = users(:admin)
     login_user(admin)
 


### PR DESCRIPTION
JupiterCore::SolrServices::Client.instance.truncate_index in test_helper
truncates the index created by setup and subsequent tests fail.  One workaround is to
turn these into massive tests until resolved

#1379