### PR TITLE
Add simple accessors for term schema and rdf class

### DIFF
--- a/config/initializers/terms.rb
+++ b/config/initializers/terms.rb
@@ -14,6 +14,12 @@ config.each do |vocab|
   end
 
   terms[name] = Object.new.tap do |obj|
+    obj.define_singleton_method :schema do
+      vocab['schema']
+    end
+    obj.define_singleton_method :rdf_class do
+      rdf_class
+    end
     vocab['terms'].each do |key, value|
       obj.define_singleton_method key.to_sym do
         rdf_class.send(value.to_sym)


### PR DESCRIPTION
Add two really simple methods to the terms constant so that we can get access to previously-internal information like the term's schema and RDF class.

Intended usage:

```ruby
TERMS[:ual].schema
=>  'http://terms.library.ualberta.ca/'
```