### PR TITLE
Add file checksum to output from file paths

### DIFF
--- a/app/controllers/aip/v1/aip_controller.rb
+++ b/app/controllers/aip/v1/aip_controller.rb
@@ -157,11 +157,12 @@ class Aip::V1::AipController < ApplicationController
     result = { files: [] }
 
     @entity.files.each do |file|
-      # Consider using olive branch for formating response with camel case keys
+      # TODO: Consider using olive branch for formating response with camel case keys
       entry = {
         file_name: file.blob.filename,
         file_path: ActiveStorage::Blob.service.send(:path_for, file.blob.key),
-        file_uuid: file.fileset_uuid
+        file_uuid: file.fileset_uuid,
+        file_checksum: file.blob.checksum
       }
 
       result[:files] << entry

--- a/test/support/aip_helper.rb
+++ b/test/support/aip_helper.rb
@@ -28,11 +28,18 @@ module AipHelper
   def file_paths_json_schema
     {
       type: 'object',
+      required: [:files],
       properties: {
         files: {
           type: 'array',
           items: {
             type: 'object',
+            required: [
+              :file_name,
+              :file_path,
+              :file_uuid,
+              :file_checksum
+            ],
             properties: {
               file_name: {
                 type: 'string'
@@ -42,12 +49,14 @@ module AipHelper
               },
               file_uuid: {
                 type: 'string'
+              },
+              file_checksum: {
+                type: 'string'
               }
             }
           }
         }
-      },
-      required: [:files]
+      }
     }
   end
 


### PR DESCRIPTION
PMPY will be doing file checks when copying the files and it makes sense
to add the file checksum from active storage to the response so we:

- Calculate the checksum only once on PMPY
- Have different source for the checksum