### PR TITLE
#1625: Check attachment association count instead of ActiveStorage model count

### DIFF
--- a/test/controllers/admin/theses/files_controller_test.rb
+++ b/test/controllers/admin/theses/files_controller_test.rb
@@ -24,9 +24,9 @@ class Admin::Theses::FilesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should be able to attach files to a draft thesis' do
-    assert_difference('ActiveStorage::Attachment.count', 1) do
-      post admin_thesis_files_url(@draft_thesis), params: { file: @file_attachment }, xhr: true
-    end
+    assert_equal 1, @draft_thesis.files.count
+
+    post admin_thesis_files_url(@draft_thesis), params: { file: @file_attachment }, xhr: true
 
     assert_response :success
 
@@ -39,9 +39,9 @@ class Admin::Theses::FilesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should be able to remove files from a draft thesis' do
-    assert_difference('ActiveStorage::Attachment.count', -1) do
-      delete admin_thesis_file_url(@draft_thesis, @draft_thesis.files.first), xhr: true
-    end
+    assert_equal 1, @draft_thesis.files.count
+
+    delete admin_thesis_file_url(@draft_thesis, @draft_thesis.files.first), xhr: true
 
     assert_response :success
 

--- a/test/controllers/admin/theses/files_controller_test.rb
+++ b/test/controllers/admin/theses/files_controller_test.rb
@@ -24,31 +24,28 @@ class Admin::Theses::FilesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should be able to attach files to a draft thesis' do
-    assert_equal 1, @draft_thesis.files.count
-
-    post admin_thesis_files_url(@draft_thesis), params: { file: @file_attachment }, xhr: true
+    assert_difference('@draft_thesis.files.count', 1) do
+      post admin_thesis_files_url(@draft_thesis), params: { file: @file_attachment }, xhr: true
+    end
 
     assert_response :success
 
     @draft_thesis.reload
 
     assert @draft_thesis.files.attached?
-    assert_equal 2, @draft_thesis.files.count
     assert_equal 'pdf-sample.pdf', @draft_thesis.files.first.filename.to_s
     assert_equal 'image-sample.jpeg', @draft_thesis.files.last.filename.to_s
   end
 
   test 'should be able to remove files from a draft thesis' do
-    assert_equal 1, @draft_thesis.files.count
-
-    delete admin_thesis_file_url(@draft_thesis, @draft_thesis.files.first), xhr: true
+    assert_difference('@draft_thesis.files.count', -1) do
+      delete admin_thesis_file_url(@draft_thesis, @draft_thesis.files.first), xhr: true
+    end
 
     assert_response :success
 
     @draft_thesis.reload
-
     assert_not @draft_thesis.files.attached?
-    assert_equal 0, @draft_thesis.files.count
   end
 
   test 'should be able to toggle the selection of the draft theses thumbnail' do

--- a/test/controllers/items/files_controller_test.rb
+++ b/test/controllers/items/files_controller_test.rb
@@ -24,9 +24,9 @@ class Items::FilesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should be able to attach files to a draft item' do
-    assert_difference('ActiveStorage::Attachment.count', 1) do
-      post item_files_url(@draft_item), params: { file: @file_attachment }, xhr: true
-    end
+    assert_equal 1, @draft_item.files.count
+
+    post item_files_url(@draft_item), params: { file: @file_attachment }, xhr: true
 
     assert_response :success
 
@@ -39,9 +39,9 @@ class Items::FilesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should be able to remove files from a draft item' do
-    assert_difference('ActiveStorage::Attachment.count', -1) do
-      delete item_file_url(@draft_item, @draft_item.files.first), xhr: true
-    end
+    assert_equal 1, @draft_item.files.count
+
+    delete item_file_url(@draft_item, @draft_item.files.first), xhr: true
 
     assert_response :success
 

--- a/test/controllers/items/files_controller_test.rb
+++ b/test/controllers/items/files_controller_test.rb
@@ -24,31 +24,27 @@ class Items::FilesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should be able to attach files to a draft item' do
-    assert_equal 1, @draft_item.files.count
-
-    post item_files_url(@draft_item), params: { file: @file_attachment }, xhr: true
-
+    assert_difference('@draft_item.files.count', 1) do
+      post item_files_url(@draft_item), params: { file: @file_attachment }, xhr: true
+    end
     assert_response :success
 
     @draft_item.reload
 
     assert @draft_item.files.attached?
-    assert_equal 2, @draft_item.files.count
     assert_equal 'pdf-sample.pdf', @draft_item.files.first.filename.to_s
     assert_equal 'image-sample.jpeg', @draft_item.files.last.filename.to_s
   end
 
   test 'should be able to remove files from a draft item' do
-    assert_equal 1, @draft_item.files.count
-
-    delete item_file_url(@draft_item, @draft_item.files.first), xhr: true
+    assert_difference('@draft_item.files.count', -1) do
+      delete item_file_url(@draft_item, @draft_item.files.first), xhr: true
+    end
 
     assert_response :success
 
     @draft_item.reload
-
     assert_not @draft_item.files.attached?
-    assert_equal 0, @draft_item.files.count
   end
 
   test 'should be able to toggle the selection of the draft items thumbnail' do


### PR DESCRIPTION
#1625

Hopefully this help reduce flakey test behaviour for team members
