### PR TITLE
Bump kaminari version for CVE-2020-11082

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and releases in Jupiter project adheres to [Semantic Versioning](http://semver.o
 
 ## [1.2.21] – 2020–05-28
 - bump kaminari from 1.1.1 to 1.2.1 [CVE-2020-11082](https://github.com/advisories/GHSA-r5jw-62xg-j433)
+- take sidekiq-unique-jobs up to 6.0.22 to fix an issue with a yanked gem
 
 ## [1.2.20] - 2020-03-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and releases in Jupiter project adheres to [Semantic Versioning](http://semver.o
 
 ## [Unreleased]
 
+## [1.2.21] – 2020–05-28
+- bump kaminari from 1.1.1 to 1.2.1 [CVE-2020-11082](https://github.com/advisories/GHSA-r5jw-62xg-j433)
+
 ## [1.2.20] - 2020-03-03
 
 ### Security

--- a/Gemfile
+++ b/Gemfile
@@ -64,7 +64,7 @@ gem 'addressable', '~> 2.7.0' # Replacement for the standard URI implementation
 gem 'danger', '~> 6.1' # Pull Request etiquette enforcement
 gem 'ezid-client', '~> 1.8.0'
 gem 'jbuilder' # generate JSON objects
-gem 'kaminari' # Pagination
+gem 'kaminari', '>= 1.2.1' # Pagination
 gem 'ransack' # ActiveRecord search/filter
 gem 'voight_kampff' # bot detection
 gem 'wicked' # Multi-step wizard

--- a/Gemfile
+++ b/Gemfile
@@ -52,7 +52,7 @@ gem 'pundit', '1.1.0'
 
 # Background tasks
 gem 'sidekiq', '~> 5.2'
-gem 'sidekiq-unique-jobs'
+gem 'sidekiq-unique-jobs', '~> 6.0.22'
 gem 'sinatra', '~> 2.0.7' # used by sidekiq/web
 # Sidekiq cron jobs
 gem 'rufus-scheduler', '3.6.0' # https://github.com/ondrejbartas/sidekiq-cron/issues/199

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -219,18 +219,18 @@ GEM
     json-ld (3.0.2)
       multi_json (~> 1.12)
       rdf (>= 2.2.8, < 4.0)
-    kaminari (1.1.1)
+    kaminari (1.2.1)
       activesupport (>= 4.1.0)
-      kaminari-actionview (= 1.1.1)
-      kaminari-activerecord (= 1.1.1)
-      kaminari-core (= 1.1.1)
-    kaminari-actionview (1.1.1)
+      kaminari-actionview (= 1.2.1)
+      kaminari-activerecord (= 1.2.1)
+      kaminari-core (= 1.2.1)
+    kaminari-actionview (1.2.1)
       actionview
-      kaminari-core (= 1.1.1)
-    kaminari-activerecord (1.1.1)
+      kaminari-core (= 1.2.1)
+    kaminari-activerecord (1.2.1)
       activerecord
-      kaminari-core (= 1.1.1)
-    kaminari-core (1.1.1)
+      kaminari-core (= 1.2.1)
+    kaminari-core (1.2.1)
     kramdown (2.1.0)
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)
@@ -528,7 +528,7 @@ DEPENDENCIES
   image_processing
   jbuilder
   jquery-rails
-  kaminari
+  kaminari (>= 1.2.1)
   launchy
   listen (>= 3.0.5, < 3.3)
   minitest-hooks

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -429,7 +429,7 @@ GEM
     sidekiq-cron (1.1.0)
       fugit (~> 1.1)
       sidekiq (>= 4.2.1)
-    sidekiq-unique-jobs (6.0.15)
+    sidekiq-unique-jobs (6.0.22)
       concurrent-ruby (~> 1.0, >= 1.0.5)
       sidekiq (>= 4.0, < 7.0)
       thor (~> 0)
@@ -560,7 +560,7 @@ DEPENDENCIES
   shoulda-matchers (~> 4.1)
   sidekiq (~> 5.2)
   sidekiq-cron
-  sidekiq-unique-jobs
+  sidekiq-unique-jobs (~> 6.0.22)
   simple_form
   simplecov
   sinatra (~> 2.0.7)


### PR DESCRIPTION
## Context

https://github.com/advisories/GHSA-r5jw-62xg-j433

## What's New

Kaminari bumped to 1.2.1