### PR TITLE
Bring back ability to run capybara in non headless mode

### DIFF
--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -3,7 +3,11 @@ require 'selenium-webdriver'
 
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
 
-  driven_by :selenium, using: :headless_chrome, screen_size: [1400, 1400]
+  if ENV['CAPYBARA_NO_HEADLESS']
+    driven_by :selenium, using: :chrome, screen_size: [1400, 1400]
+  else
+    driven_by :selenium, using: :headless_chrome, screen_size: [1400, 1400]
+  end
 
   # Logs in a test user. Used for system tests.
   def login_user(user)


### PR DESCRIPTION
Stems from this conversation: https://github.com/ualbertalib/jupiter/pull/1519#discussion_r388469513

Re Enable easy way to run in non headless mode for those who like that:
`CAPYBARA_NO_HEADLESS=true rails test:system`

(why danger policing me? this has no `has_app_changes` as I didn't modify anything in app/lib folder? 🤔)

#trivial 