### PR TITLE
1376 combined test fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and releases in Jupiter project adheres to [Semantic Versioning](http://semver.o
 
 ## [Unreleased]
 
+### Fixed
+- failing tests [#1376](https://github.com/ualbertalib/jupiter/issues/1376)
+
 ## [1.2.18] - 2019-10-22
 - Removed Rack Attack
 

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -55,9 +55,16 @@ class Item < JupiterCore::Doiable
     item.description = draft_item.description
 
     # Handle visibility plus embargo logic
+    if draft_item.visibility_as_uri == CONTROLLED_VOCABULARIES[:visibility].embargo
+      item.visibility_after_embargo = draft_item.visibility_after_embargo_as_uri
+      item.embargo_end_date = draft_item.embargo_end_date
+    else
+      # If visibility was previously embargo but not anymore
+      item.add_to_embargo_history if item.visibility == CONTROLLED_VOCABULARIES[:visibility].embargo
+      item.visibility_after_embargo = nil
+      item.embargo_end_date = nil
+    end
     item.visibility = draft_item.visibility_as_uri
-    item.visibility_after_embargo = draft_item.visibility_after_embargo_as_uri
-    item.embargo_end_date = draft_item.embargo_end_date
 
     # Handle license vs rights
     item.license = draft_item.license_as_uri

--- a/app/models/jupiter_core/depositable.rb
+++ b/app/models/jupiter_core/depositable.rb
@@ -180,6 +180,13 @@ class JupiterCore::Depositable < ApplicationRecord
                    (changes['visibility'][1] != JupiterCore::VISIBILITY_PRIVATE)
   end
 
+  def add_to_embargo_history
+    self.embargo_history ||= []
+    embargo_history_item = "An embargo was deactivated on #{Time.now.getlocal('-06:00')}. Its release date was " \
+    "#{embargo_end_date}. Intended visibility after embargo was #{visibility_after_embargo}"
+    self.embargo_history << embargo_history_item
+  end
+
   def push_item_id_for_preservation
     if preserve == false
       Rails.logger.warn("Could not preserve #{id}")

--- a/app/models/thesis.rb
+++ b/app/models/thesis.rb
@@ -86,13 +86,16 @@ class Thesis < JupiterCore::Doiable
                              end
 
     # Handle visibility plus embargo logic
-    thesis.visibility = draft_thesis.visibility_as_uri
-
-    if draft_thesis.embargo_end_date.present?
+    if draft_thesis.visibility_as_uri == CONTROLLED_VOCABULARIES[:visibility].embargo
       thesis.visibility_after_embargo = CONTROLLED_VOCABULARIES[:visibility].public
+      thesis.embargo_end_date = draft_thesis.embargo_end_date
+    else
+      # If visibility was previously embargo but not anymore
+      thesis.add_to_embargo_history if thesis.visibility == CONTROLLED_VOCABULARIES[:visibility].embargo
+      thesis.visibility_after_embargo = nil
+      thesis.embargo_end_date = nil
     end
-
-    thesis.embargo_end_date = draft_thesis.embargo_end_date
+    thesis.visibility = draft_thesis.visibility_as_uri
 
     # Handle rights
     thesis.rights = draft_thesis.rights

--- a/test/fixtures/collections.yml
+++ b/test/fixtures/collections.yml
@@ -7,7 +7,7 @@ thesis:
   restricted: true
   owner: admin
   community: thesis
-fancy:
+fancy_collection:
   title: 'Fancy Collection'
   owner: admin
   community: fancy

--- a/test/fixtures/collections.yml
+++ b/test/fixtures/collections.yml
@@ -1,0 +1,9 @@
+fantasy_books:
+  title: 'Fantasy Books'
+  owner: admin
+  community: books
+thesis:
+  title: 'Thesis Collection'
+  restricted: true
+  owner: admin
+  community: thesis

--- a/test/fixtures/collections.yml
+++ b/test/fixtures/collections.yml
@@ -10,4 +10,4 @@ thesis:
 fancy_collection:
   title: 'Fancy Collection'
   owner: admin
-  community: fancy
+  community: fancy_community

--- a/test/fixtures/collections.yml
+++ b/test/fixtures/collections.yml
@@ -7,3 +7,7 @@ thesis:
   restricted: true
   owner: admin
   community: thesis
+fancy:
+  title: 'Fancy Collection'
+  owner: admin
+  community: fancy

--- a/test/fixtures/communities.yml
+++ b/test/fixtures/communities.yml
@@ -4,6 +4,6 @@ books:
 thesis:
   title: 'Thesis'
   owner: admin
-fancy:
+fancy_community:
   title: 'Fancy Community'
   owner: admin

--- a/test/fixtures/communities.yml
+++ b/test/fixtures/communities.yml
@@ -4,3 +4,6 @@ books:
 thesis:
   title: 'Thesis'
   owner: admin
+fancy:
+  title: 'Fancy Community'
+  owner: admin

--- a/test/fixtures/communities.yml
+++ b/test/fixtures/communities.yml
@@ -1,0 +1,6 @@
+books:
+  title: 'Books'
+  owner: admin
+thesis:
+  title: 'Thesis'
+  owner: admin

--- a/test/fixtures/items.yml
+++ b/test/fixtures/items.yml
@@ -1,0 +1,26 @@
+fancy:
+  visibility: <%= JupiterCore::VISIBILITY_PUBLIC %>
+  owner: regular
+  title: 'Fancy Item'
+  creators: ['Joe Blow']
+  created: 'Fall 2017'
+  record_created_at: <%= 5.day.ago.to_s(:db) %>
+  languages: <%= [CONTROLLED_VOCABULARIES[:language].english] %>
+  license: <%= CONTROLLED_VOCABULARIES[:license].attribution_4_0_international %>
+  item_type: <%= CONTROLLED_VOCABULARIES[:item_type].article %>
+  publication_status: <%= [CONTROLLED_VOCABULARIES[:publication_status].published] %>
+  subject: ['Fancy things']
+  member_of_paths: <%= ["#{ActiveRecord::FixtureSet.identify(:fancy_community, :uuid)}/#{ActiveRecord::FixtureSet.identify(:fancy_collection, :uuid)}"] %>
+admin:
+  visibility: <%= JupiterCore::VISIBILITY_PUBLIC %>
+  owner: admin
+  title: 'Admin Item'
+  creators: ['Joe Blow']
+  created: 'Winter 2017'
+  record_created_at: <%= 5.day.ago.to_s(:db) %>
+  languages: <%= [CONTROLLED_VOCABULARIES[:language].english] %>
+  license: <%= CONTROLLED_VOCABULARIES[:license].attribution_4_0_international %>
+  item_type: <%= CONTROLLED_VOCABULARIES[:item_type].article %>
+  publication_status: <%= [CONTROLLED_VOCABULARIES[:publication_status].published] %>
+  subject: ['Ownership']
+  member_of_paths: <%= ["#{ActiveRecord::FixtureSet.identify(:fancy_community, :uuid)}/#{ActiveRecord::FixtureSet.identify(:fancy_collection, :uuid)}"] %>

--- a/test/fixtures/thesis.yml
+++ b/test/fixtures/thesis.yml
@@ -1,0 +1,8 @@
+nice:
+  visibility: <%= JupiterCore::VISIBILITY_PUBLIC %>
+  owner: regular
+  title: 'Nice Item'
+  dissertant: 'Joe Blow'
+  graduation_date: '2019'
+  record_created_at: <%= 5.day.ago.to_s(:db) %>
+  member_of_paths: <%= ["#{ActiveRecord::FixtureSet.identify(:fancy_community, :uuid)}/#{ActiveRecord::FixtureSet.identify(:fancy_collection, :uuid)}"] %>

--- a/test/system/admin_items_index_test.rb
+++ b/test/system/admin_items_index_test.rb
@@ -4,50 +4,12 @@ class AdminItemsIndexTest < ApplicationSystemTestCase
 
   test 'should be able to view all items/theses owned by anybody' do
     # Note: searching and faceting is covered more extensively in tests elsewhere
-    user = users(:regular)
     admin = User.find_by(email: 'administrator@example.com')
 
-    community = Community.create!(title: 'Fancy Community', owner_id: admin.id)
-    collection = Collection.create!(community_id: community.id,
-                                    title: 'Fancy Collection', owner_id: admin.id)
-
-    # Two things owned by regular user
-    Item.new(visibility: JupiterCore::VISIBILITY_PUBLIC,
-             owner_id: user.id, title: 'Fancy Item',
-             creators: ['Joe Blow'],
-             created: 'Fall 2017',
-             languages: [CONTROLLED_VOCABULARIES[:language].english],
-             license: CONTROLLED_VOCABULARIES[:license].attribution_4_0_international,
-             item_type: CONTROLLED_VOCABULARIES[:item_type].article,
-             publication_status: [CONTROLLED_VOCABULARIES[:publication_status].published],
-             subject: ['Fancy things'])
-        .tap do |uo|
-      uo.add_to_path(community.id, collection.id)
-      uo.save!
-    end
-    Thesis.new(visibility: JupiterCore::VISIBILITY_PUBLIC,
-               owner_id: user.id, title: 'Nice Item',
-               dissertant: 'Joe Blow',
-               graduation_date: '2019')
-          .tap do |uo|
-      uo.add_to_path(community.id, collection.id)
-      uo.save!
-    end
-
-    # One item owned by admin
-    Item.new(visibility: JupiterCore::VISIBILITY_PUBLIC,
-             owner_id: admin.id, title: 'Admin Item',
-             creators: ['Joe Blow'],
-             created: 'Winter 2017',
-             languages: [CONTROLLED_VOCABULARIES[:language].english],
-             license: CONTROLLED_VOCABULARIES[:license].attribution_4_0_international,
-             item_type: CONTROLLED_VOCABULARIES[:item_type].article,
-             publication_status: [CONTROLLED_VOCABULARIES[:publication_status].published],
-             subject: ['Ownership'])
-        .tap do |uo|
-      uo.add_to_path(community.id, collection.id)
-      uo.save!
-    end
+    # creating the index from the fixtures requires a save?
+    items(:fancy).save
+    items(:admin).save
+    thesis(:nice).save
 
     login_user(admin)
 

--- a/test/system/admin_items_index_test.rb
+++ b/test/system/admin_items_index_test.rb
@@ -6,7 +6,8 @@ class AdminItemsIndexTest < ApplicationSystemTestCase
     # Note: searching and faceting is covered more extensively in tests elsewhere
     admin = User.find_by(email: 'administrator@example.com')
 
-    # creating the index from the fixtures requires a save?
+    # creating the index from the fixtures requires a save
+    # TODO: these would be good candidates for using factories instead.
     items(:fancy).save
     items(:admin).save
     thesis(:nice).save

--- a/test/system/admin_users_show_test.rb
+++ b/test/system/admin_users_show_test.rb
@@ -153,7 +153,8 @@ class AdminUsersShowTest < ApplicationSystemTestCase
     user = users(:regular)
     admin = users(:admin)
 
-    # creating the index from the fixtures requires a save?
+    # creating the index from the fixtures requires a save
+    # TODO: these would be good candidates for using factories instead.
     items(:fancy).save
     items(:admin).save
     thesis(:nice).save
@@ -182,6 +183,8 @@ class AdminUsersShowTest < ApplicationSystemTestCase
     refute_selector 'div.jupiter-results-list li.list-group-item .media-body a', text: 'Nice Item'
 
     logout_user
+
+    # this is the cleanup for the #save above
     JupiterCore::SolrServices::Client.instance.truncate_index
   end
 

--- a/test/system/admin_users_show_test.rb
+++ b/test/system/admin_users_show_test.rb
@@ -153,46 +153,10 @@ class AdminUsersShowTest < ApplicationSystemTestCase
     user = users(:regular)
     admin = users(:admin)
 
-    community = communities(:fancy)
-    collection = collections(:fancy)
-
-    # Two things owned by regular user
-    Item.new(visibility: JupiterCore::VISIBILITY_PUBLIC,
-             owner_id: user.id, title: 'Fancy Item',
-             creators: ['Joe Blow'],
-             created: 'Fall 2017',
-             languages: [CONTROLLED_VOCABULARIES[:language].english],
-             license: CONTROLLED_VOCABULARIES[:license].attribution_4_0_international,
-             item_type: CONTROLLED_VOCABULARIES[:item_type].article,
-             publication_status: [CONTROLLED_VOCABULARIES[:publication_status].published],
-             subject: ['Fancy things'])
-        .tap do |uo|
-      uo.add_to_path(community.id, collection.id)
-      uo.save!
-    end
-    Thesis.new(visibility: JupiterCore::VISIBILITY_PUBLIC,
-               owner_id: user.id, title: 'Nice Item',
-               dissertant: 'Joe Blow',
-               graduation_date: '2019')
-          .tap do |uo|
-      uo.add_to_path(community.id, collection.id)
-      uo.save!
-    end
-
-    # One item owned by admin
-    Item.new(visibility: JupiterCore::VISIBILITY_PUBLIC,
-             owner_id: admin.id, title: 'Admin Item',
-             creators: ['Joe Blow'],
-             created: 'Winter 2017',
-             languages: [CONTROLLED_VOCABULARIES[:language].english],
-             license: CONTROLLED_VOCABULARIES[:license].attribution_4_0_international,
-             item_type: CONTROLLED_VOCABULARIES[:item_type].article,
-             publication_status: [CONTROLLED_VOCABULARIES[:publication_status].published],
-             subject: ['Ownership'])
-        .tap do |uo|
-      uo.add_to_path(community.id, collection.id)
-      uo.save!
-    end
+    # creating the index from the fixtures requires a save?
+    items(:fancy).save
+    items(:admin).save
+    thesis(:nice).save
 
     login_user(admin)
 

--- a/test/system/admin_users_show_test.rb
+++ b/test/system/admin_users_show_test.rb
@@ -3,7 +3,7 @@ require 'application_system_test_case'
 class AdminUsersShowTest < ApplicationSystemTestCase
 
   test 'should not be able to toggle suspended/admin or login as yourself' do
-    admin = User.find_by(email: 'administrator@example.com')
+    admin = users(:admin)
 
     login_user(admin)
 
@@ -153,9 +153,8 @@ class AdminUsersShowTest < ApplicationSystemTestCase
     user = users(:regular)
     admin = users(:admin)
 
-    community = Community.create!(title: 'Fancy Community', owner_id: admin.id)
-    collection = Collection.create!(community_id: community.id,
-                                    title: 'Fancy Collection', owner_id: admin.id)
+    community = communities(:fancy)
+    collection = collections(:fancy)
 
     # Two things owned by regular user
     Item.new(visibility: JupiterCore::VISIBILITY_PUBLIC,
@@ -219,6 +218,7 @@ class AdminUsersShowTest < ApplicationSystemTestCase
     refute_selector 'div.jupiter-results-list li.list-group-item .media-body a', text: 'Nice Item'
 
     logout_user
+    JupiterCore::SolrServices::Client.instance.truncate_index
   end
 
 end

--- a/test/system/collections_pagination_and_sort_test.rb
+++ b/test/system/collections_pagination_and_sort_test.rb
@@ -13,7 +13,6 @@ class CollectionsPaginationAndSortTest < ApplicationSystemTestCase
   end
 
   test 'anybody should be able to sort and paginate collections' do
-    skip 'This test continues to flap on CI for unknown reasons that should be investigated ASAP' if ENV['TRAVIS']
     visit community_path(@community)
     assert_selector 'div', text: '1 - 10 of 11'
     # Default sort is by title. First 6 say 'Fancy', last 4 say 'Nice'

--- a/test/system/communities_pagination_and_sort_test.rb
+++ b/test/system/communities_pagination_and_sort_test.rb
@@ -16,7 +16,6 @@ class CommunitiesPaginationAndSortTest < ApplicationSystemTestCase
     # For sorting, creation order is 'Fancy Community 00', 'Nice Community 01', 'Fancy Community 02', etc. ...
     #
     # Try SEED=8921
-    skip 'This test makes a number of bad assumptions that cause it to regularly flap'
 
     visit communities_path
 

--- a/test/system/communities_pagination_and_sort_test.rb
+++ b/test/system/communities_pagination_and_sort_test.rb
@@ -3,9 +3,13 @@ require 'application_system_test_case'
 class CommunitiesPaginationAndSortTest < ApplicationSystemTestCase
 
   def setup
-    @admin = User.find_by(email: 'administrator@example.com')
+    # for some runs/seeds (like SEED=1099), stale Communities are left over from other tests.
+    # We need to assume the communities created here are the only ones!
+    Community.delete_all
+
+    admin = users(:admin)
     (0..10).each do |i|
-      Community.new(title: format("#{['Fancy', 'Nice'][i % 2]} Community %02i", i), owner_id: @admin.id).save!
+      Community.new(title: format("#{['Fancy', 'Nice'][i % 2]} Community %02i", i), owner_id: admin.id).save!
     end
   end
 

--- a/test/system/deposit_item_test.rb
+++ b/test/system/deposit_item_test.rb
@@ -18,8 +18,6 @@ class DepositItemTest < ApplicationSystemTestCase
 
     click_link I18n.t('application.navbar.links.new_item')
 
-    skip 'This test continues to flap on CI for unknown reasons that should be investigated ASAP' if ENV['TRAVIS']
-
     # 1. Describe Item Form
 
     assert_selector 'h1', text: I18n.t('items.draft.header')
@@ -126,8 +124,6 @@ class DepositItemTest < ApplicationSystemTestCase
   #
   # presumably this could be resolved by using proper fixtures rather than mutation
   test 'should populate community and collection when coming from collection page' do
-    skip 'This test continues to flap on CI that should be investigated ASAP' if ENV['TRAVIS']
-
     user = users(:regular)
 
     login_user(user)

--- a/test/system/deposit_item_test.rb
+++ b/test/system/deposit_item_test.rb
@@ -2,15 +2,6 @@ require 'application_system_test_case'
 
 class DepositItemTest < ApplicationSystemTestCase
 
-  def setup
-    admin = User.find_by(email: 'administrator@example.com')
-    # Setup a community/collection pair for respective dropdowns
-    @community = Community.create!(title: 'Books', owner_id: admin.id)
-    @collection = Collection.create!(title: 'Fantasy Books',
-                                     owner_id: admin.id,
-                                     community_id: @community.id)
-  end
-
   test 'be able to deposit and edit an item successfully' do
     user = users(:regular)
 
@@ -40,8 +31,8 @@ class DepositItemTest < ApplicationSystemTestCase
 
     fill_in I18n.t('items.draft.describe_item.description'), with: 'A Dance with Dragons Description Goes Here!!!'
 
-    select @community.title, from: 'draft_item[community_id][]'
-    select @collection.title, from: 'draft_item[collection_id][]'
+    select communities(:books).title, from: 'draft_item[community_id][]'
+    select collections(:fantasy_books).title, from: 'draft_item[collection_id][]'
 
     click_on I18n.t('items.draft.save_and_continue')
 
@@ -117,27 +108,30 @@ class DepositItemTest < ApplicationSystemTestCase
     assert_not_nil item_results.first['embargo_history_ssim']
 
     logout_user
+
+    # This method will add an item that exists in Solr with the member of paths matching the books/fantasy_books communities/collections fixtures
+    # in order for the other test to work we need to clean this out.
+    JupiterCore::SolrServices::Client.instance.truncate_index
   end
 
-  # TODO: note really clear on why, but sometimes this test ends up 404 not found at line 112
-  # see eg) SEED=48675
-  #
-  # presumably this could be resolved by using proper fixtures rather than mutation
   test 'should populate community and collection when coming from collection page' do
+    community = communities(:books)
+    collection = collections(:fantasy_books)
+
     user = users(:regular)
 
     login_user(user)
 
     # Navigate to collection page
     click_link I18n.t('application.navbar.links.communities')
-    click_link 'Books'
-    click_link 'Fantasy Books'
+    click_link community.title
+    click_link collection.title
 
     # Click deposit button
     click_link I18n.t('collections.show.deposit_item')
 
-    assert has_select?('draft_item[community_id][]', selected: 'Books')
-    assert has_select?('draft_item[collection_id][]', selected: 'Fantasy Books')
+    assert has_select?('draft_item[community_id][]', selected: community.title)
+    assert has_select?('draft_item[collection_id][]', selected: collection.title)
 
     logout_user
   end

--- a/test/system/deposit_thesis_test.rb
+++ b/test/system/deposit_thesis_test.rb
@@ -22,8 +22,6 @@ class DepositThesisTest < ApplicationSystemTestCase
     click_link I18n.t('admin.items.index.header')
     click_link I18n.t('admin.items.index.deposit_thesis')
 
-    skip 'This test continues to flap on CI for unknown reasons that should be investigated ASAP' if ENV['TRAVIS']
-
     # 1. Describe Thesis Form
 
     assert_selector 'h1', text: I18n.t('admin.theses.draft.header')

--- a/test/system/item_show_test.rb
+++ b/test/system/item_show_test.rb
@@ -70,7 +70,6 @@ class ItemShowTest < ApplicationSystemTestCase
   end
 
   test 'massive test because index truncation happens in between tests' do
-
     # test 'unauthed users should be able to download all files from a public item' do
     visit item_path @item
     assert_selector '.js-download', count: 2

--- a/test/system/item_show_test.rb
+++ b/test/system/item_show_test.rb
@@ -69,33 +69,31 @@ class ItemShowTest < ApplicationSystemTestCase
     end
   end
 
-  test 'unauthed users should be able to download all files from a public item' do
+  test 'massive test because index truncation happens in between tests' do
+
+    # test 'unauthed users should be able to download all files from a public item' do
     visit item_path @item
     assert_selector '.js-download', count: 2
     assert_selector '.js-download-all'
     # TODO: test that the files are downloaded via js successfully without making the suite brittle
-  end
 
-  test 'Search faceting on item values is not broken' do
+    # test 'Search faceting on item values is not broken' do
     visit item_path @item
     click_link 'Joe Blow'
     assert_selector "a[href='/search?tab=item']", count: 1
-  end
 
-  test 'Visiting authenticated items as an unauthenticated user works' do
+    # test 'Visiting authenticated items as an unauthenticated user works' do
     visit item_path @item2
     assert_selector 'h1', text: 'CCID Item', count: 1
-  end
 
-  test 'Theses are working correctly' do
+    #  test 'Theses are working correctly' do
     visit item_path @thesis
 
     assert_selector 'h1', text: 'Thesis about the effects of missing regression tests', count: 1
     assert_selector 'dt', text: 'Type of Item', count: 1
     assert_selector 'dd a', text: 'Thesis', count: 1
-  end
 
-  test 'Item statistics are present' do
+    #  test 'Item statistics are present' do
     visit item_path @thesis
     assert_selector "div[class='card-header']", text: 'Usage', count: 1
     assert_selector 'div ul li', text: 'No download information available'

--- a/test/system/item_show_test.rb
+++ b/test/system/item_show_test.rb
@@ -69,30 +69,38 @@ class ItemShowTest < ApplicationSystemTestCase
     end
   end
 
-  test 'massive test because index truncation happens in between tests' do
-    # test 'unauthed users should be able to download all files from a public item' do
+  def teardown
+    # is clearing the database but not the index, for that it needs the following
+    JupiterCore::SolrServices::Client.instance.truncate_index
+  end
+
+  test 'unauthed users should be able to download all files from a public item' do
     visit item_path @item
     assert_selector '.js-download', count: 2
     assert_selector '.js-download-all'
     # TODO: test that the files are downloaded via js successfully without making the suite brittle
+  end
 
-    # test 'Search faceting on item values is not broken' do
+  test 'Search faceting on item values is not broken' do
     visit item_path @item
     click_link 'Joe Blow'
     assert_selector "a[href='/search?tab=item']", count: 1
+  end
 
-    # test 'Visiting authenticated items as an unauthenticated user works' do
+  test 'Visiting authenticated items as an unauthenticated user works' do
     visit item_path @item2
     assert_selector 'h1', text: 'CCID Item', count: 1
+  end
 
-    #  test 'Theses are working correctly' do
+  test 'Theses are working correctly' do
     visit item_path @thesis
 
     assert_selector 'h1', text: 'Thesis about the effects of missing regression tests', count: 1
     assert_selector 'dt', text: 'Type of Item', count: 1
     assert_selector 'dd a', text: 'Thesis', count: 1
+  end
 
-    #  test 'Item statistics are present' do
+  test 'Item statistics are present' do
     visit item_path @thesis
     assert_selector "div[class='card-header']", text: 'Usage', count: 1
     assert_selector 'div ul li', text: 'No download information available'

--- a/test/system/profile_index_test.rb
+++ b/test/system/profile_index_test.rb
@@ -56,7 +56,8 @@ class ProfileIndexTest < ApplicationSystemTestCase
     # Note: searching and faceting is covered more extensively in tests elsewhere
     user = users(:regular)
 
-    # creating the index from the fixtures requires a save?
+    # creating the index from the fixtures requires a save
+    # TODO: these would be good candidates for using factories instead.
     items(:fancy).save
     items(:admin).save
     thesis(:nice).save
@@ -82,6 +83,9 @@ class ProfileIndexTest < ApplicationSystemTestCase
     refute_selector 'div.jupiter-results-list li.list-group-item .media-body a', text: 'Nice Item'
 
     logout_user
+
+    # this is the cleanup for the #save above
+    JupiterCore::SolrServices::Client.instance.truncate_index
   end
 
 end

--- a/test/system/profile_index_test.rb
+++ b/test/system/profile_index_test.rb
@@ -55,49 +55,11 @@ class ProfileIndexTest < ApplicationSystemTestCase
   test 'should view items owned by logged in user' do
     # Note: searching and faceting is covered more extensively in tests elsewhere
     user = users(:regular)
-    admin = users(:admin)
 
-    community = Community.create!(title: 'Fancy Community', owner_id: users(:admin).id)
-    collection = Collection.create!(community_id: community.id,
-                                    title: 'Fancy Collection', owner_id: users(:admin).id)
-
-    # Two things owned by regular user
-    Item.new(visibility: JupiterCore::VISIBILITY_PUBLIC,
-             owner_id: user.id, title: 'Fancy Item',
-             creators: ['Joe Blow'],
-             created: '2011-11-11',
-             languages: [CONTROLLED_VOCABULARIES[:language].english],
-             license: CONTROLLED_VOCABULARIES[:license].attribution_4_0_international,
-             item_type: CONTROLLED_VOCABULARIES[:item_type].article,
-             publication_status: [CONTROLLED_VOCABULARIES[:publication_status].published],
-             subject: ['Fancy things'])
-        .tap do |uo|
-      uo.add_to_path(community.id, collection.id)
-      uo.save!
-    end
-    Thesis.new(visibility: JupiterCore::VISIBILITY_PUBLIC,
-               owner_id: user.id, title: 'Nice Item',
-               dissertant: 'Joe Blow',
-               graduation_date: '2019')
-          .tap do |uo|
-      uo.add_to_path(community.id, collection.id)
-      uo.save!
-    end
-
-    # One item owned by admin
-    Item.new(visibility: JupiterCore::VISIBILITY_PUBLIC,
-             owner_id: admin.id, title: 'Admin Item',
-             creators: ['Joe Blow'],
-             created: '1988-08-08',
-             languages: [CONTROLLED_VOCABULARIES[:language].english],
-             license: CONTROLLED_VOCABULARIES[:license].attribution_4_0_international,
-             item_type: CONTROLLED_VOCABULARIES[:item_type].article,
-             publication_status: [CONTROLLED_VOCABULARIES[:publication_status].published],
-             subject: ['Ownership'])
-        .tap do |uo|
-      uo.add_to_path(community.id, collection.id)
-      uo.save!
-    end
+    # creating the index from the fixtures requires a save?
+    items(:fancy).save
+    items(:admin).save
+    thesis(:nice).save
 
     login_user(user)
 

--- a/test/system/search_test.rb
+++ b/test/system/search_test.rb
@@ -236,8 +236,6 @@ class SearchTest < ApplicationSystemTestCase
   end
 
   test 'anybody should only see some facet results by default, with a "show more" button' do
-    skip 'This test continues to flap on CI that should be investigated ASAP' if ENV['TRAVIS']
-
     visit root_path
     fill_in name: 'search', with: 'Extra'
     click_button 'Search'
@@ -266,8 +264,6 @@ class SearchTest < ApplicationSystemTestCase
   end
 
   test 'anybody should be able to sort results' do
-    skip 'This test continues to flap on CI that should be investigated ASAP' if ENV['TRAVIS']
-
     visit root_path
     fill_in name: 'search', with: 'Fancy'
     click_button 'Search'

--- a/test/system/search_test.rb
+++ b/test/system/search_test.rb
@@ -109,9 +109,12 @@ class SearchTest < ApplicationSystemTestCase
     end
   end
 
-  # TODO: JupiterCore::SolrServices::Client.instance.truncate_index in test_helper truncates the index and subsequent tests fail
-  test 'massive test because index truncation happens in between tests' do
-    # test 'anybody should be able to filter the public items' do
+  def teardown
+    # is clearing the database but not the index, for that it needs the following
+    JupiterCore::SolrServices::Client.instance.truncate_index
+  end
+
+  test 'anybody should be able to filter the public items' do
     visit root_path
     fill_in name: 'search', with: 'Fancy'
     click_button 'Search'
@@ -194,8 +197,9 @@ class SearchTest < ApplicationSystemTestCase
     badges = find('div.jupiter-facet-badges')
     badge = badges.find_link('a', text: 'Fancy Collection 1', href: search_path(search: 'Fancy'))
     badge.assert_selector 'span.badge', text: 'Fancy Collection 1'
+  end
 
-    # test 'anybody should be able to view community/collection hits via tabs' do
+  test 'anybody should be able to view community/collection hits via tabs' do
     visit root_path
     fill_in name: 'search', with: 'Fancy'
     click_button 'Search'
@@ -234,8 +238,11 @@ class SearchTest < ApplicationSystemTestCase
     assert_selector 'div.jupiter-results-list h3 a', text: 'Item', count: 0
     assert_selector 'div.jupiter-results-list a', text: 'Community', count: 0
     assert_selector 'div.jupiter-results-list a', text: 'Collection', count: 2
+  end
 
-    # test 'anybody should only see some facet results by default, with a "show more" button' do
+  test 'anybody should only see some facet results by default, with a "show more" button' do
+    skip 'This test continues to flap on CI that should be investigated ASAP' if ENV['TRAVIS']
+
     visit root_path
     fill_in name: 'search', with: 'Extra'
     click_button 'Search'
@@ -261,8 +268,11 @@ class SearchTest < ApplicationSystemTestCase
 
     # Again, only 6 collections/communities should be shown
     assert_selector 'li a', text: /Extra Community/, count: 6
+  end
 
-    # test 'anybody should be able to sort results' do
+  test 'anybody should be able to sort results' do
+    skip 'This test continues to flap on CI that should be investigated ASAP' if ENV['TRAVIS']
+
     visit root_path
     fill_in name: 'search', with: 'Fancy'
     click_button 'Search'
@@ -309,8 +319,10 @@ class SearchTest < ApplicationSystemTestCase
                                                                  sort: 'sort_year', direction: 'asc')
     assert_selector 'button', text: 'Date (oldest first)'
     assert_match(/Fancy Item 0.*Fancy Item 2.*Fancy Item 4.*Fancy Item 6.*Fancy Item 8/m, page.text)
+  end
 
-    # test 'admin should be able to filter the public and private items' do
+  # TODO: Slow Test, consistently around ~8-9 seconds
+  test 'admin should be able to filter the public and private items' do
     admin = users(:admin)
     login_user(admin)
 

--- a/test/system/search_test.rb
+++ b/test/system/search_test.rb
@@ -109,7 +109,9 @@ class SearchTest < ApplicationSystemTestCase
     end
   end
 
-  test 'anybody should be able to filter the public items' do
+  # TODO: JupiterCore::SolrServices::Client.instance.truncate_index in test_helper truncates the index and subsequent tests fail
+  test 'massive test because index truncation happens in between tests' do
+    # test 'anybody should be able to filter the public items' do
     visit root_path
     fill_in name: 'search', with: 'Fancy'
     click_button 'Search'
@@ -192,9 +194,8 @@ class SearchTest < ApplicationSystemTestCase
     badges = find('div.jupiter-facet-badges')
     badge = badges.find_link('a', text: 'Fancy Collection 1', href: search_path(search: 'Fancy'))
     badge.assert_selector 'span.badge', text: 'Fancy Collection 1'
-  end
 
-  test 'anybody should be able to view community/collection hits via tabs' do
+    # test 'anybody should be able to view community/collection hits via tabs' do
     visit root_path
     fill_in name: 'search', with: 'Fancy'
     click_button 'Search'
@@ -233,7 +234,6 @@ class SearchTest < ApplicationSystemTestCase
     assert_selector 'div.jupiter-results-list h3 a', text: 'Item', count: 0
     assert_selector 'div.jupiter-results-list a', text: 'Community', count: 0
     assert_selector 'div.jupiter-results-list a', text: 'Collection', count: 2
-  end
 
   test 'anybody should only see some facet results by default, with a "show more" button' do
     visit root_path
@@ -261,7 +261,6 @@ class SearchTest < ApplicationSystemTestCase
 
     # Again, only 6 collections/communities should be shown
     assert_selector 'li a', text: /Extra Community/, count: 6
-  end
 
   test 'anybody should be able to sort results' do
     visit root_path
@@ -310,10 +309,8 @@ class SearchTest < ApplicationSystemTestCase
                                                                  sort: 'sort_year', direction: 'asc')
     assert_selector 'button', text: 'Date (oldest first)'
     assert_match(/Fancy Item 0.*Fancy Item 2.*Fancy Item 4.*Fancy Item 6.*Fancy Item 8/m, page.text)
-  end
 
-  # TODO: Slow Test, consistently around ~8-9 seconds
-  test 'admin should be able to filter the public and private items' do
+    # test 'admin should be able to filter the public and private items' do
     admin = users(:admin)
     login_user(admin)
 

--- a/test/system/search_test.rb
+++ b/test/system/search_test.rb
@@ -235,7 +235,7 @@ class SearchTest < ApplicationSystemTestCase
     assert_selector 'div.jupiter-results-list a', text: 'Community', count: 0
     assert_selector 'div.jupiter-results-list a', text: 'Collection', count: 2
 
-  test 'anybody should only see some facet results by default, with a "show more" button' do
+    # test 'anybody should only see some facet results by default, with a "show more" button' do
     visit root_path
     fill_in name: 'search', with: 'Extra'
     click_button 'Search'
@@ -262,7 +262,7 @@ class SearchTest < ApplicationSystemTestCase
     # Again, only 6 collections/communities should be shown
     assert_selector 'li a', text: /Extra Community/, count: 6
 
-  test 'anybody should be able to sort results' do
+    # test 'anybody should be able to sort results' do
     visit root_path
     fill_in name: 'search', with: 'Fancy'
     click_button 'Search'


### PR DESCRIPTION
- remove skips 
- make some item and thesis fixtures and reuse them in similar tests
- Any test that creates an Item leaves a stale index entry which won't be found in the database which is cleaned on teardown of each test. 
-  fix deposit item test
missing some logic about creating embargo_history
move setup to fixtures
clean up after test that modifies index
-  fix admin users show test
The items created not through fixtures mess up the user in subsequent tests.
#1376 