### PR TITLE
#1445: Refactor admin controller tests. Remove all before_all blocks,…

### DIFF
--- a/test/controllers/admin/collections_controller_test.rb
+++ b/test/controllers/admin/collections_controller_test.rb
@@ -2,13 +2,9 @@ require 'test_helper'
 
 class Admin::CollectionsControllerTest < ActionDispatch::IntegrationTest
 
-  def before_all
-    super
-    @community = Community.create!(title: 'Nice community', owner_id: users(:admin).id)
-    @collection = Collection.create!(title: 'Nice collection', owner_id: users(:admin).id, community_id: @community.id)
-  end
-
   def setup
+    @community = communities(:books)
+    @collection = collections(:fantasy_books)
     @admin = users(:admin)
     sign_in_as @admin
   end

--- a/test/controllers/admin/communities_controller_test.rb
+++ b/test/controllers/admin/communities_controller_test.rb
@@ -2,15 +2,9 @@ require 'test_helper'
 
 class Admin::CommunitiesControllerTest < ActionDispatch::IntegrationTest
 
-  def before_all
-    super
-    @admin = users(:admin)
-    @community = Community.new(title: 'Nice community',
-                               owner_id: @admin.id)
-    @community.save!
-  end
-
   def setup
+    @admin = users(:admin)
+    @community = communities(:books)
     sign_in_as users(:admin)
   end
 
@@ -26,6 +20,12 @@ class Admin::CommunitiesControllerTest < ActionDispatch::IntegrationTest
 
   test 'should show community' do
     get admin_community_url(@community)
+    assert_response :success
+  end
+
+  test 'should show community for js response' do
+    get admin_community_url(@community), xhr: true
+
     assert_response :success
   end
 

--- a/test/controllers/admin/items_controller_test.rb
+++ b/test/controllers/admin/items_controller_test.rb
@@ -21,4 +21,5 @@ class Admin::ItemsControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to root_path
     assert_equal I18n.t('admin.items.destroy.deleted'), flash[:notice]
   end
+
 end

--- a/test/controllers/admin/items_controller_test.rb
+++ b/test/controllers/admin/items_controller_test.rb
@@ -6,6 +6,11 @@ class Admin::ItemsControllerTest < ActionDispatch::IntegrationTest
     @item = items(:fancy)
     @admin = users(:admin)
     sign_in_as @admin
+
+    File.open(file_fixture('text-sample.txt'), 'r') do |file|
+      @item.add_and_ingest_files([file])
+    end
+
   end
 
   test 'should get items index' do
@@ -14,7 +19,7 @@ class Admin::ItemsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should destroy item and its derivatives' do
-    assert_difference(['Item.count'], -1) do
+    assert_difference(['Item.count', 'ActiveStorage::Attachment.count'], -1) do
       delete admin_item_url(@item)
     end
 

--- a/test/controllers/admin/items_controller_test.rb
+++ b/test/controllers/admin/items_controller_test.rb
@@ -10,7 +10,6 @@ class Admin::ItemsControllerTest < ActionDispatch::IntegrationTest
     File.open(file_fixture('text-sample.txt'), 'r') do |file|
       @item.add_and_ingest_files([file])
     end
-
   end
 
   test 'should get items index' do

--- a/test/controllers/admin/items_controller_test.rb
+++ b/test/controllers/admin/items_controller_test.rb
@@ -3,40 +3,8 @@ require 'test_helper'
 class Admin::ItemsControllerTest < ActionDispatch::IntegrationTest
 
   def setup
-    JupiterCore::SolrServices::Client.instance.truncate_index
-
+    @item = items(:fancy)
     @admin = users(:admin)
-
-    @community = Community.new(title: 'Desolate community',
-                               owner_id: @admin.id)
-    @community.save!
-    @collection = Collection.new(community_id: @community.id,
-                                 title: 'Desolate collection',
-                                 owner_id: @admin.id)
-    @collection.save!
-
-    @item = Item.new(
-      title: 'item for deletion',
-      owner_id: @admin.id,
-      creators: ['Joe Blow'],
-      created: '1972-08-08',
-      languages: [CONTROLLED_VOCABULARIES[:language].english],
-      license: CONTROLLED_VOCABULARIES[:license].attribution_4_0_international,
-      visibility: JupiterCore::VISIBILITY_PUBLIC,
-      item_type: CONTROLLED_VOCABULARIES[:item_type].article,
-      publication_status: [CONTROLLED_VOCABULARIES[:publication_status].published],
-      subject: ['Deletion']
-    ).tap do |unlocked_item|
-      unlocked_item.add_to_path(@community.id, @collection.id)
-      unlocked_item.save!
-    end
-    Sidekiq::Testing.inline! do
-      File.open(file_fixture('pdf-sample.pdf'), 'r') do |file|
-        @item.add_and_ingest_files([file])
-      end
-    end
-    @item.set_thumbnail(@item.files.first) # ensure there is a thumbnail to test deletion of
-
     sign_in_as @admin
   end
 
@@ -46,8 +14,6 @@ class Admin::ItemsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should destroy item and its derivatives' do
-    # TODO: 'ActiveStorage::Attachment.count' || 'ActiveStorage::Blob.count'
-    # wish I could test the thumbnail deletion but flaky on travis-ci
     assert_difference(['Item.count'], -1) do
       delete admin_item_url(@item)
     end
@@ -55,7 +21,4 @@ class Admin::ItemsControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to root_path
     assert_equal I18n.t('admin.items.destroy.deleted'), flash[:notice]
   end
