### PR TITLE
Add a simple standard PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -1,0 +1,11 @@
+## Context
+
+Please describe any relevant motivation and context for these changes.
+
+Related to # (issue)
+
+## What's New
+
+Please summarize what's new or changed in this PR.
+
+Remember to request a reviewer when you submit!


### PR DESCRIPTION
## Context

We've been using this in Oaisys for a bit, and I've found it handy to have something similar in other organizations in the past. 

The intention isn't that this should be super onerous or require a lot of extra "paperwork" from people, it's just intended to remind people to be kind to reviewers by giving them a bit of context to help them understand your PR. 

Things are always optional where they don't really apply – like there's no issue number associated with this PR, and it would be pointless busywork to go create one when I just had the idea to add this five minutes ago.

## What's New

- Adds a basic template GitHub will use to pre-populate PR descriptions.
- That's it. That's the PR.
