### PR TITLE
#1669: Make sure we are setting fileset_uuid whenever we add files for items/theses

### DIFF
--- a/app/models/draft_item.rb
+++ b/app/models/draft_item.rb
@@ -153,7 +153,10 @@ class DraftItem < ApplicationRecord
 
     # add an association between the same underlying blobs the Item uses and the Draft
     item.files_attachments.each do |attachment|
-      ActiveStorage::Attachment.create(record: self, blob: attachment.blob, name: :files)
+      ActiveStorage::Attachment.create(record: self,
+                                       blob: attachment.blob,
+                                       name: :files,
+                                       fileset_uuid: UUIDTools::UUID.random_create)
     end
   end
 

--- a/app/models/draft_thesis.rb
+++ b/app/models/draft_thesis.rb
@@ -109,7 +109,10 @@ class DraftThesis < ApplicationRecord
 
     # add an association between the same underlying blobs the Item uses and the Draft
     thesis.files_attachments.each do |attachment|
-      ActiveStorage::Attachment.create(record: self, blob: attachment.blob, name: :files)
+      ActiveStorage::Attachment.create(record: self,
+                                       blob: attachment.blob,
+                                       name: :files,
+                                       fileset_uuid: UUIDTools::UUID.random_create)
     end
   end
 

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -106,7 +106,9 @@ class Item < JupiterCore::Doiable
     # add an association between the same underlying blobs the Draft uses and the Item
     draft_item.files_attachments.each do |attachment|
       ActiveStorage::Attachment.create(record: item,
-                                       blob: attachment.blob, name: :files)
+                                       blob: attachment.blob,
+                                       name: :files,
+                                       fileset_uuid: UUIDTools::UUID.random_create)
     end
 
     item.set_thumbnail(item.files.find_by(blob_id: draft_item.thumbnail.blob.id)) if draft_item.thumbnail.present?

--- a/app/models/thesis.rb
+++ b/app/models/thesis.rb
@@ -105,7 +105,9 @@ class Thesis < JupiterCore::Doiable
     # add an association between the same underlying blobs the Draft uses and the Item
     draft_thesis.files_attachments.each do |attachment|
       ActiveStorage::Attachment.create(record: thesis,
-                                       blob: attachment.blob, name: :files)
+                                       blob: attachment.blob,
+                                       name: :files,
+                                       fileset_uuid: UUIDTools::UUID.random_create)
     end
 
     thesis.set_thumbnail(thesis.files.find_by(blob_id: draft_thesis.thumbnail.blob.id))

--- a/app/views/items/_files_section_sidebar.html.erb
+++ b/app/views/items/_files_section_sidebar.html.erb
@@ -26,18 +26,6 @@
                         download: file.filename) %>
           </div>
         </div>
-      <% else %>
-        <h4 class="mt-3"><%= t('.header') %></h4>
-        <div class="list-group item-files">
-          <div class="list-group-item list-group-item-action d-flex flex-column">
-            <div class="item-filename text-center pb-3"><%= file.filename %></div>
-            <div class="d-flex justify-content-center">
-              <div class="text-center pb-3">
-                <%= t('.processing') %>
-              </div>
-            </div>
-          </div>
-        </div>
       <% end %>
     <% else %>
       <div class="card mt-3">
@@ -65,12 +53,6 @@
                                   class: 'js-download btn btn-outline-primary',
                                   rel: 'nofollow',
                                   download: file.filename) %>
-                    </div>
-                  </div>
-                <% else %>
-                  <div class="d-flex justify-content-center">
-                    <div class="text-center pb-3">
-                      <%= t('.processing') %>
                     </div>
                   </div>
                 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -563,7 +563,6 @@ en:
       header: 'Files'
       ccid_restricted_item: Item Restricted to University of Alberta Users
       login_with_ccid_to_view: Log In with CCID to View Item
-      processing: 'This file is processing and will be available shortly'
     new:
       header: 'Deposit Item'
     create:


### PR DESCRIPTION
#1669

This should fix this issue for "files are processing" which was a result of `fileset_uuid` not being set on items/theses. 

Seems like we only set `fileset_uuid` via `add_and_ingest_files` method but this is only being called when we seed items/theses or batch ingest items/theses.

So when we actually create or edit items in Jupiter, these files are not being given a `fileset_uuid`. My changes fix this so now that when we add files from create/edit items, `fileset_uuid` is getting set correctly.

What is `fileset_uuid` being used for? Its essentially just legacy and is for decorating the URL we use when serving these files. When you view or download a file in ERA you get a URL like the following:

/items/{{id}//download/{{fileset_uuid}}

Example: https://era.library.ualberta.ca/items/d8d783c1-b0bb-42cf-8266-497dfee4e1f1/download/dd3414be-7cdb-417e-84a5-a2d245cad896

