### PR TITLE
centralize abstraction for thumbnail generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ and releases in Jupiter project adheres to [Semantic Versioning](http://semver.o
 - Update UAL Logo [#1616](https://github.com/ualbertalib/jupiter/issues/1616)
 - Refactor `inactive` draft cleanup rake task to be sidekiq cron job [#1611](https://github.com/ualbertalib/jupiter/issues/1611)
 - Feature Image on Item show page need to be centered align within column [#1405](https://github.com/ualbertalib/jupiter/issues/1405)
-
+- Centralize Abstraction for Thumbnail Generation [#1343](https://github.com/ualbertalib/jupiter/issues/1343)
 
 ### Fixed
 - failing tests [#1376](https://github.com/ualbertalib/jupiter/issues/1376)

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 - **PostgreSQL**
 - **Redis**
 - **Solr**
-- **ImageMagick**
+- **ImageMagick, Poppler, FFMpeg**
 - **Node.js** 10.13.0+
 - **Yarn**
 

--- a/app/models/community.rb
+++ b/app/models/community.rb
@@ -48,13 +48,6 @@ class Community < JupiterCore::Depositable
     logo_attachment.purge
   end
 
-  # compatibility with item thumbnail API
-  def thumbnail_path(args = { resize: '100x100', auto_orient: true })
-    return nil if logo_attachment.blank?
-
-    Rails.application.routes.url_helpers.rails_representation_path(logo_attachment.variant(args).processed)
-  end
-
   def thumbnail_file
     logo.attachment
   end

--- a/app/models/concerns/draft_properties.rb
+++ b/app/models/concerns/draft_properties.rb
@@ -50,19 +50,6 @@ module DraftProperties
       files.first
     end
 
-    # compatibility with the thumbnail API used in Items/Theses and Communities
-    def thumbnail_path(args = { resize: '100x100', auto_orient: true })
-      return nil unless thumbnail.present? && thumbnail.blob.present?
-
-      Rails.application.routes.url_helpers.rails_representation_path(thumbnail.variant(args).processed)
-    rescue ActiveStorage::InvariableError
-      begin
-        Rails.application.routes.url_helpers.rails_representation_path(thumbnail.preview(args).processed)
-      rescue ActiveStorage::UnpreviewableError
-        nil
-      end
-    end
-
     def thumbnail_file
       thumbnail if thumbnail.present? && thumbnail.blob.present?
     end

--- a/app/models/jupiter_core/depositable.rb
+++ b/app/models/jupiter_core/depositable.rb
@@ -104,19 +104,6 @@ class JupiterCore::Depositable < ApplicationRecord
   end
   # rubocop:enable Naming/AccessorMethodName
 
-  def thumbnail_path(args = { resize: '100x100', auto_orient: true })
-    logo = files.find_by(id: logo_id)
-    return nil if logo.blank?
-
-    Rails.application.routes.url_helpers.rails_representation_path(logo.variant(args).processed)
-  rescue ActiveStorage::InvariableError
-    begin
-      Rails.application.routes.url_helpers.rails_representation_path(logo.preview(args).processed)
-    rescue ActiveStorage::UnpreviewableError
-      nil
-    end
-  end
-
   def thumbnail_file
     files.find_by(id: logo_id)
   end

--- a/app/views/admin/theses/draft/_thumbnail.html.erb
+++ b/app/views/admin/theses/draft/_thumbnail.html.erb
@@ -1,18 +1,8 @@
-<% begin %>
-<%# NOTE: This is superficially similar to the logic in DraftItem#thumbnail, but this file is run against
-every file attached to an item via a JS callback rendering files/update_files_list.js.erb calling _files_list.html.erb
-whereas DraftItem#thumbnail specifically only deals with rendering the designated file for representing it as a
-thumbnail and is used on various other pages, like profiles, which use the application/_thumbnail partial.%>
-  <% thumbnail = rails_representation_path(file.variant(resize: '100x100', auto_orient: true).processed) %>
-  <%= safe_thumbnail_tag(thumbnail, alt: '', title: file.filename, size: '100x100') %>
-<% rescue  ActiveStorage::InvariableError %>
-  <% begin %>
-      <% thumbnail = rails_representation_path(file.preview(resize: '100x100', auto_orient: true).processed) %>
-      <%= safe_thumbnail_tag(thumbnail, alt: '', title: file.filename, size: '100x100') %>
-  <% rescue ActiveStorage::UnpreviewableError %>
-    <div class="text-muted text-center img-thumbnail p-3">
-      <%= icon('far', file_icon(file.content_type), class: 'fa-5x') %>
-      <span class="sr-only"><%= file.filename %></span>
-    </div>
-  <% end %>
+<% if thumbnail_path(file).present? %>
+  <%= safe_thumbnail_tag(thumbnail_path(file), alt: '', title: file.filename, size: '100x100') %>
+<% else %>
+  <div class="text-muted text-center img-thumbnail p-3">
+    <%= icon('far', file_icon(file.content_type), class: 'fa-5x') %>
+    <span class="sr-only"><%= file.filename %></span>
+  </div>
 <% end %>

--- a/app/views/application/_feature_image.html.erb
+++ b/app/views/application/_feature_image.html.erb
@@ -1,6 +1,6 @@
 <% if policy(object).thumbnail? %>
-  <% if object.thumbnail_path.present? %>
-    <%= safe_thumbnail_tag(object.thumbnail_path(resize: '350x350', auto_orient: true), alt: '', size: '350x350') %>
+  <% if thumbnail_path(object&.thumbnail_file).present? %>
+    <%= safe_thumbnail_tag(thumbnail_path(object&.thumbnail_file, resize: '350x350', auto_orient: true), alt: '', size: '350x350') %>
   <% else %>
     <div class="d-flex justify-content-center align-items-center img-thumbnail p-5">
       <%= icon('far', file_icon(object.thumbnail_file&.content_type), class: 'fa-5x text-muted') %>

--- a/app/views/application/_thumbnail.html.erb
+++ b/app/views/application/_thumbnail.html.erb
@@ -1,6 +1,6 @@
 <% if policy(object).thumbnail? %>
-  <% if object.thumbnail_path.present? %>
-    <%= safe_thumbnail_tag(object.thumbnail_path, alt: '', title: object.title, size: '100x100') %>
+  <% if thumbnail_path(object&.thumbnail_file).present? %>
+    <%= safe_thumbnail_tag(thumbnail_path(object&.thumbnail_file), alt: '', title: object.title, size: '100x100') %>
   <% else %>
     <% if object.is_a? Community %>
       <%= image_pack_tag('era-logo-without-text.png', class: 'j-thumbnail img-thumbnail', alt: '', title: object.title, size: '100x100') %>

--- a/app/views/items/draft/_thumbnail.html.erb
+++ b/app/views/items/draft/_thumbnail.html.erb
@@ -1,18 +1,8 @@
-<% begin %>
-<%# NOTE: This is superficially similar to the logic in DraftItem#thumbnail, but this file is run against
-every file attached to an item via a JS callback rendering files/update_files_list.js.erb calling _files_list.html.erb
-whereas DraftItem#thumbnail specifically only deals with rendering the designated file for representing it as a
-thumbnail and is used on various other pages, like profiles, which use the application/_thumbnail partial.%>
-  <% thumbnail = rails_representation_path(file.variant(resize: '100x100', auto_orient: true).processed) %>
-  <%= safe_thumbnail_tag(thumbnail, alt: '', title: file.filename, size: '100x100') %>
-<% rescue  ActiveStorage::InvariableError %>
-  <% begin %>
-      <% thumbnail = rails_representation_path(file.preview(resize: '100x100', auto_orient: true).processed) %>
-      <%= safe_thumbnail_tag(thumbnail, alt: '', title: file.filename, size: '100x100') %>
-  <% rescue ActiveStorage::UnpreviewableError %>
-    <div class="text-muted text-center img-thumbnail p-3">
-      <%= icon('far', file_icon(file.content_type), class: 'fa-5x') %>
-      <span class="sr-only"><%= file.filename %></span>
-    </div>
-  <% end %>
+<% if thumbnail_path(file).present? %>
+  <%= safe_thumbnail_tag(thumbnail_path(file), alt: '', title: file.filename, size: '100x100') %>
+<% else %>
+  <div class="text-muted text-center img-thumbnail p-3">
+    <%= icon('far', file_icon(file.content_type), class: 'fa-5x') %>
+    <span class="sr-only"><%= file.filename %></span>
+  </div>
 <% end %>

--- a/test/fixtures/active_storage/attachments.yml
+++ b/test/fixtures/active_storage/attachments.yml
@@ -1,0 +1,5 @@
+logo:
+  name: 'files'
+  record_type: 'Item'
+  record_id: <%= ActiveRecord::FixtureSet.identify(:fancy) %>
+  blob_id: <%= ActiveRecord::FixtureSet.identify(:jpeg) %>

--- a/test/fixtures/active_storage/blobs.yml
+++ b/test/fixtures/active_storage/blobs.yml
@@ -1,0 +1,6 @@
+jpeg:
+  key: '12345'
+  filename: 'image-sample.jpeg'
+  content_type: 'image/jpeg'
+  byte_size: 12086
+  checksum: "GxpIjJsC4KnRoBKNjWnkJA=="

--- a/test/helpers/page_layout_helper_test.rb
+++ b/test/helpers/page_layout_helper_test.rb
@@ -16,7 +16,6 @@ class PageLayoutHelperTest < ActionView::TestCase
 
   # page_title
 
-  # page_title
   test 'should return the page title when given one' do
     assert_equal t('site_name'), page_title(t('site_name'))
   end
@@ -93,8 +92,93 @@ class PageLayoutHelperTest < ActionView::TestCase
     @community.logo.attach io: File.open(file_fixture('image-sample.jpeg')),
                            filename: 'image-sample.jpeg', content_type: 'image/jpeg'
 
-    assert_equal page_image_url, request.base_url + @community.thumbnail_path
+    assert_equal page_image_url, request.base_url + thumbnail_path(@community.thumbnail_file)
   end
+
+  # thumbnail_path
+
+  test 'thumbnail_path should return preview for pdf (Invariable but Previewable)' do
+    community = communities(:books)
+    collection = collections(:fantasy_books)
+    @item = Item.new.tap do |uo|
+      uo.title = 'Fantastic item'
+      uo.owner_id = users(:admin).id
+      uo.creators = ['Joe Blow', 'Smokey Chantilly-Tiffany', 'Céline Marie Claudette Dion']
+      uo.visibility = JupiterCore::VISIBILITY_PUBLIC
+      uo.created = '1999-09-09'
+      uo.languages = [CONTROLLED_VOCABULARIES[:language].english]
+      uo.license = CONTROLLED_VOCABULARIES[:license].attribution_4_0_international
+      uo.item_type = CONTROLLED_VOCABULARIES[:item_type].article
+      uo.publication_status = [CONTROLLED_VOCABULARIES[:publication_status].draft,
+                               CONTROLLED_VOCABULARIES[:publication_status].submitted]
+      uo.subject = ['Items']
+      uo.add_to_path(community.id, collection.id)
+      uo.save!
+    end
+    Sidekiq::Testing.inline! do
+      # Attach a file to the item so that it provide preview
+      File.open(file_fixture('pdf-sample.pdf'), 'r') do |file|
+        @item.add_and_ingest_files([file])
+      end
+    end
+
+    logo = @item.files.first
+    expected = Rails.application.routes.url_helpers.rails_representation_path(
+      logo.preview(resize: '100x100', auto_orient: true).processed
+    )
+    assert_equal expected, thumbnail_path(logo)
+  end
+
+  test 'thumbnail_path should return preview for image (Variable)' do
+    community = communities(:books)
+    collection = collections(:fantasy_books)
+    @item = Item.new.tap do |uo|
+      uo.title = 'Fantastic item'
+      uo.owner_id = users(:admin).id
+      uo.creators = ['Joe Blow', 'Smokey Chantilly-Tiffany', 'Céline Marie Claudette Dion']
+      uo.visibility = JupiterCore::VISIBILITY_PUBLIC
+      uo.created = '1999-09-09'
+      uo.languages = [CONTROLLED_VOCABULARIES[:language].english]
+      uo.license = CONTROLLED_VOCABULARIES[:license].attribution_4_0_international
+      uo.item_type = CONTROLLED_VOCABULARIES[:item_type].article
+      uo.publication_status = [CONTROLLED_VOCABULARIES[:publication_status].draft,
+                               CONTROLLED_VOCABULARIES[:publication_status].submitted]
+      uo.subject = ['Items']
+      uo.add_to_path(community.id, collection.id)
+      uo.save!
+    end
+    Sidekiq::Testing.inline! do
+      # Attach a file to the item so that it can provide variant
+      File.open(file_fixture('image-sample.jpeg'), 'r') do |file|
+        @item.add_and_ingest_files([file])
+      end
+    end
+
+    logo = @item.files.first
+    expected = Rails.application.routes.url_helpers.rails_representation_path(
+      logo.variant(resize: '100x100', auto_orient: true).processed
+    )
+    assert_equal expected, thumbnail_path(logo)
+  end
+
+  test 'thumbnail_path should provide nil if no thumbnail is possible (StandardError on variable)' do
+    logo = active_storage_attachments(:logo)
+    logo.define_singleton_method(:variant) { |_| throw StandardError }
+
+    assert_nil thumbnail_path(logo)
+    # TODO: assert that the logger.warn was written
+  end
+
+  test 'thumbnail_path should return nil if both the variant and preview fail' do
+    logo = active_storage_attachments(:logo)
+    logo.define_singleton_method(:variant) { |_| throw ActiveStorage::InvariableError }
+    logo.define_singleton_method(:preview) { |_| throw StandardError }
+
+    assert_nil thumbnail_path(logo)
+    # TODO: assert that the logger.warn was written
+  end
+
+  # canonical_href
 
   test 'canonical_href is returning the correct canoncial url' do
     assert_equal Jupiter::PRODUCTION_URL, canonical_href(nil)


### PR DESCRIPTION
## Context
Similar logic appeared in `Depositable`, `DraftProperties`, `Community` and the thumbnail/feature_image partials. By refactoring the `thumbnail_path` into a helper and being able to call `thumbnail_file` on each instance we can centralize the logic and have each class only deal with the things that concern them.

Related to #1343 

## What's New
Refactor so no new functionality.  Added #thumbnail_path to page_layout_helper and updated anything that called the old way.  Also added tests for the logic in the helper.

In investigating this I learned a few new things.  ImageMagick is required for variant on images, but a pdf utility like Poppler is required to preview PDFs and ffmpeg is required to preview video. All three are requirements for our thumbnails to work correctly.

I tried a few different things in order to test the helper.  I tried creating a dummy `@logo` which implemented only the surface area that the `thumbnail_path` touched.  With this approach I got stuck on the `rails_representation_path` with the pdf and images case.  Then I tried creating fixtures (turns out that active_storage fixtures are supported out of the box) for these objects.  I ran into a similar road block because the fixtures wouldn't respond to `variant` and `preview`. Finally I tried a hybrid approach using real objects for the pdf and image and fixtures for the error cases. Success!

I would have liked to also test that a useful warning was logged in the error cases but couldn't find a approach that worked for me short of using the minitest-logger gem.  Maybe that is the best way forward.