### PR TITLE
#1675: Fix feature images being styled as thumbnails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ and releases in Jupiter project adheres to [Semantic Versioning](http://semver.o
 - Can now go through wizard with an old license [#1539](https://github.com/ualbertalib/jupiter/pull/1539)
 - Fixed rake tasks [#1585](https://github.com/ualbertalib/jupiter/issues/1585)
 - Style "Files" section as a card to keep consistent with rest of sidebar on item show page [#1676](https://github.com/ualbertalib/jupiter/issues/1676)
+- Feature Images on Item show page are being styled as Thumbnails [#1675](https://github.com/ualbertalib/jupiter/issues/1675)
 
 ### Security
 - add `noopener noreferrer` when opening a link in a new tab [PR#1344](https://github.com/ualbertalib/jupiter/pull/1344)

--- a/app/helpers/images_helper.rb
+++ b/app/helpers/images_helper.rb
@@ -26,7 +26,7 @@ module ImagesHelper
   end
 
   def safe_thumbnail_tag(thumbnail, image_tag_options)
-    image_tag_options[:class] = 'j-thumbnail img-thumbnail'
+    image_tag_options[:class] ||= 'j-thumbnail img-thumbnail'
     image_tag_options[:onerror] = "this.onerror=null;this.src='#{
       asset_pack_url('media/images/era-logo-without-text.png')
     }';"

--- a/app/views/application/_feature_image.html.erb
+++ b/app/views/application/_feature_image.html.erb
@@ -1,6 +1,9 @@
 <% if policy(object).thumbnail? %>
   <% if thumbnail_path(object&.thumbnail_file).present? %>
-    <%= safe_thumbnail_tag(thumbnail_path(object&.thumbnail_file, resize: '350x350', auto_orient: true), alt: '', size: '350x350') %>
+    <%= safe_thumbnail_tag(thumbnail_path(object&.thumbnail_file, resize: '350x350', auto_orient: true),
+                           alt: '',
+                           size: '350x350',
+                           class: 'j-feature-image img-thumbnail') %>
   <% else %>
     <div class="d-flex justify-content-center align-items-center img-thumbnail p-5">
       <%= icon('far', file_icon(object.thumbnail_file&.content_type), class: 'fa-5x text-muted') %>


### PR DESCRIPTION
Fixes #1675

Feature Image now takes up far more real estate and easier to see. What this looks like:

![image](https://user-images.githubusercontent.com/1930474/83844553-72ea9b00-a6c4-11ea-9be4-d54a301ad2d1.png)

Question: We resize our images (via activestorage/imagemagick) and set html width/height to be 350x350 for feature images and 100x100 for thumbnails. However for CSS we set a max-width/max-height for these differently as 270x350 for feature images and 135x175 for thumbnails. So not sure why these are different? We set these max widths as a solution for this issue : https://github.com/ualbertalib/jupiter/issues/661. But curious since we are forcing a resize via imagemagick if this is doing what we think it is (if the images are always going to be 100x100 or 350x350 since we resize them, then our max-width/max-height CSS will force them into different dimensions which could hurt the image quality)? 

Also in Rails 6 there appears to be better/improved resize methods we should maybe look into (#resize_to_fit, #resize_to_fill) 