### PR TITLE
1566 enable GitHub actions

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -9,6 +9,7 @@ jobs:
       postgres:
         image: postgres:11-alpine
         ports: ["5432:5432"]
+        options: -e="POSTGRES_PASSWORD=mysecretpassword"
 
       redis:
         image: redis:alpine

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -5,25 +5,11 @@ jobs:
   test:
     runs-on: ubuntu-latest
 
-    services:
-      postgres:
-        image: postgres:11-alpine
-        ports: ["5432:5432"]
-        options: -e="POSTGRES_PASSWORD=mysecretpassword"
-
-      redis:
-        image: redis:alpine
-        ports: ["6379:6379"]
-
-      solr:
-        image: solr:6.6
-        ports: ["8983:8983"]
-        volumes:
-          - ./solr/config:/config
-          - ./solr/scripts/solr-precreate-jupiter.sh:/docker-entrypoint-initdb.d/solr-precreate-jupiter.sh
-
     steps:
       - uses: actions/checkout@v1
+
+      - name: Build the docker-compose stack
+        run: docker-compose up -d
 
       - name: Set up Ruby 2.6
         uses: actions/setup-ruby@v1

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,0 +1,73 @@
+name: CI
+on: push
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:11-alpine
+        ports: ["5432:5432"]
+
+      redis:
+        image: redis:alpine
+        ports: ["6379:6379"]
+
+      solr:
+        image: solr:6.6
+        ports: ["8983:8983"]
+        volumes:
+          - ./solr/config:/config
+          - ./solr/scripts/solr-precreate-jupiter.sh:/docker-entrypoint-initdb.d/solr-precreate-jupiter.sh
+
+    steps:
+      - uses: actions/checkout@v1
+
+      - name: Set up Ruby 2.6
+        uses: actions/setup-ruby@v1
+        with:
+          ruby-version: 2.6.x
+
+      - name: Install PostgreSQL client
+        run: |
+          sudo apt-get -yqq install libpq-dev
+
+      - name: Cache Ruby gems
+        uses: actions/cache@v1
+        with:
+          path: vendor/bundle
+          key: ${{ runner.os }}-gem-${{ hashFiles('**/Gemfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-gem-
+
+      - name: Bundle gems
+        run: |
+          gem install bundler
+          bundle config path vendor/bundle
+          bundle install --jobs 4 --retry 3 --without production development
+
+      - name: Lint with RuboCop
+        run: bundle exec rubocop --parallel
+
+      - name: Get yarn cache
+        id: yarn-cache
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+
+      - uses: actions/cache@v1
+        with:
+          path: ${{ steps.yarn-cache.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
+      - name: Install Node modules
+        run: yarn install
+
+      - name: Run Tests
+        env:
+          RAILS_ENV: test
+        run: |
+          bundle exec rails db:create db:schema:load
+          bundle exec rails test
+          bundle exec rails test:system

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -51,6 +51,14 @@ jobs:
       - name: Install Node modules
         run: yarn install
 
+      - name: Lint with Eslint
+        run: yarn lint
+
+      - name: Run Danger
+        env:
+          DANGER_GITHUB_API_TOKEN: ${{ secrets.DANGER_GITHUB_API_TOKEN }}
+        run: bundle exec danger
+
       - name: Run Tests
         env:
           RAILS_ENV: test

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Jupiter
 
 [![Build Status](https://travis-ci.org/ualbertalib/jupiter.svg?branch=master)](https://travis-ci.org/ualbertalib/jupiter)
+[![Github Build Status](https://github.com/ualbertalib/jupiter/workflows/CI/badge.svg)](https://github.com/ualbertalib/jupiter/actions)
 
 # Architecture
 


### PR DESCRIPTION
#1566 

All seems to work. Github Actions is now building and running our unit tests, system tests, danger and eslint/rubocop.

Had to reuse our Docker compose solution as I wasn't able to use Github Actions Services as Solr is a bit painful (chicken and egg problem....we need our code pull down as we use some of it to configure solr....but Services are created and setup before we checkout our code..)