### PR TITLE
Update the epic template

### DIFF
--- a/.github/ISSUE_TEMPLATE/epic---user-story.md
+++ b/.github/ISSUE_TEMPLATE/epic---user-story.md
@@ -22,6 +22,11 @@ This should not be a description of a particular wished-for solution – to quot
 so that... < Context. How does the immediate desire to do something fit into the bigger picture?
 What’s the overall benefit we’re trying to achieve? What is the big problem that needs solving?>
 
+
+### Additional information:
+
+Any other information you can think of related to this! Links to discussion, other details that would be helpful to know, etc, etc
+
 ## Step 2: The Elevator Pitch & Refinement
 
 ### Elevator Pitch


### PR DESCRIPTION
## Context

Now that we have had someone try out the new User Story template,  we have a sense of how they're perceiving it, and want to tweak it to encourage them to share additional information, rather than feel restricted to just writing a user-oriented "as a..." statement.

## What's New

Add an additional info section to the User Story portion of the template, to encourage people to share additional details