### PR TITLE
Refactor javascript code for fallback thumbnail, use something more simplier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and releases in Jupiter project adheres to [Semantic Versioning](http://semver.o
 - bump rubocop-rails to 2.4.1 Rails/FilePath default changed to slashes [PR#1398](https://github.com/ualbertalib/jupiter/pull/1398)
 - Upgrade Rails gem to latest v6.x [#1430](https://github.com/ualbertalib/jupiter/issues/1430)
 - Transition to Zeitwerk for Autoloading [#1432](https://github.com/ualbertalib/jupiter/issues/1432)
+- Changed thumbnail fallback to ERA logo without text instead of file icon [PR#1521](https://github.com/ualbertalib/jupiter/pull/1521)
 
 ### Fixed
 - failing tests [#1376](https://github.com/ualbertalib/jupiter/issues/1376)

--- a/app/assets/javascripts/jupiter/thumbnail.js
+++ b/app/assets/javascripts/jupiter/thumbnail.js
@@ -1,8 +1,0 @@
-// Replace thumbnail with default thumbnail on error
-function default_thumbnail($element) {
-  if ($element.parentElement.getElementsByClassName("img-thumbnail").length > 1) return;
-  $element.error = null;
-  $element.style.display = 'none';
-  $thumbnail_html = "<div class='text-muted text-center img-thumbnail p-3'><i class='fa fa-file-o fa-5x'></i></div>";
-  $element.insertAdjacentHTML('beforebegin', $thumbnail_html);
-}

--- a/app/helpers/images_helper.rb
+++ b/app/helpers/images_helper.rb
@@ -27,7 +27,7 @@ module ImagesHelper
 
   def safe_thumbnail_tag(thumbnail, image_tag_options)
     image_tag_options[:class] = 'j-thumbnail img-thumbnail'
-    image_tag_options[:onerror] = 'default_thumbnail(this)'
+    image_tag_options[:onerror] = "this.onerror=null;this.src='#{image_url('era-logo-without-text.png')}';"
 
     image_tag(thumbnail, image_tag_options)
   end


### PR DESCRIPTION
So this was an issue I was fighting with for awhile on the webpacker PR. 

The problem is we want this `default_thumbnail()` method setup as a global method and exposed to the entire app (e.g you can call it from browser console, or any html). This goes against Webpackers defaults and is a major pain to get something like this to work in webpacker. I tried to replace this with jquery and watching for `.error/.load` events on the image but it works half the time (works on turbolinks page loads, but on a hard refresh it fails as image fails to load before javascript loads and fires). Also looked into using a library like https://github.com/desandro/imagesloaded but didn't get much success either. Other option is opening a `<script></script` tag and throwing this function inside to by pass webpacker...but thats messy as well.

Instead of spending a ton of time on this, I just took a simple approach. Just fallback to the ERA logo without any text on it. We do this for community thumbnails already, so figured this be okay here as well. 

Tested this and it all works quite nicely. If we cannot load an image we just get the ERA logo without text as such:

![image](https://user-images.githubusercontent.com/1930474/75917831-dcce7c80-5e17-11ea-9c09-1127bd456a0f.png)
