### PR TITLE
Use fakers new api (named arguments) from v2.0.0. 

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -59,7 +59,7 @@ if Rails.env.development? || Rails.env.uat?
     community = Community.create!(
       owner_id: admin.id,
       title: title,
-      description: Faker::Lorem.sentence(20, false, 0).chop
+      description: Faker::Lorem.sentence(word_count: 20, supplemental: false, random_words_to_add: 0).chop
     )
 
     # Attach logos, if possible
@@ -67,7 +67,7 @@ if Rails.env.development? || Rails.env.uat?
     unless File.exist?(filename)
       unless ENV['SKIP_DOWNLOAD_COMMUNITY_LOGOS'].present?
         set = (thing == 'cat') ? 'set4' : 'set1'
-        url = Faker::Avatar.image(thing, "100x100", "png", set)
+        url = Faker::Avatar.image(slug: thing, size: "100x100", format: "png", set: set)
         File.open(filename, 'wb') do |fo|
           fo.write open(url).read
         end
@@ -81,14 +81,14 @@ if Rails.env.development? || Rails.env.uat?
       owner_id: admin.id,
       title: "The annals of '#{thing.capitalize} International'",
       community_id: community.id,
-      description: Faker::Lorem.sentence(40, false, 0).chop
+      description: Faker::Lorem.sentence(word_count: 40, supplemental: false, random_words_to_add: 0).chop
     )
 
     thesis_collection = Collection.create!(
       owner_id: admin.id,
       title: "Theses about #{thing.pluralize}",
       community_id: community.id,
-      description: Faker::Lorem.sentence(40, false, 0).chop
+      description: Faker::Lorem.sentence(word_count: 40, supplemental: false, random_words_to_add: 0).chop
     )
 
     # Items
@@ -102,9 +102,9 @@ if Rails.env.development? || Rails.env.uat?
       }
       # Add an occasional verbose description
       description = if i % 10 == 5
-                      Faker::Lorem.sentence(100, false, 0).chop
+                      Faker::Lorem.sentence(word_count: 100, supplemental: false, random_words_to_add: 0).chop
                     else
-                      Faker::Lorem.sentence(20, false, 0).chop
+                      Faker::Lorem.sentence(word_count: 20, supplemental: false, random_words_to_add: 0).chop
                     end
       # Probabilistically about 70% English, 20% French, 10% Ukrainian
       languages = if seed % 10 > 2
@@ -253,7 +253,7 @@ if Rails.env.development? || Rails.env.uat?
       visibility: JupiterCore::VISIBILITY_PRIVATE,
       created: rand(20_000).days.ago.to_s,
       title: "Private #{thing.pluralize}, public lives: a survey of social media trends",
-      description: Faker::Lorem.sentence(20, false, 0).chop,
+      description: Faker::Lorem.sentence(word_count: 20, supplemental: false, random_words_to_add: 0).chop,
       languages: [CONTROLLED_VOCABULARIES[:language].english],
       license: CONTROLLED_VOCABULARIES[:license].attribution_4_0_international,
       item_type: CONTROLLED_VOCABULARIES[:item_type].chapter,
@@ -271,7 +271,7 @@ if Rails.env.development? || Rails.env.uat?
       visibility: JupiterCore::VISIBILITY_AUTHENTICATED,
       created: rand(20_000).days.ago.to_s,
       title: "Everything You Need To Know About: University of Alberta and #{thing.pluralize}!",
-      description: Faker::Lorem.sentence(20, false, 0).chop,
+      description: Faker::Lorem.sentence(word_count: 20, supplemental: false, random_words_to_add: 0).chop,
       languages: [CONTROLLED_VOCABULARIES[:language].english],
       license: CONTROLLED_VOCABULARIES[:license].attribution_4_0_international,
       item_type: CONTROLLED_VOCABULARIES[:item_type].report,
@@ -289,7 +289,7 @@ if Rails.env.development? || Rails.env.uat?
       visibility: Item::VISIBILITY_EMBARGO,
       created: rand(20_000).days.ago.to_s,
       title: "Embargo and #{Faker::Address.country}: were the #{thing.pluralize} left behind?",
