### PR TITLE
#1611: Refactor inactive draft cleanup rake task to be a sidekiq cron…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and releases in Jupiter project adheres to [Semantic Versioning](http://semver.o
 - Transition to Webpacker from Sprockets [#1431](https://github.com/ualbertalib/jupiter/issues/1431)
 - Post Fedora Automated Test Cleanup [#1445](https://github.com/ualbertalib/jupiter/issues/1445)
 - Update UAL Logo [#1616](https://github.com/ualbertalib/jupiter/issues/1616)
+- Refactor `inactive` draft cleanup rake task to be sidekiq cron job [#1611](https://github.com/ualbertalib/jupiter/issues/1611)
 
 ### Fixed
 - failing tests [#1376](https://github.com/ualbertalib/jupiter/issues/1376)

--- a/app/jobs/remove_inactive_drafts_job.rb
+++ b/app/jobs/remove_inactive_drafts_job.rb
@@ -1,0 +1,25 @@
+class RemoveInactiveDraftsJob < ApplicationJob
+
+  # Deposit Wizard has potential of leaving stale inactive draft objects around,
+  # For example if someone goes to the deposit screen and then leaves,
+  # a draft object gets created and left in an inactive state.
+  # This job will cleanup these inactive draft objects
+  #
+  # We will queue this job via sidekiq-cron once a week to remove any
+  # stale inactive drafts from the database
+
+  queue_as :default
+
+  def perform
+    # Find all the inactive draft items older than yesterday
+    inactive_draft_items = DraftItem.where('DATE(created_at) < DATE(?)', Date.yesterday).where(status: :inactive)
+    # delete them all
+    inactive_draft_items.destroy_all
+
+    # Find all the inactive draft theses older than yesterday
+    inactive_draft_theses = DraftThesis.where('DATE(created_at) < DATE(?)', Date.yesterday).where(status: :inactive)
+    # delete them all
+    inactive_draft_theses.destroy_all
+  end
+
+end

--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -1,9 +1,16 @@
 # NOTE: Time in this file is in Coordinated Universal Time (UTC). So you must convert your local time into UTC.
 # For example, if you want a job to run at 10 PM MDT, this should be defined in the cron as 4 AM UTC.
 check_embargo_expiry:
+  # Every day at 10 PM MDT
   cron: "0 4 * * *"
   class: "EmbargoExpiryJob"
 
 garbage_collect_orphan_blobs:
+  # Every Sunday at 11 PM MDT
   cron: "0 5 * * 0"
   class: "GarbageCollectBlobsJob"
+
+remove_inactive_drafts:
+  # Every Saturday at 11 PM MDT
+  cron: "0 4 * * 6"
+  class: "RemoveInactiveDraftsJob"

--- a/lib/tasks/jupiter.rake
+++ b/lib/tasks/jupiter.rake
@@ -1,27 +1,4 @@
 namespace :jupiter do
-  # Wizard has potential of leaving stale inactive draft items around,
-  # For example if someone goes to the deposit screen and then leaves
-  # a draft item gets created and left in an inactive state.
-  # This rake task is to cleanup these inactive draft items
-  desc 'removes stale inactive drafts from the database'
-  task remove_inactive_drafts: :environment do
-    # Find all the inactive draft items older than yesterday
-    inactive_draft_items = DraftItem.where('DATE(created_at) < DATE(?)', Date.yesterday).where(status: :inactive)
-    puts "Deleting #{inactive_draft_items.count} Inactive Draft Items..."
-
-    # delete them all
-    inactive_draft_items.destroy_all
-
-    # Find all the inactive draft theses older than yesterday
-    inactive_draft_theses = DraftThesis.where('DATE(created_at) < DATE(?)', Date.yesterday).where(status: :inactive)
-    puts "Deleting #{inactive_draft_theses.count} Inactive Draft Theses..."
-
-    # delete them all
-    inactive_draft_theses.destroy_all
-
-    puts 'Cleanup of Inactive Draft Items and Draft Theses now completed!'
-  end
-
   desc 'fetch and unlock every object then save'
   task :reindex, [:batch_size] => :environment do |_, args|
     desired_batch_size = args.batch_size.to_i ||= 1000


### PR DESCRIPTION
New job under cron here:
![image](https://user-images.githubusercontent.com/1930474/81120663-6cf97280-8eea-11ea-89e9-74b0aab335a0.png)

Tested this on dev (created a few Inactive DraftItems (by clicking on Deposit link), back dated one of them to a few days ago, ran job from sidekiq dashboard and checked DraftItem counts before and after and all looks good)