### PR TITLE
Danger should not be installed in production. 

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -1,8 +1,8 @@
 # Make sure non-trivial amounts of code changes come with corresponding tests
 has_app_changes = !git.modified_files.grep(/lib/).empty? || !git.modified_files.grep(/app/).empty?
-has_spec_changes = !git.modified_files.grep(/test/).empty?
+has_test_changes = !git.modified_files.grep(/test/).empty?
 
-if  git.lines_of_code > 50 && has_app_changes && !has_spec_changes
+if  git.lines_of_code > 50 && has_app_changes && !has_test_changes
   warn('There are code changes, but no corresponding tests. '\
          'Please include tests if this PR introduces any modifications in '\
          'behavior.',

--- a/Gemfile
+++ b/Gemfile
@@ -58,7 +58,6 @@ gem 'sidekiq-cron'
 # Misc Utilities
 gem 'aasm' # state-machine management
 gem 'addressable', '~> 2.7.0' # Replacement for the standard URI implementation
-gem 'danger', '~> 6.1' # Pull Request etiquette enforcement
 gem 'ezid-client', '~> 1.8.0'
 gem 'jbuilder' # generate JSON objects
 gem 'kaminari' # Pagination
@@ -111,6 +110,7 @@ group :development do
 end
 
 group :test do
+  gem 'danger', '~> 6.1', require: false # Pull Request etiquette enforcement
   gem 'simplecov'
   # Faker added 0.5 seconds to the test suite per call. Haikunator seems much faster for faking strings
   gem 'haikunator'


### PR DESCRIPTION
Update Gemfile to reflect this. Also added require false, as we don't need to load Danger.

Also changed `spec` to `test` in Dangerfile