-      description: Faker::Lorem.sentence(20, false, 0).chop,
+      description: Faker::Lorem.sentence(word_count: 20, supplemental: false, random_words_to_add: 0).chop,
       languages: [CONTROLLED_VOCABULARIES[:language].english],
       license: CONTROLLED_VOCABULARIES[:license].attribution_4_0_international,
       item_type: CONTROLLED_VOCABULARIES[:item_type].conference_workshop_presentation,
@@ -309,7 +309,7 @@ if Rails.env.development? || Rails.env.uat?
       visibility: Item::VISIBILITY_EMBARGO,
       created: rand(20_000).days.ago.to_s,
       title: "Former embargo of #{Faker::Address.country}: the day the #{thing.pluralize} were free",
-      description: Faker::Lorem.sentence(20, false, 0).chop,
+      description: Faker::Lorem.sentence(word_count: 20, supplemental: false, random_words_to_add: 0).chop,
       languages: [CONTROLLED_VOCABULARIES[:language].english],
       license: CONTROLLED_VOCABULARIES[:license].attribution_4_0_international,
       item_type: CONTROLLED_VOCABULARIES[:item_type].dataset,
@@ -329,7 +329,7 @@ if Rails.env.development? || Rails.env.uat?
       visibility: JupiterCore::VISIBILITY_PUBLIC,
       created: rand(20_000).days.ago.to_s,
       title: "Impact of non-admin users on #{thing.pluralize}",
-      description: Faker::Lorem.sentence(20, false, 0).chop,
+      description: Faker::Lorem.sentence(word_count: 20, supplemental: false, random_words_to_add: 0).chop,
       languages: [CONTROLLED_VOCABULARIES[:language].english],
       license: CONTROLLED_VOCABULARIES[:license].attribution_4_0_international,
       item_type: CONTROLLED_VOCABULARIES[:item_type].learning_object,
@@ -349,7 +349,7 @@ if Rails.env.development? || Rails.env.uat?
       visibility: JupiterCore::VISIBILITY_PUBLIC,
       created: rand(20_000).days.ago.to_s,
       title: "Multi-collection random images of #{thing.pluralize}",
-      description: Faker::Lorem.sentence(20, false, 0).chop,
+      description: Faker::Lorem.sentence(word_count: 20, supplemental: false, random_words_to_add: 0).chop,
       # No linguistic content
       languages: [CONTROLLED_VOCABULARIES[:language].no_linguistic_content],
       license: CONTROLLED_VOCABULARIES[:license].attribution_4_0_international,
@@ -370,7 +370,7 @@ if Rails.env.development? || Rails.env.uat?
     Community.create!(
       owner_id: admin.id,
       title: "Zoo#{thing}ology Institute of North-Eastern Upper Alberta (and Saskatchewan)",
-      description: Faker::Lorem.sentence(20, false, 0).chop
+      description: Faker::Lorem.sentence(word_count: 20, supplemental: false, random_words_to_add: 0).chop
     )
   end
 
@@ -378,7 +378,7 @@ if Rails.env.development? || Rails.env.uat?
   community = Community.create!(
     owner_id: admin.id,
     title: "The Everything Department",
-    description: Faker::Lorem.sentence(20, false, 0).chop
+    description: Faker::Lorem.sentence(word_count: 20, supplemental: false, random_words_to_add: 0).chop
   )
 
   EXTRA_THINGS.each do |thing|


### PR DESCRIPTION
This fixes our seeds since we updated faker to v2.0.0. More info here: https://github.com/faker-ruby/faker/blob/master/CHANGELOG.md#important-note

Previously you get messages like this when running seeds:

```
To automatically update from positional arguments to keyword arguments,
install rubocop-faker and run:
rubocop \
  --require rubocop-faker \
  --only Faker/DeprecatedArguments \
  --auto-correct
/Users/murny/Code/jupiter/db/seeds.rb:373: Passing `word_count` with the 1st argument of `sentence` is deprecated. Use keyword argument like `sentence(word_count: ...)` instead.
/Users/murny/Code/jupiter/db/seeds.rb:373: Passing `supplemental` with the 2nd argument of `sentence` is deprecated. Use keyword argument like `sentence(supplemental: ...)` instead.
/Users/murny/Code/jupiter/db/seeds.rb:373: Passing `random_words_to_add` with the 3rd argument of `sentence` is deprecated. Use keyword argument like `sentence(random_words_to_add: ...)` instead.
```