### PR TITLE
#1614: Remove is_published_in_era column and all use cases of it (drafts scope)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and releases in Jupiter project adheres to [Semantic Versioning](http://semver.o
 
 ### Removed
 - Removed Matomo analytic tracking [#1493](https://github.com/ualbertalib/jupiter/issues/1493)
+- Cleanup all references of `is_published_in_era` and `drafts` scope on DraftItem/DraftThesis [#1614](https://github.com/ualbertalib/jupiter/issues/1614)
 
 ## [1.2.18] - 2019-10-22
 - Removed Rack Attack

--- a/app/controllers/concerns/draft_actions.rb
+++ b/app/controllers/concerns/draft_actions.rb
@@ -91,7 +91,7 @@ module DraftActions
         'collection_id' => [collection.id]
       }
     end
-    @draft = draft_class.drafts.create(create_params)
+    @draft = draft_class.create(create_params)
     authorize @draft if needs_authorization?
 
     redirect_to wizard_path(steps.first, draft_id_param => @draft.id)
@@ -139,7 +139,7 @@ module DraftActions
   end
 
   def set_draft
-    @draft = draft_class.drafts.find(params[draft_id_param])
+    @draft = draft_class.find(params[draft_id_param])
   end
 
   def initialize_communities

--- a/app/models/draft_item.rb
+++ b/app/models/draft_item.rb
@@ -1,7 +1,5 @@
 class DraftItem < ApplicationRecord
 
-  scope :drafts, -> { where(is_published_in_era: false) }
-
   include DraftProperties
 
   enum wizard_step: { describe_item: 0,
@@ -134,7 +132,6 @@ class DraftItem < ApplicationRecord
       citations: item.is_version_of,
       source: item.source,
       related_item: item.related_link,
-      is_published_in_era: false,
       thumbnail_id: thumbnail_file&.blob_id
     }
     assign_attributes(draft_attributes)
@@ -169,8 +166,8 @@ class DraftItem < ApplicationRecord
   end
 
   def self.from_item(item, for_user:)
-    draft = DraftItem.drafts.find_by(uuid: item.id)
-    draft ||= DraftItem.drafts.new(uuid: item.id)
+    draft = DraftItem.find_by(uuid: item.id)
+    draft ||= DraftItem.new(uuid: item.id)
 
     draft.update_from_fedora_item(item, for_user)
     draft

--- a/app/models/draft_thesis.rb
+++ b/app/models/draft_thesis.rb
@@ -1,7 +1,5 @@
 class DraftThesis < ApplicationRecord
 
-  scope :drafts, -> { where(is_published_in_era: false) }
-
   include DraftProperties
 
   # Metadata team prefers we store and use a number (e.g. '06' or '11')
@@ -124,8 +122,8 @@ class DraftThesis < ApplicationRecord
   end
 
   def self.from_thesis(thesis, for_user:)
-    draft = DraftThesis.drafts.find_by(uuid: thesis.id)
-    draft ||= DraftThesis.drafts.new(uuid: thesis.id)
+    draft = DraftThesis.find_by(uuid: thesis.id)
+    draft ||= DraftThesis.new(uuid: thesis.id)
 
     draft.update_from_fedora_thesis(thesis, for_user)
     draft

--- a/db/migrate/20200428061736_drop_is_published_in_era_column.rb
+++ b/db/migrate/20200428061736_drop_is_published_in_era_column.rb
@@ -1,0 +1,6 @@
+class DropIsPublishedInEraColumn < ActiveRecord::Migration[6.0]
+  def change
+    remove_column :draft_items, :is_published_in_era
+    remove_column :draft_theses, :is_published_in_era
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_03_231907) do
+ActiveRecord::Schema.define(version: 2020_04_28_061736) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -116,7 +116,6 @@ ActiveRecord::Schema.define(version: 2020_04_03_231907) do
     t.json "citations", array: true
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.boolean "is_published_in_era", default: false, null: false
     t.index ["id"], name: "index_draft_items_on_id", unique: true
     t.index ["type_id"], name: "index_draft_items_on_type_id"
     t.index ["user_id"], name: "index_draft_items_on_user_id"
@@ -160,7 +159,6 @@ ActiveRecord::Schema.define(version: 2020_04_03_231907) do
     t.json "committee_members", array: true
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.boolean "is_published_in_era", default: false, null: false
     t.index ["id"], name: "index_draft_theses_on_id", unique: true
     t.index ["institution_id"], name: "index_draft_theses_on_institution_id"
     t.index ["language_id"], name: "index_draft_theses_on_language_id"

