### PR TITLE
#1405: Center align feature images within sidebar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ and releases in Jupiter project adheres to [Semantic Versioning](http://semver.o
 - Post Fedora Automated Test Cleanup [#1445](https://github.com/ualbertalib/jupiter/issues/1445)
 - Update UAL Logo [#1616](https://github.com/ualbertalib/jupiter/issues/1616)
 - Refactor `inactive` draft cleanup rake task to be sidekiq cron job [#1611](https://github.com/ualbertalib/jupiter/issues/1611)
+- Feature Image on Item show page need to be centered align within column [#1405](https://github.com/ualbertalib/jupiter/issues/1405)
+
 
 ### Fixed
 - failing tests [#1376](https://github.com/ualbertalib/jupiter/issues/1376)

--- a/app/views/items/_files_section_sidebar.html.erb
+++ b/app/views/items/_files_section_sidebar.html.erb
@@ -1,88 +1,92 @@
-<%= render partial: 'feature_image', locals: { object: @item } %>
+<div class="mb-3">
+  <div class="d-flex justify-content-center">
+    <%= render partial: 'feature_image', locals: { object: @item } %>
+  </div>
 
-<% if policy(@item).download? %>
-  <% if @item.files.count == 1 %>
-    <% file = @item.files.first %>
-    <% if file.present? && file.fileset_uuid.present? %>
-      <div class="d-flex justify-content-center mt-3">
-        <div class="p-1">
-          <%= link_to(t('.view'),
-                      file_view_item_url(id: file.record.id,
-                                         file_set_id: file.fileset_uuid,
-                                         file_name: file.filename.to_s),
-                      class: 'btn btn-outline-primary',
-                      rel: 'noopener noreferrer',
-                      target: :_blank) %>
+  <% if policy(@item).download? %>
+    <% if @item.files.count == 1 %>
+      <% file = @item.files.first %>
+      <% if file.present? && file.fileset_uuid.present? %>
+        <div class="d-flex justify-content-center mt-3">
+          <div class="p-1">
+            <%= link_to(t('.view'),
+                        file_view_item_url(id: file.record.id,
+                                           file_set_id: file.fileset_uuid,
+                                           file_name: file.filename.to_s),
+                        class: 'btn btn-outline-primary',
+                        rel: 'noopener noreferrer',
+                        target: :_blank) %>
+          </div>
+          <div class="p-1">
+            <%= link_to(t('.download'),
+                        file_download_item_url(id: file.record.id,
+                                               file_set_id: file.fileset_uuid),
+                        class: 'btn btn-outline-primary',
+                        rel: 'nofollow',
+                        download: file.filename) %>
+          </div>
         </div>
-        <div class="p-1">
-          <%= link_to(t('.download'),
-                      file_download_item_url(id: file.record.id,
-                                             file_set_id: file.fileset_uuid),
-                      class: 'btn btn-outline-primary',
-                      rel: 'nofollow',
-                      download: file.filename) %>
+      <% else %>
+        <h4 class="mt-3"><%= t('.header') %></h4>
+        <div class="list-group item-files">
+          <div class="list-group-item list-group-item-action d-flex flex-column">
+            <div class="item-filename text-center pb-3"><%= file.filename %></div>
+            <div class="d-flex justify-content-center">
+              <div class="text-center pb-3">
+                <%= t('.processing') %>
+              </div>
+            </div>
+          </div>
         </div>
-      </div>
+      <% end %>
     <% else %>
       <h4 class="mt-3"><%= t('.header') %></h4>
       <div class="list-group item-files">
-        <div class="list-group-item list-group-item-action d-flex flex-column">
-          <div class="item-filename text-center pb-3"><%= file.filename %></div>
-          <div class="d-flex justify-content-center">
-            <div class="text-center pb-3">
-              <%= t('.processing') %>
-            </div>
+        <% @item.files.each do |file| %>
+          <div class="list-group-item list-group-item-action d-flex flex-column">
+            <div class="item-filename text-center pb-3"><%= file.filename %></div>
+            <% if file.fileset_uuid.present? %>
+              <div class="d-flex justify-content-center">
+                <div class="p-1">
+                  <%= link_to(t('.view'),
+                              file_view_item_url(id: file.record.id,
+                                                 file_set_id: file.fileset_uuid,
+                                                 file_name: file.filename.to_s),
+                              class: 'btn btn-outline-primary',
+                              rel: 'noopener noreferrer',
+                              target: :_blank) %>
+                </div>
+                <div class="p-1">
+                  <%= link_to(t('.download'),
+                              file_download_item_url(id: file.record.id,
+                                                     file_set_id: file.fileset_uuid),
+                              class: 'js-download btn btn-outline-primary',
+                              rel: 'nofollow',
+                              download: file.filename) %>
+                </div>
+              </div>
+            <% else %>
+              <div class="d-flex justify-content-center">
+                <div class="text-center pb-3">
+                  <%= t('.processing') %>
+                </div>
+              </div>
+            <% end %>
           </div>
+        <% end %>
+        <div class="pt-3">
+          <% unless @item.files.any? {|file| file.fileset_uuid.blank?} %>
+            <button type="button" class="js-download-all btn btn-outline-primary float-right">
+              <%= t('.download_all') %>
+            </button>
+          <% end %>
         </div>
       </div>
     <% end %>
   <% else %>
-    <h4 class="mt-3"><%= t('.header') %></h4>
-    <div class="list-group item-files">
-      <% @item.files.each do |file| %>
-        <div class="list-group-item list-group-item-action d-flex flex-column">
-          <div class="item-filename text-center pb-3"><%= file.filename %></div>
-          <% if file.fileset_uuid.present? %>
-            <div class="d-flex justify-content-center">
-              <div class="p-1">
-                <%= link_to(t('.view'),
-                            file_view_item_url(id: file.record.id,
-                                               file_set_id: file.fileset_uuid,
-                                               file_name: file.filename.to_s),
-                            class: 'btn btn-outline-primary',
-                            rel: 'noopener noreferrer',
-                            target: :_blank) %>
-              </div>
-              <div class="p-1">
-                <%= link_to(t('.download'),
-                            file_download_item_url(id: file.record.id,
-                                                   file_set_id: file.fileset_uuid),
-                            class: 'js-download btn btn-outline-primary',
-                            rel: 'nofollow',
-                            download: file.filename) %>
-              </div>
-            </div>
-          <% else %>
-            <div class="d-flex justify-content-center">
-              <div class="text-center pb-3">
-                 <%= t('.processing') %>
-              </div>
-            </div>
-          <% end %>
-        </div>
-      <% end %>
-      <div class="pt-3">
-        <% unless @item.files.any? {|file| file.fileset_uuid.blank?} %>
-          <button type="button" class="js-download-all btn btn-outline-primary float-right">
-            <%= t('.download_all') %>
-          </button>
-        <% end %>
-      </div>
+    <div class="col text-center mt-3">
+      <p><%= t('.ccid_restricted_item') %></p>
+      <%= link_to t('.login_with_ccid_to_view'), '/auth/saml', class: 'btn btn-block btn-outline-primary', method: :post %>
     </div>
   <% end %>
-<% else %>
-  <div class="col text-center mt-3">
-    <p><%= t('.ccid_restricted_item') %></p>
-    <%= link_to t('.login_with_ccid_to_view'), '/auth/saml', class: 'btn btn-block btn-outline-primary', method: :post %>
-  </div>
-<% end %>
+</div>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -38,9 +38,7 @@
     <div class="col-md-4 mt-5">
       <%# FILES SIDEBAR %>
       <% if @item.files.present? %>
-        <div class="mb-3">
-          <%= render partial: 'files_section_sidebar' %>
-        </div>
+        <%= render partial: 'files_section_sidebar' %>
       <% end %>
 
       <%# COMMUNITY/COLLECTION PATHS %>


### PR DESCRIPTION
#1405 

<img width="1182" alt="Screen Shot 2020-05-27 at 10 54 17 PM" src="https://user-images.githubusercontent.com/1930474/83179766-b438e480-a0df-11ea-8f2a-a229c6403376.png">


Couple of questions:

- We displaying this feature image as a "thumbnail" which has the following css:
  ```css
  .j-thumbnail {
      max-width: 135px;
      max-height: 175px;
  }
  ```
  But we have more real-estate to work with here? Should we increase the size of these feature 
  images on the show page, so users can view the image better? 

  This actually appears to be a regression. We were orginally styling them as feature images 
  before: https://github.com/ualbertalib/jupiter/blob/integration_postmigration/app/javascript/styles/image.scss#L6-L9. But when we added the fallback image, we changed everything to `j-thumbnail`


- For objects with multiple files, the files section looks quite a bit different then everything else in this sidebar. It be nice to keep this consistent with community/collections and usage cards and put the files section into a card component (card header is files and body contains all file objects with a download all button). Think this would greatly improve the look of the sidebar and keep it consistent with the facets sidebar on search index.

Both of the above questions have been broken out as issues now ( #1675  & #1676 )