### PR TITLE
Fix problem with postgress requiring password

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,8 @@ services:
       - postgres-data:/var/lib/postgresql/data
     ports:
       - '5432:5432'
+    environment:
+      - POSTGRES_HOST_AUTH_METHOD=trust
 
   solr:
     image: solr:6.6


### PR DESCRIPTION
New postgres image requires a super user to be set up. This reverts to
old behavior.