--- a/lib/tasks/jupiter.rake
+++ b/lib/tasks/jupiter.rake
@@ -6,15 +6,14 @@ namespace :jupiter do
   desc 'removes stale inactive drafts from the database'
   task remove_inactive_drafts: :environment do
     # Find all the inactive draft items older than yesterday
-    inactive_draft_items = DraftItem.drafts.where('DATE(created_at) < DATE(?)', Date.yesterday).where(status: :inactive)
+    inactive_draft_items = DraftItem.where('DATE(created_at) < DATE(?)', Date.yesterday).where(status: :inactive)
     puts "Deleting #{inactive_draft_items.count} Inactive Draft Items..."
 
     # delete them all
     inactive_draft_items.destroy_all
 
     # Find all the inactive draft theses older than yesterday
-    inactive_draft_theses = DraftThesis.drafts
-                                       .where('DATE(created_at) < DATE(?)', Date.yesterday).where(status: :inactive)
+    inactive_draft_theses = DraftThesis.where('DATE(created_at) < DATE(?)', Date.yesterday).where(status: :inactive)
     puts "Deleting #{inactive_draft_theses.count} Inactive Draft Theses..."
 
     # delete them all

--- a/test/controllers/admin/theses/draft_controller_test.rb
+++ b/test/controllers/admin/theses/draft_controller_test.rb
@@ -204,7 +204,7 @@ class Admin::Theses::DraftControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should not be able to create a draft thesis if not logged in' do
-    assert_no_difference('DraftThesis.drafts.count') do
+    assert_no_difference('DraftThesis.count') do
       assert_raises ActionController::RoutingError do
         post create_draft_admin_theses_url
       end
@@ -214,7 +214,7 @@ class Admin::Theses::DraftControllerTest < ActionDispatch::IntegrationTest
   test 'should not be able to create a draft thesis if not admin' do
     sign_in_as users(:regular)
 
-    assert_no_difference('DraftThesis.drafts.count') do
+    assert_no_difference('DraftThesis.count') do
       assert_raises ActionController::RoutingError do
         post create_draft_admin_theses_url
       end
@@ -224,12 +224,12 @@ class Admin::Theses::DraftControllerTest < ActionDispatch::IntegrationTest
   test 'should be able to create a draft thesis if logged in' do
     sign_in_as @admin
 
-    assert_difference('DraftThesis.drafts.count', 1) do
+    assert_difference('DraftThesis.count', 1) do
       post create_draft_admin_theses_url
     end
 
     assert_redirected_to admin_thesis_draft_path(id: :describe_thesis,
-                                                 thesis_id: DraftThesis.drafts.order(created_at: :asc).last.id)
+                                                 thesis_id: DraftThesis.order(created_at: :asc).last.id)
   end
 
   test 'other admins should be able to delete a draft thesis even if they do not own the thesis' do
@@ -237,7 +237,7 @@ class Admin::Theses::DraftControllerTest < ActionDispatch::IntegrationTest
 
     draft_thesis = draft_theses(:completed_choose_license_and_visibility_step)
 
-    assert_difference('DraftThesis.drafts.count', -1) do
+    assert_difference('DraftThesis.count', -1) do
       delete admin_thesis_delete_draft_url(thesis_id: draft_thesis.id)
     end
 
@@ -249,7 +249,7 @@ class Admin::Theses::DraftControllerTest < ActionDispatch::IntegrationTest
 
     draft_thesis = draft_theses(:completed_choose_license_and_visibility_step)
 
-    assert_difference('DraftThesis.drafts.count', -1) do
+    assert_difference('DraftThesis.count', -1) do
       delete admin_thesis_delete_draft_url(thesis_id: draft_thesis.id)
     end
 

--- a/test/controllers/items/draft_controller_test.rb
+++ b/test/controllers/items/draft_controller_test.rb
@@ -212,7 +212,7 @@ class Items::DraftControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should not be able to create a draft item if not logged in' do
-    assert_no_difference('DraftItem.drafts.count') do
+    assert_no_difference('DraftItem.count') do
       post create_draft_items_url
     end
     assert_redirected_to root_url
@@ -221,10 +221,10 @@ class Items::DraftControllerTest < ActionDispatch::IntegrationTest
   test 'should be able to create a draft item if logged in' do
     sign_in_as @user
 
