### PR TITLE
Revert "Bump vcr from 5.0.0 to 6.0.0"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -110,7 +110,7 @@ group :test do
 
   gem 'json-schema', '~> 2.8.1'
   gem 'launchy'
-  gem 'vcr', '6.0.0', require: false
+  gem 'vcr', '5.0', require: false
   gem 'webdrivers', '~> 4.3'
   gem 'webmock', require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -458,7 +458,7 @@ GEM
       thread_safe (~> 0.1)
     unicode-display_width (1.7.0)
     uuidtools (2.1.5)
-    vcr (6.0.0)
+    vcr (5.0.0)
     voight_kampff (1.1.4)
       rack (>= 1.4, < 3.0)
     web-console (4.0.2)
@@ -554,7 +554,7 @@ DEPENDENCIES
   sinatra (~> 2.0.8)
   skylight
   uuidtools
-  vcr (= 6.0.0)
+  vcr (= 5.0)
   voight_kampff
   web-console (>= 3.3.0)
   webdrivers (~> 4.3)


### PR DESCRIPTION
Reverts ualbertalib/jupiter#1665

@murny a while back we chatted about if we are able to use VCR beyond 5.0 because it changed the the MIT-HIP licence. #1469

I should have told dependabot to ignore major versions too until we got legal feedback about this, but I only specified minor versions.