### PR TITLE
Recent RDF vocab version renamed filename to resourceFilename

### DIFF
--- a/db/migrate/20200123180959_annotate_active_storage_blobs_with_rdf.rb
+++ b/db/migrate/20200123180959_annotate_active_storage_blobs_with_rdf.rb
@@ -2,7 +2,7 @@ class AnnotateActiveStorageBlobsWithRdf < ActiveRecord::Migration[5.2]
 
   def change
     add_rdf_table_annotations for_table: :active_storage_blobs do |t|
-      t.filename has_predicate: ::RDF::Vocab::EBUCore.filename
+      t.filename has_predicate: ::RDF::Vocab::EBUCore.resourceFilename
       t.content_type has_predicate: ::RDF::Vocab::EBUCore.hasMimeType
       t.byte_size has_predicate: ::RDF::Vocab::PREMIS.hasSize
       t.checksum has_predicate: ::RDF::Vocab::PREMIS.hasMessageDigest


### PR DESCRIPTION
This was breaking migration after we updated rdf-vocab gem.

Change is made in this giant commit: https://github.com/ruby-rdf/rdf-vocab/commit/d07779dbcc4cca5c34a96d6118c4aa8ee23673a9

For whatever reason they changed the name from  `EBUCore::filename` to `EBUCore::resourceFilename`