### PR TITLE
Now ignoring strings of length 4 for dates in coerce_value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and releases in Jupiter project adheres to [Semantic Versioning](http://semver.o
 ## [Unreleased]
 
 ### Fixed
-- Now ignoring strings of length 4 for dates in coerce_value
+- Now ignoring strings of length 4 for dates in coerce_value [PR#1700](https://github.com/ualbertalib/jupiter/pull/1700)
 
 ## [1.2.17] - 2019-09-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and releases in Jupiter project adheres to [Semantic Versioning](http://semver.o
 
 ## [Unreleased]
 
+### Fixed
+- Now ignoring strings of length 4 for dates in coerce_value
+
 ## [1.2.17] - 2019-09-24
 
 ### Security

--- a/app/models/jupiter_core/locked_ldp_object.rb
+++ b/app/models/jupiter_core/locked_ldp_object.rb
@@ -504,7 +504,7 @@ class JupiterCore::LockedLdpObject
       when :json_array
         JSON.parse(value)
       when :date
-        if value.is_a?(String)
+        if value.is_a?(String) && value.length != 4
           Time.zone.parse(value)
         elsif value.is_a?(DateTime)
           value

--- a/docker-compose.lightweight.yml
+++ b/docker-compose.lightweight.yml
@@ -5,30 +5,30 @@
 version: '3'
 
 volumes:
-  postgres:
-    driver: local
+  # postgres:
+  #   driver: local
   solr:
     driver: local
   fcrepo:
     driver: local
-  redis:
-    driver: local
+  # redis:
+  #   driver: local
 
 services:
   # Need postgres? Uncomment postgres settings below and respective volume above
   # To configure the app for the settings below, use environment varable setting:
   #   JUPITER_DATABASE_URL=postgresql://jupiter:mysecretpassword@127.0.0.1?pool=5
   #
-  postgres:
-    image: postgres:9.6-alpine
-    environment:
-      PGDATA: /var/lib/postgresql/data/pgdata
-      POSTGRES_PASSWORD: mysecretpassword
-      POSTGRES_USER: jupiter
-    volumes:
-      - postgres:/var/lib/postgresql/data
-    ports:
-      - "5432:5432"
+  # postgres:
+  #   image: postgres:9.6-alpine
+  #   environment:
+  #     PGDATA: /var/lib/postgresql/data/pgdata
+  #     POSTGRES_PASSWORD: mysecretpassword
+  #     POSTGRES_USER: jupiter
+  #   volumes:
+  #     - postgres:/var/lib/postgresql/data
+  #   ports:
+  #     - "5432:5432"
 
   solr:
     image: solr:6.6
@@ -47,9 +47,9 @@ services:
       - "8080:8080"
 
   # Need redis? Uncomment this and respective volume above
-  redis:
-    image: redis:alpine
-    volumes:
-      - redis:/data
-    ports:
-      - "6379:6379"
+  # redis:
+  #   image: redis:alpine
+  #   volumes:
+  #     - redis:/data
+  #   ports:
+  #     - "6379:6379"

--- a/docker-compose.lightweight.yml
+++ b/docker-compose.lightweight.yml
@@ -5,30 +5,30 @@
 version: '3'
 
 volumes:
-  # postgres:
-  #   driver: local
+  postgres:
+    driver: local
   solr:
     driver: local
   fcrepo:
     driver: local
-  # redis:
-  #   driver: local
+  redis:
+    driver: local
 
 services:
   # Need postgres? Uncomment postgres settings below and respective volume above
   # To configure the app for the settings below, use environment varable setting:
   #   JUPITER_DATABASE_URL=postgresql://jupiter:mysecretpassword@127.0.0.1?pool=5
   #
-  # postgres:
-  #   image: postgres:9.6-alpine
-  #   environment:
-  #     PGDATA: /var/lib/postgresql/data/pgdata
-  #     POSTGRES_PASSWORD: mysecretpassword
-  #     POSTGRES_USER: jupiter
-  #   volumes:
-  #     - postgres:/var/lib/postgresql/data
-  #   ports:
-  #     - "5432:5432"
+  postgres:
+    image: postgres:9.6-alpine
+    environment:
+      PGDATA: /var/lib/postgresql/data/pgdata
+      POSTGRES_PASSWORD: mysecretpassword
+      POSTGRES_USER: jupiter
+    volumes:
+      - postgres:/var/lib/postgresql/data
+    ports:
+      - "5432:5432"
 
   solr:
     image: solr:6.6
@@ -47,9 +47,9 @@ services:
       - "8080:8080"
 
   # Need redis? Uncomment this and respective volume above
-  # redis:
-  #   image: redis:alpine
-  #   volumes:
-  #     - redis:/data
-  #   ports:
-  #     - "6379:6379"
+  redis:
+    image: redis:alpine
+    volumes:
+      - redis:/data
+    ports:
+      - "6379:6379"


### PR DESCRIPTION
#1685
Decided to just simply ignore strings of length 4 when coercing dates. Should resolve our invalid date_accepted entries. Initially I had a plpgsql query that checked if the date was invalid but it was decided that that is overkill as this should be enough.