### PR TITLE
Reverse Tabnabbing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ and releases in Jupiter project adheres to [Semantic Versioning](http://semver.o
 - Fix Sprockets v4.0.0 upgrade problem with how Sass Variables were being defined
 - Fix bug for page_image_url helper which was double rendering urls for default image [PR#1512](https://github.com/ualbertalib/jupiter/pull/1512)
 
+### Security
+- add `noopener noreferrer` when opening a link in a new tab [PR#1344](https://github.com/ualbertalib/jupiter/pull/1344)
+
 ## [1.2.18] - 2019-10-22
 - Removed Rack Attack
 

--- a/app/views/items/_files_section_sidebar.html.erb
+++ b/app/views/items/_files_section_sidebar.html.erb
@@ -11,6 +11,7 @@
                                          file_set_id: file.fileset_uuid,
                                          file_name: file.filename.to_s),
                       class: 'btn btn-outline-primary',
+                      rel: 'noopener noreferrer',
                       target: :_blank) %>
         </div>
         <div class="p-1">
@@ -49,6 +50,7 @@
                                                file_set_id: file.fileset_uuid,
                                                file_name: file.filename.to_s),
                             class: 'btn btn-outline-primary',
+                            rel: 'noopener noreferrer',
                             target: :_blank) %>
               </div>
               <div class="p-1">


### PR DESCRIPTION
When opening a link in a new tab without setting `rel: "noopener noreferrer"`, the new tab can control the parent tab's location. For example, an attacker could redirect to a phishing page.

https://github.com/ualbertalib/di_internal/issues/61