-    assert_difference('DraftItem.drafts.count', 1) do
+    assert_difference('DraftItem.count', 1) do
       post create_draft_items_url
     end
-    assert_redirected_to item_draft_path(id: :describe_item, item_id: DraftItem.drafts.order(created_at: :asc).last.id)
+    assert_redirected_to item_draft_path(id: :describe_item, item_id: DraftItem.order(created_at: :asc).last.id)
   end
 
   test 'should not be able to delete a draft item if you do not own the item' do
@@ -232,7 +232,7 @@ class Items::DraftControllerTest < ActionDispatch::IntegrationTest
 
     draft_item = draft_items(:completed_choose_license_and_visibility_step)
 
-    assert_no_difference('DraftItem.drafts.count') do
+    assert_no_difference('DraftItem.count') do
       delete item_delete_draft_url(item_id: draft_item.id)
     end
 
@@ -245,7 +245,7 @@ class Items::DraftControllerTest < ActionDispatch::IntegrationTest
 
     draft_item = draft_items(:completed_choose_license_and_visibility_step)
 
-    assert_difference('DraftItem.drafts.count', -1) do
+    assert_difference('DraftItem.count', -1) do
       delete item_delete_draft_url(item_id: draft_item.id)
     end
 

--- a/test/controllers/items_controller_test.rb
+++ b/test/controllers/items_controller_test.rb
@@ -47,12 +47,12 @@ class ItemsControllerTest < ActionDispatch::IntegrationTest
     sign_in_as @admin
     # test editing of an item.
     get edit_item_url(@item)
-    draft_item = DraftItem.drafts.find_by(uuid: @item.id)
+    draft_item = DraftItem.find_by(uuid: @item.id)
     assert_redirected_to item_draft_path(id: Wicked::FIRST_STEP, item_id: draft_item.id)
 
     # test editing of a thesis.
     get edit_item_url(@thesis)
-    draft_thesis = DraftThesis.drafts.find_by(uuid: @thesis.id)
+    draft_thesis = DraftThesis.find_by(uuid: @thesis.id)
     assert_redirected_to admin_thesis_draft_path(id: Wicked::FIRST_STEP, thesis_id: draft_thesis.id)
   end
 

--- a/test/fixtures/draft_items.yml
+++ b/test/fixtures/draft_items.yml
@@ -1,6 +1,5 @@
 inactive:
   user: regular
-  is_published_in_era: false
 
 completed_describe_item_step:
   user: regular
@@ -18,7 +17,6 @@ completed_describe_item_step:
     a genuine masterpiece, bringing together the best the genre has to offer. Mystery, intrigue,
     romance, and adventure fill the pages of this magnificent saga, the first volume in an epic
     series sure to delight fantasy fans everywhere.'
-  is_published_in_era: false
 
 completed_choose_license_and_visibility_step:
   user: regular
@@ -39,4 +37,3 @@ completed_choose_license_and_visibility_step:
   license_text_area: 'Copyright license goes here'
   visibility: <%= DraftItem.visibilities[:embargo] %>
   embargo_end_date: <%= Date.current + 5.year %>
-  is_published_in_era: false

--- a/test/fixtures/draft_theses.yml
+++ b/test/fixtures/draft_theses.yml
@@ -1,6 +1,5 @@
 inactive:
   user: admin
-  is_published_in_era: false
 
 completed_describe_thesis_step:
   user: admin
@@ -14,7 +13,6 @@ completed_describe_thesis_step:
     'Doggo ipsum long woofer much ruin diet waggy wags borkdrive, pupper doggo long doggo,
     such treat doggorino. Most angery pupper I have ever seen thicc long woofer much ruin
     diet borkf heckin corgo, fat boi heckin good boys and girls super chub heck.'
-  is_published_in_era: false
 
 completed_choose_license_and_visibility_step:
   user: admin
@@ -33,4 +31,3 @@ completed_choose_license_and_visibility_step:
   visibility: <%= DraftThesis.visibilities[:embargo] %>
   embargo_end_date: <%= Date.current + 5.year %>
   rights: 'License text goes here'
-  is_published_in_era: false

--- a/test/models/draft_item_test.rb
+++ b/test/models/draft_item_test.rb
@@ -23,20 +23,20 @@ class DraftItemTest < ActiveSupport::TestCase
   end
 
   test 'should not be able to create a draft item without user' do