-
-  # TODO: test 'should fail gracefully' but punted on stub/mocking raising an error
-
 end

--- a/test/controllers/admin/theses/draft_controller_test.rb
+++ b/test/controllers/admin/theses/draft_controller_test.rb
@@ -2,16 +2,9 @@ require 'test_helper'
 
 class Admin::Theses::DraftControllerTest < ActionDispatch::IntegrationTest
 
-  def before_all
-    super
-    @community = Community.create!(title: 'Books', description: 'a bunch of books', owner_id: users(:admin).id)
-    @collection = Collection.create!(title: 'Thesis collection',
-                                     owner_id: users(:admin).id,
-                                     restricted: true,
-                                     community_id: @community.id)
-  end
-
   setup do
+    @community = communities(:thesis)
+    @collection = collections(:thesis)
     @admin = users(:admin)
     Thesis.destroy_all
   end

--- a/test/controllers/admin/theses/files_controller_test.rb
+++ b/test/controllers/admin/theses/files_controller_test.rb
@@ -2,16 +2,10 @@ require 'test_helper'
 
 class Admin::Theses::FilesControllerTest < ActionDispatch::IntegrationTest
 
-  def before_all
-    super
-    @community = Community.create!(title: 'Books', description: 'a bunch of books', owner_id: users(:admin).id)
-    @collection = Collection.create!(title: 'Thesis collection',
-                                     owner_id: users(:admin).id,
-                                     restricted: true,
-                                     community_id: @community.id)
-  end
-
   setup do
+    @community = communities(:thesis)
+    @collection = collections(:thesis)
+
     @admin = users(:admin)
     sign_in_as @admin
 
@@ -30,10 +24,9 @@ class Admin::Theses::FilesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should be able to attach files to a draft thesis' do
-    # TODO: Why this failing?
-    # assert_difference('ActiveStorage::Attachment.count', 1) do
-    post admin_thesis_files_url(@draft_thesis), params: { file: @file_attachment }, xhr: true
-    # end
+    assert_difference('ActiveStorage::Attachment.count', 1) do
+      post admin_thesis_files_url(@draft_thesis), params: { file: @file_attachment }, xhr: true
+    end
 
     assert_response :success
 

--- a/test/fixtures/collections.yml
+++ b/test/fixtures/collections.yml
@@ -2,16 +2,24 @@ fantasy_books:
   title: 'Fantasy Books'
   owner: admin
   community: books
+  record_created_at: <%= Time.zone.now - 1.hour %>
+  date_ingested: <%= Time.zone.now - 1.hour %>
 thesis:
   title: 'Thesis Collection'
   restricted: true
   owner: admin
   community: thesis
+  record_created_at: <%= Time.zone.now - 1.hour %>
+  date_ingested: <%= Time.zone.now - 1.hour %>
 fancy_collection:
   title: 'Fancy Collection'
   owner: admin
   community: fancy_community
+  record_created_at: <%= Time.zone.now - 1.hour %>
+  date_ingested: <%= Time.zone.now - 1.hour %>
 fancier_collection:
   title: 'Fancier Collection'
   owner: admin
   community: fancy_community
+  record_created_at: <%= Time.zone.now - 1.hour %>
+  date_ingested: <%= Time.zone.now - 1.hour %>

--- a/test/fixtures/communities.yml
+++ b/test/fixtures/communities.yml
@@ -1,9 +1,15 @@
 books:
   title: 'Books'
   owner: admin
+  record_created_at: <%= Time.zone.now - 1.hour %>
+  date_ingested: <%= Time.zone.now - 1.hour %>
 thesis:
   title: 'Thesis'
   owner: admin
+  record_created_at: <%= Time.zone.now - 1.hour %>
+  date_ingested: <%= Time.zone.now - 1.hour %>
 fancy_community:
   title: 'Fancy Community'
   owner: admin
+  record_created_at: <%= Time.zone.now - 1.hour %>
+  date_ingested: <%= Time.zone.now - 1.hour %>


### PR DESCRIPTION
… and other refactors

#1445 

First of many PRs. This one just tackles our admin/controller tests.

A quick example of how minor this change is amd helps illustrate how quick setup and fixtures are:

Using `before_all` to create objects before all tests which are then used for each test.

```
➜  jupiter (integration_postmigration) ✗ rails test test/controllers/admin/theses/draft_controller_test.rb
Run options: --seed 8096

# Running:

..............

Finished in 3.027713s, 4.6240 runs/s, 15.8536 assertions/s.
14 runs, 48 assertions, 0 failures, 0 errors, 0 skips
Coverage report generated for Unit Tests to /Code/jupiter/coverage. 1404 / 2670 LOC (52.58%) covered.
```

Using `setup` and fixtures, to tear down the DB and reprovision the DB with all the fixture data before each and every test:
```
➜  jupiter (integration_postmigration) ✗ rails test test/controllers/admin/theses/draft_controller_test.rb
Run options: --seed 53600
# Running:

..............

Finished in 3.037624s, 4.6089 runs/s, 15.8018 assertions/s.
14 runs, 48 assertions, 0 failures, 0 errors, 0 skips
Coverage report generated for Unit Tests to /Code/jupiter/coverage. 1398 / 2670 LOC (52.36%) covered.
```

Difference is hardly even noticeable


NOTE: Travis is hating on this PR. Looking into this. Seems to have been fixed...maybe caching issue? will have to keep an eye out for this.