### PR TITLE
Added active storage queues to sidekiq configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and releases in Jupiter project adheres to [Semantic Versioning](http://semver.o
 - Metadata Presenters for OAI:DC & OAI:ETDMS
 - Local system accounts authentication
 - Bring in ERBLint [PR#1646](https://github.com/ualbertalib/jupiter/pull/1646)
+- Rails 6 sidekiq queues
 
 ### Changed
 - bump rubocop-rails to 2.4.1 Rails/FilePath default changed to slashes [PR#1398](https://github.com/ualbertalib/jupiter/pull/1398)

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -2,8 +2,12 @@
 :concurrency: 5
 :pidfile: tmp/pids/sidekiq.pid
 :queues:
-  - default
-  - mailers
+ - critical
+ - default
+ - active_storage_analysis
+ - active_storage_purge
+ - mailers
+ - low
 development:
   :logfile: log/sidekiq_development.log
 uat:


### PR DESCRIPTION
## Context

When I was depositing items I was finding that a active_storage_analysis queue was filling up but not being processed.

https://mikerogers.io/2019/06/06/rails-6-sidekiq-queues.html describes some new queue names in Rails 6 for ActiveStorage.

I've added the ones that make sense to me.

Note that this doesn't resolve the "This file is processing and will be available shortly" message for deposited items like I had hoped it would.

## What's New

Add `active_storage_analysis` and `active_storage_purge` queues to sidekiq config.  I also added `critical` and `low` but less certain if they'll actually be used by our application at any point.