### PR TITLE
Revert "Bump vcr from 5.0.0 to 5.1.0"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -119,7 +119,7 @@ group :test do
 
   gem 'json-schema', '~> 2.8.1'
   gem 'launchy'
-  gem 'vcr', require: false
+  gem 'vcr', '5.0', require: false
   gem 'webdrivers', '~> 4.2'
   gem 'webmock', require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -469,7 +469,7 @@ GEM
       execjs (>= 0.3.0, < 3)
     unicode-display_width (1.6.1)
     uuidtools (2.1.5)
-    vcr (5.1.0)
+    vcr (5.0.0)
     voight_kampff (1.1.3)
       rack (>= 1.4, < 3.0)
     web-console (4.0.1)
@@ -568,7 +568,7 @@ DEPENDENCIES
   turbolinks (~> 5)
   uglifier (>= 1.3.0)
   uuidtools
-  vcr
+  vcr (= 5.0)
   voight_kampff
   web-console (>= 3.3.0)
   webdrivers (~> 4.2)


### PR DESCRIPTION
Revert #1453

We need to consider if we can use gems that have the Hippocratic License