### PR TITLE
Increase wait time for Capybara, default is 2 secs, now 5 secs.

### DIFF
--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -3,6 +3,8 @@ require 'selenium-webdriver'
 
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
 
+  Capybara.default_max_wait_time = 5
+
   if ENV['CAPYBARA_NO_HEADLESS']
     driven_by :selenium, using: :chrome, screen_size: [1400, 1400]
   else


### PR DESCRIPTION
## Context

Some of our system tests flak when waiting for elements to show up on the page. Currently these assert_selector/etc wait for a default time of 2 seconds. 

## What's New

Let's increase this to 5 seconds. 

This should not impact the time tests run. If everything is good then chances are the tests will run the exact same time (Ran this with and without and both are run around 110 seconds). This just gives a bit more forgiveness for when things do happen that may cause our tests to flake (less resources on travis/github/etc could result in slow tests/responses/etc)

Similar suggestion here for Ajax calls on Capybara docs: https://github.com/teamcapybara/capybara#asynchronous-javascript-ajax-and-friends

#trivial