### PR TITLE
Fix/1408 - Cleanup null values for DraftItem and DraftThesis is_published_in_era attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and releases in Jupiter project adheres to [Semantic Versioning](http://semver.o
 - failing tests [#1376](https://github.com/ualbertalib/jupiter/issues/1376)
 - Fix Sprockets v4.0.0 upgrade problem with how Sass Variables were being defined
 - Fix bug for page_image_url helper which was double rendering urls for default image [PR#1512](https://github.com/ualbertalib/jupiter/pull/1512)
+- Fix three-state logic problems on DraftItem and DraftThesis models where boolean attribute is_published_in_era was nullable [#1408](https://github.com/ualbertalib/jupiter/issues/1408)
 
 ### Security
 - add `noopener noreferrer` when opening a link in a new tab [PR#1344](https://github.com/ualbertalib/jupiter/pull/1344)

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -2,7 +2,7 @@ class Collection < JupiterCore::Depositable
 
   acts_as_rdfable
 
-  scope :drafts, -> { where(is_published_in_era: false).or(where(is_published_in_era: nil)) }
+  scope :drafts, -> { where(is_published_in_era: false) }
 
   has_solr_exporter Exporters::Solr::CollectionExporter
 

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -2,8 +2,6 @@ class Collection < JupiterCore::Depositable
 
   acts_as_rdfable
 
-  scope :drafts, -> { where(is_published_in_era: false) }
-
   has_solr_exporter Exporters::Solr::CollectionExporter
 
   belongs_to :owner, class_name: 'User'

--- a/app/models/community.rb
+++ b/app/models/community.rb
@@ -2,8 +2,6 @@ class Community < JupiterCore::Depositable
 
   acts_as_rdfable
 
-  scope :drafts, -> { where(is_published_in_era: false) }
-
   has_solr_exporter Exporters::Solr::CommunityExporter
 
   belongs_to :owner, class_name: 'User'

--- a/app/models/community.rb
+++ b/app/models/community.rb
@@ -2,7 +2,7 @@ class Community < JupiterCore::Depositable
 
   acts_as_rdfable
 
-  scope :drafts, -> { where(is_published_in_era: false).or(where(is_published_in_era: nil)) }
+  scope :drafts, -> { where(is_published_in_era: false) }
 
   has_solr_exporter Exporters::Solr::CommunityExporter
 

--- a/app/models/draft_item.rb
+++ b/app/models/draft_item.rb
@@ -1,6 +1,6 @@
 class DraftItem < ApplicationRecord
 
-  scope :drafts, -> { where(is_published_in_era: false).or(where(is_published_in_era: nil)) }
+  scope :drafts, -> { where(is_published_in_era: false) }
 
   include DraftProperties
 

--- a/app/models/draft_item.rb
+++ b/app/models/draft_item.rb
@@ -306,7 +306,9 @@ class DraftItem < ApplicationRecord
 
   def strip_input_fields
     attributes.each do |key, value|
-      self[key] = value.reject(&:blank?) if value.is_a?(Array)
+      next unless value.is_a?(Array)
+
+      self[key] = value.reject(&:blank?)
       self[key] = nil if self[key].blank?
     end
   end

--- a/app/models/draft_thesis.rb
+++ b/app/models/draft_thesis.rb
@@ -1,6 +1,6 @@
 class DraftThesis < ApplicationRecord
 
-  scope :drafts, -> { where(is_published_in_era: false).or(where(is_published_in_era: nil)) }
+  scope :drafts, -> { where(is_published_in_era: false) }
 
   include DraftProperties
 

--- a/db/migrate/20200320164053_change_is_published_in_era_column_to_not_null.rb
+++ b/db/migrate/20200320164053_change_is_published_in_era_column_to_not_null.rb
@@ -1,0 +1,6 @@
+class ChangeIsPublishedInEraColumnToNotNull < ActiveRecord::Migration[6.0]
+  def change
+    change_column_null :draft_items, :is_published_in_era, false, false
+    change_column_null :draft_theses, :is_published_in_era, false, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_05_210657) do
+ActiveRecord::Schema.define(version: 2020_03_20_164053) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -116,7 +116,7 @@ ActiveRecord::Schema.define(version: 2020_03_05_210657) do
     t.json "citations", array: true
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.boolean "is_published_in_era", default: false
+    t.boolean "is_published_in_era", default: false, null: false
     t.index ["id"], name: "index_draft_items_on_id", unique: true
     t.index ["type_id"], name: "index_draft_items_on_type_id"
     t.index ["user_id"], name: "index_draft_items_on_user_id"
@@ -160,7 +160,7 @@ ActiveRecord::Schema.define(version: 2020_03_05_210657) do
     t.json "committee_members", array: true
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.boolean "is_published_in_era", default: false
+    t.boolean "is_published_in_era", default: false, null: false
     t.index ["id"], name: "index_draft_theses_on_id", unique: true
     t.index ["institution_id"], name: "index_draft_theses_on_institution_id"
     t.index ["language_id"], name: "index_draft_theses_on_language_id"


### PR DESCRIPTION
Change Draft entities' boolean attribute is_published_in_era to not null.
    
Both entities DraftItem and DraftThesis had boolean columns is_published_in_era that where nullable. This created a three-valued logic problem when null values started to creep in.
    
Columns is_published_in_era are no longer nullable and null entries are set to their default false value.
    
The draft scopes that checked for nil values have been simplified by only checking for false.