-    draft_item = DraftItem.drafts.new
+    draft_item = DraftItem.new
     assert_not draft_item.valid?
     assert_equal 'User must exist', draft_item.errors.full_messages.first
   end
 
   test 'should be able to create a draft item with user when on inactive status' do
     user = users(:regular)
-    draft_item = DraftItem.drafts.new(user: user)
+    draft_item = DraftItem.new(user: user)
     assert draft_item.valid?
   end
 
   test 'should run validations when on describe_item step' do
     user = users(:regular)
-    draft_item = DraftItem.drafts.new(user: user, status: DraftItem.statuses[:active])
+    draft_item = DraftItem.new(user: user, status: DraftItem.statuses[:active])
     assert_not draft_item.valid?
 
     draft_item.assign_attributes(
@@ -55,7 +55,7 @@ class DraftItemTest < ActiveSupport::TestCase
   test 'should run validations when on choose_license_and_visibility wizard step' do
     user = users(:regular)
 
-    draft_item = DraftItem.drafts.new(
+    draft_item = DraftItem.new(
       user: user,
       status: DraftItem.statuses[:active],
       wizard_step: DraftItem.wizard_steps[:choose_license_and_visibility],
@@ -118,7 +118,7 @@ class DraftItemTest < ActiveSupport::TestCase
   test 'should handle license text validations' do
     user = users(:regular)
 
-    draft_item = DraftItem.drafts.new(
+    draft_item = DraftItem.new(
       user: user,
       status: DraftItem.statuses[:active],
       wizard_step: DraftItem.wizard_steps[:choose_license_and_visibility],
@@ -144,7 +144,7 @@ class DraftItemTest < ActiveSupport::TestCase
   test 'should handle embargo end date visibility validations' do
     user = users(:regular)
 
-    draft_item = DraftItem.drafts.new(
+    draft_item = DraftItem.new(
       user: user,
       status: DraftItem.statuses[:active],
       wizard_step: DraftItem.wizard_steps[:choose_license_and_visibility],
@@ -171,7 +171,7 @@ class DraftItemTest < ActiveSupport::TestCase
   test 'should handle community/collection validations on member_of_paths' do
     user = users(:regular)
 
-    draft_item = DraftItem.drafts.new(
+    draft_item = DraftItem.new(
       user: user,
       status: DraftItem.statuses[:active],
       title: 'Book of Random',
@@ -225,7 +225,7 @@ class DraftItemTest < ActiveSupport::TestCase
   test '#strip_input_fields should strip empty strings from array fields' do
     user = users(:regular)
 
-    draft_item = DraftItem.drafts.new(
+    draft_item = DraftItem.new(
       user: user,
       status: DraftItem.statuses[:active],
       title: 'Book of Random',

--- a/test/models/draft_thesis_test.rb
+++ b/test/models/draft_thesis_test.rb
@@ -20,20 +20,20 @@ class DraftThesisTest < ActiveSupport::TestCase
   end
 
   test 'should not be able to create a draft thesis without user' do
-    draft_thesis = DraftThesis.drafts.new
+    draft_thesis = DraftThesis.new
     assert_not draft_thesis.valid?
     assert_equal 'User must exist', draft_thesis.errors.full_messages.first
   end
 
   test 'should be able to create a draft thesis with user when on inactive status' do
     user = users(:admin)
-    draft_thesis = DraftThesis.drafts.new(user: user)
+    draft_thesis = DraftThesis.new(user: user)
     assert draft_thesis.valid?
   end
 
   test 'should run validations when on describe_item step' do
     user = users(:admin)
-    draft_thesis = DraftThesis.drafts.new(user: user, status: DraftThesis.statuses[:active])
+    draft_thesis = DraftThesis.new(user: user, status: DraftThesis.statuses[:active])
 
     assert_not draft_thesis.valid?
     assert_equal 5, draft_thesis.errors.full_messages.count
@@ -53,7 +53,7 @@ class DraftThesisTest < ActiveSupport::TestCase
   test 'should run validations when on choose_license_and_visibility wizard step' do
     user = users(:admin)
 
-    draft_thesis = DraftThesis.drafts.new(
+    draft_thesis = DraftThesis.new(
       user: user,
       status: DraftThesis.statuses[:active],
       wizard_step: DraftThesis.wizard_steps[:choose_license_and_visibility],
@@ -114,7 +114,7 @@ class DraftThesisTest < ActiveSupport::TestCase
   test 'should handle embargo end date visibility validations' do
     user = users(:admin)
 
-    draft_thesis = DraftThesis.drafts.new(
+    draft_thesis = DraftThesis.new(
       user: user,
       status: DraftThesis.statuses[:active],
       wizard_step: DraftThesis.wizard_steps[:choose_license_and_visibility],
@@ -141,7 +141,7 @@ class DraftThesisTest < ActiveSupport::TestCase
   test 'should handle community/collection validations on member_of_paths' do
     user = users(:admin)
 
-    draft_thesis = DraftThesis.drafts.new(
+    draft_thesis = DraftThesis.new(
       user: user,
       status: DraftThesis.statuses[:active],
       title: 'Thesis of Random',
@@ -174,7 +174,7 @@ class DraftThesisTest < ActiveSupport::TestCase
   test 'regular user cannot deposit' do
     user = users(:regular)
 
-    draft_thesis = DraftThesis.drafts.new(
+    draft_thesis = DraftThesis.new(
       user: user,
       status: DraftThesis.statuses[:active],
       title: 'Thesis of Random',
@@ -195,7 +195,7 @@ class DraftThesisTest < ActiveSupport::TestCase
                                                    owner_id: users(:admin).id,
                                                    community_id: @community.id)
 
-    draft_thesis = DraftThesis.drafts.new(
+    draft_thesis = DraftThesis.new(
       user: user,
       status: DraftThesis.statuses[:active],
       title: 'Thesis of Random',
@@ -214,7 +214,7 @@ class DraftThesisTest < ActiveSupport::TestCase
 
   test 'parse_graduation_term_from_fedora works correctly' do
     user = users(:admin)
-    draft_thesis = DraftThesis.drafts.new(user: user)
+    draft_thesis = DraftThesis.new(user: user)
 
     assert_equal '11', draft_thesis.send(:parse_graduation_term_from_fedora, '2018-11')
     assert_equal '06', draft_thesis.send(:parse_graduation_term_from_fedora, '2018-06')
@@ -226,7 +226,7 @@ class DraftThesisTest < ActiveSupport::TestCase
   test 'should handle thesis description validations' do
     user = users(:admin)
 
-    draft_thesis = DraftThesis.drafts.new(
+    draft_thesis = DraftThesis.new(
       user: user,
       status: DraftThesis.statuses[:active],
       wizard_step: DraftThesis.wizard_steps[:choose_license_and_visibility],

--- a/test/system/thumbnail_resetting_test.rb
+++ b/test/system/thumbnail_resetting_test.rb
@@ -24,7 +24,7 @@ class ThumbnailResettingTest < ApplicationSystemTestCase
 
     click_on I18n.t('edit')
     # Thumbnail set as first attachment by default.
-    first_thumbnail_id = DraftItem.drafts.find_by(uuid: item.id).thumbnail_id
+    first_thumbnail_id = DraftItem.find_by(uuid: item.id).thumbnail_id
     click_on I18n.t('items.draft.save_and_continue')
     click_on I18n.t('items.draft.save_and_continue')
     click_on 'Set as Thumbnail'
@@ -34,7 +34,7 @@ class ThumbnailResettingTest < ApplicationSystemTestCase
 
     click_on I18n.t('edit')
     # Thumbnail set as second attachment.
-    second_thumbnail_id = DraftItem.drafts.find_by(uuid: item.id).thumbnail_id
+    second_thumbnail_id = DraftItem.find_by(uuid: item.id).thumbnail_id
     click_on I18n.t('items.draft.save_and_continue')
     click_on I18n.t('items.draft.save_and_continue')
     click_on I18n.t('items.draft.save_and_continue')
@@ -43,7 +43,7 @@ class ThumbnailResettingTest < ApplicationSystemTestCase
 
     click_on I18n.t('edit')
     # Thumbnail still set as second attachment.
-    third_thumbnail_id = DraftItem.drafts.find_by(uuid: item.id).thumbnail_id
+    third_thumbnail_id = DraftItem.find_by(uuid: item.id).thumbnail_id
     click_on I18n.t('items.draft.save_and_continue')
     click_on I18n.t('items.draft.save_and_continue')
     click_on I18n.t('items.draft.save_and_continue')


### PR DESCRIPTION
Wraps up work needed for #1614 (from findings #1556 )

No longer need `is_published_in_era` and `.drafts` scope. This PR removes this stuff from Jupiter