### PR TITLE
Introduce Draper, Reorganize FacetValue Presenters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and releases in Jupiter project adheres to [Semantic Versioning](http://semver.o
 ### Added
 - Mounted Oaisys engine
 - Added and set up papertrail gem
+- Added Draper and re-organized facet presenters
 
 ### Changed
 - bump rubocop-rails to 2.4.1 Rails/FilePath default changed to slashes [PR#1398](https://github.com/ualbertalib/jupiter/pull/1398)

--- a/Gemfile
+++ b/Gemfile
@@ -31,7 +31,7 @@ gem 'simple_form'
 gem 'canonical-rails'
 
 # RDF stuff
-gem 'acts_as_rdfable', github: 'mbarnett/acts_as_rdfable', tag: 'v0.2.2'
+gem 'acts_as_rdfable', github: 'ualbertalib/acts_as_rdfable', tag: 'v0.2.2'
 gem 'rdf-vocab'
 
 # Database stuff
@@ -58,6 +58,7 @@ gem 'sidekiq-cron'
 # Misc Utilities
 gem 'aasm' # state-machine management
 gem 'addressable', '~> 2.7.0' # Replacement for the standard URI implementation
+gem 'draper'
 gem 'ezid-client', '~> 1.8.0'
 gem 'jbuilder' # generate JSON objects
 gem 'kaminari' # Pagination

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 GIT
-  remote: https://github.com/mbarnett/acts_as_rdfable.git
+  remote: https://github.com/ualbertalib/acts_as_rdfable.git
   revision: b3f9011b3c42c3bfd3bb2fe1d4f526dc30de401a
   tag: v0.2.2
   specs:
@@ -64,6 +64,10 @@ GEM
       globalid (>= 0.3.6)
     activemodel (5.2.4.1)
       activesupport (= 5.2.4.1)
+    activemodel-serializers-xml (1.0.2)
+      activemodel (> 5.x)
+      activesupport (> 5.x)
+      builder (~> 3.1)
     activerecord (5.2.4.1)
       activemodel (= 5.2.4.1)
       activesupport (= 5.2.4.1)
@@ -141,6 +145,12 @@ GEM
       terminal-table (~> 1)
     debug_inspector (0.0.3)
     docile (1.3.2)
+    draper (3.1.0)
+      actionpack (>= 5.0)
+      activemodel (>= 5.0)
+      activemodel-serializers-xml (>= 1.0)
+      activesupport (>= 5.0)
+      request_store (>= 1.0)
     dropzonejs-rails (0.8.4)
       rails (> 3.1)
     erubi (1.9.0)
@@ -458,6 +468,7 @@ DEPENDENCIES
   clamby
   connection_pool
   danger (~> 6.2)
+  draper
   dropzonejs-rails
   ezid-client (~> 1.8.0)
   faker
@@ -516,4 +527,4 @@ DEPENDENCIES
   wicked
 
 BUNDLED WITH
-   2.0.2
+   2.1.4

--- a/app/decorators/facets/community_id.rb
+++ b/app/decorators/facets/community_id.rb
@@ -1,0 +1,7 @@
+class Facets::CommunityId < Facets::DefaultFacetDecorator
+
+  def display
+    Community.find(@value).title
+  end
+
+end

--- a/app/decorators/facets/default_facet_decorator.rb
+++ b/app/decorators/facets/default_facet_decorator.rb
@@ -1,4 +1,4 @@
-class Presenters::FacetValues::DefaultPresenter
+class Facets::DefaultFacetDecorator
 
   attr_reader :count
 

--- a/app/decorators/facets/item_type_with_status.rb
+++ b/app/decorators/facets/item_type_with_status.rb
@@ -1,4 +1,4 @@
-class Presenters::FacetValues::ItemTypeWithStatus < Presenters::FacetValues::DefaultPresenter
+class Facets::ItemTypeWithStatus < Facets::DefaultFacetDecorator
 
   def display
     I18n.t("controlled_vocabularies.item_type_with_status.#{@value}")

--- a/app/decorators/facets/languages.rb
+++ b/app/decorators/facets/languages.rb
@@ -1,0 +1,7 @@
+class Facets::Languages < Facets::URIValue
+
+  def display
+    translate_uri(:language, @value)
+  end
+
+end

--- a/app/decorators/facets/license.rb
+++ b/app/decorators/facets/license.rb
@@ -1,4 +1,4 @@
-class Facets::License < Facets::DefaultFacetDecorator
+class Facets::License < Facets::URIValue
 
   def display
     translate_uri(:license, @value)

--- a/app/decorators/facets/license.rb
+++ b/app/decorators/facets/license.rb
@@ -1,0 +1,7 @@
+class Facets::License < Facets::DefaultFacetDecorator
+
+  def display
+    translate_uri(:license, @value)
+  end
+
+end

--- a/app/decorators/facets/member_of_paths.rb
+++ b/app/decorators/facets/member_of_paths.rb
@@ -1,4 +1,4 @@
-class Presenters::FacetValues::MemberOfPaths < Presenters::FacetValues::DefaultPresenter
+class Facets::MemberOfPaths < Facets::DefaultFacetDecorator
 
   def display
     # This would be the seam where we may want to introduce a more efficient cache for mapping

--- a/app/decorators/facets/uri_value.rb
+++ b/app/decorators/facets/uri_value.rb
@@ -1,4 +1,4 @@
-class Presenters::FacetValues::URIValue < Presenters::FacetValues::DefaultPresenter
+class Facets::URIValue < Facets::DefaultFacetDecorator
 
   protected
 

--- a/app/decorators/facets/visibility.rb
+++ b/app/decorators/facets/visibility.rb
@@ -1,0 +1,7 @@
+class Facets::Visibility < Facets::DefaultFacetDecorator
+
+  def display
+    translate_uri(:visibility, @value)
+  end
+
+end

--- a/app/decorators/facets/visibility.rb
+++ b/app/decorators/facets/visibility.rb
@@ -1,4 +1,4 @@
-class Facets::Visibility < Facets::DefaultFacetDecorator
+class Facets::Visibility < Facets::URIValue
 
   def display
     translate_uri(:visibility, @value)

--- a/app/helpers/presenters_helper.rb
+++ b/app/helpers/presenters_helper.rb
@@ -13,7 +13,7 @@ module PresentersHelper
     if obj.is_a?(JupiterCore::SolrServices::FacetResult::FacetValue)
       present_facet(obj)
     else
-      presenter_for(obj).new(self, obj)
+      presenter_for(obj).decorate(obj)
     end
   end
 
@@ -21,10 +21,10 @@ module PresentersHelper
 
   def present_facet(facet_value)
     @presenter_cache[facet_value] ||= begin
-      klass_name = "Presenters::FacetValues::#{facet_value.attribute_name.to_s.camelize}"
+      klass_name = "Facets::#{facet_value.attribute_name.to_s.camelize}"
       klass_name.constantize
     rescue NameError
-      ::Presenters::FacetValues::DefaultPresenter
+      ::Facets::DefaultFacetDecorator
     end
 
     @presenter_cache[facet_value].new(self, params[:facets], facet_value)
@@ -32,10 +32,10 @@ module PresentersHelper
 
   def presenter_for(obj)
     @presenter_cache[obj] ||= begin
-      klass_name = "Presenters::#{obj.class}"
+      klass_name = "Models::#{obj.class}Decorator"
       klass_name.constantize
     rescue NameError
-      raise NoSuchPresenter, "Presenter #{klass_name} is not defined for #{obj}"
+      raise NoSuchPresenter, "Draper-derived Decorator #{klass_name} is not defined for #{obj}"
     end
   end
   # rubocop:enable Rails/HelperInstanceVariable

--- a/app/models/presenters/facet_values/community_id.rb
+++ b/app/models/presenters/facet_values/community_id.rb
@@ -1,7 +1,0 @@
-class Presenters::FacetValues::CommunityId < Presenters::FacetValues::DefaultPresenter
-
-  def display
-    Community.find(@value).title
-  end
-
-end

--- a/app/models/presenters/facet_values/languages.rb
+++ b/app/models/presenters/facet_values/languages.rb
@@ -1,7 +1,0 @@
-class Presenters::FacetValues::Languages < Presenters::FacetValues::URIValue
-
-  def display
-    translate_uri(:language, @value)
-  end
-
-end

--- a/app/models/presenters/facet_values/license.rb
+++ b/app/models/presenters/facet_values/license.rb
@@ -1,7 +1,0 @@
-class Presenters::FacetValues::License < Presenters::FacetValues::URIValue
-
-  def display
-    translate_uri(:license, @value)
-  end
-
-end

--- a/app/models/presenters/facet_values/visibility.rb
+++ b/app/models/presenters/facet_values/visibility.rb
@@ -1,7 +1,0 @@
-class Presenters::FacetValues::Visibility < Presenters::FacetValues::URIValue
-
-  def display
-    translate_uri(:visibility, @value)
-  end
-
-end


### PR DESCRIPTION
## Context

As part of the introduction of presenters for the Metadata renderers for OAI, we've decided to bring in the Draper gem for presenters/decorators. Metadata renderers are being finalized in a separate branch/PR.

## Changes

- Adds a dependency on Draper. 
- Moves existing facet presenters into a top-level decorators directory for consistency with Draper decorators, and changes the terminology accordingly. Facet decorators continue to use a non-Draper base class, as each decorator translates an individual _value_ of FacetValue, whereas Draper is based on wrapping a class. We could explore changing the way FacetValues are wrapped entirely, but the two approaches co-exist transparently from the view layer's perspective via a consistent helper interface.
- Changes the `present` and `presenter_for` helpers which wrap models in presenters for the view to use Draper decorators where applicable.