### PR TITLE
Add rdf annotations to ActiveStorage::Blob

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,7 +31,7 @@ gem 'simple_form'
 gem 'canonical-rails'
 
 # RDF stuff
-gem 'acts_as_rdfable', github: 'mbarnett/acts_as_rdfable', tag: 'v0.2.1'
+gem 'acts_as_rdfable', github: 'mbarnett/acts_as_rdfable', tag: 'v0.2.2'
 gem 'rdf-vocab'
 
 # Database stuff

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/mbarnett/acts_as_rdfable.git
-  revision: 1314de0a93f623b742fccb257bb7f2cf905fe675
+  revision: b3f9011b3c42c3bfd3bb2fe1d4f526dc30de401a
   tag: v0.2.1
   specs:
     acts_as_rdfable (0.2.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/mbarnett/acts_as_rdfable.git
   revision: b3f9011b3c42c3bfd3bb2fe1d4f526dc30de401a
-  tag: v0.2.1
+  tag: v0.2.2
   specs:
     acts_as_rdfable (0.2.1)
       rails (~> 5.2.3)

--- a/db/migrate/20200123180959_annotate_active_storage_blobs_with_rdf.rb
+++ b/db/migrate/20200123180959_annotate_active_storage_blobs_with_rdf.rb
@@ -1,0 +1,12 @@
+class AnnotateActiveStorageBlobsWithRdf < ActiveRecord::Migration[5.2]
+
+  def change
+    add_rdf_table_annotations for_table: :active_storage_blobs do |t|
+      t.filename has_predicate: ::RDF::Vocab::EBUCore.filename
+      t.content_type has_predicate: ::RDF::Vocab::EBUCore.hasMimeType
+      t.byte_size has_predicate: ::RDF::Vocab::PREMIS.hasSize
+      t.checksum has_predicate: ::RDF::Vocab::PREMIS.hasMessageDigest
+    end
+  end
+
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_09_26_213733) do
+ActiveRecord::Schema.define(version: 2020_01_23_180959) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"


### PR DESCRIPTION
Files need to provide information through prefixes, the migration
included provides this functionality.