### PR TITLE
#1668: Use resize_to_limit instead of resize for images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ and releases in Jupiter project adheres to [Semantic Versioning](http://semver.o
 - Style "Files" section as a card to keep consistent with rest of sidebar on item show page [#1676](https://github.com/ualbertalib/jupiter/issues/1676)
 - Feature Images on Item show page are being styled as Thumbnails [#1675](https://github.com/ualbertalib/jupiter/issues/1675)
 - Fix "This file is processing and will be available shortly [#1669](https://github.com/ualbertalib/jupiter/issues/1669)
+- Use #resize_to_limit instead of #resize for thumbnail/images in Jupiter [#1698](https://github.com/ualbertalib/jupiter/issues/1698)
 
 ### Security
 - add `noopener noreferrer` when opening a link in a new tab [PR#1344](https://github.com/ualbertalib/jupiter/pull/1344)

--- a/app/helpers/page_layout_helper.rb
+++ b/app/helpers/page_layout_helper.rb
@@ -44,7 +44,7 @@ module PageLayoutHelper
   end
   # rubocop:enable Rails/HelperInstanceVariable
 
-  def thumbnail_path(logo, args = { resize: '100x100', auto_orient: true })
+  def thumbnail_path(logo, args = { resize_to_limit: [100, 100], auto_orient: true })
     return nil if logo.blank?
 
     # images have variants

--- a/app/javascript/styles/image.scss
+++ b/app/javascript/styles/image.scss
@@ -1,9 +1,9 @@
 .j-thumbnail {
-  max-width: 135px;
-  max-height: 175px;
+  max-width: 100px;
+  max-height: 100px;
 }
 
 .j-feature-image {
   max-height: 350px;
-  max-width: 270px;
+  max-width: 100%;
 }

--- a/app/views/application/_feature_image.html.erb
+++ b/app/views/application/_feature_image.html.erb
@@ -1,6 +1,6 @@
 <% if policy(object).thumbnail? %>
   <% if thumbnail_path(object&.thumbnail_file).present? %>
-    <%= safe_thumbnail_tag(thumbnail_path(object&.thumbnail_file, resize: '350x350', auto_orient: true),
+    <%= safe_thumbnail_tag(thumbnail_path(object&.thumbnail_file, resize_to_limit: [350, 350], auto_orient: true),
                            alt: '',
                            size: '350x350',
                            class: 'j-feature-image img-thumbnail') %>

--- a/test/helpers/page_layout_helper_test.rb
+++ b/test/helpers/page_layout_helper_test.rb
@@ -115,7 +115,7 @@ class PageLayoutHelperTest < ActionView::TestCase
 
     logo = item.reload.files.first
     expected = Rails.application.routes.url_helpers.rails_representation_path(
-      logo.preview(resize: '100x100', auto_orient: true).processed
+      logo.preview(resize_to_limit: [100, 100], auto_orient: true).processed
     )
     assert_equal expected, thumbnail_path(logo)
   end
@@ -128,7 +128,7 @@ class PageLayoutHelperTest < ActionView::TestCase
 
     logo = item.reload.files.first
     expected = Rails.application.routes.url_helpers.rails_representation_path(
-      logo.variant(resize: '100x100', auto_orient: true).processed
+      logo.variant(resize_to_limit: [100, 100], auto_orient: true).processed
     )
     assert_equal expected, thumbnail_path(logo)
   end


### PR DESCRIPTION
#1668 

Also update max-width/max-heigh css for images

Deposit workflow image upload page uses both thumbnails and feature image css (same as search results page and item show page). So this provides a good showcase of how different size images look like with using `.resize_to_limit` and the new css changes:

<img width="986" alt="Screen Shot 2020-06-11 at 10 46 45 PM" src="https://user-images.githubusercontent.com/1930474/84466877-ad5db600-ac37-11ea-95a5-4b7e8e0f68be.png">
<img width="678" alt="Screen Shot 2020-06-11 at 10 47 04 PM" src="https://user-images.githubusercontent.com/1930474/84466878-ae8ee300-ac37-11ea-8310-585aecbcb945.png">
<img width="336" alt="Screen Shot 2020-06-11 at 10 47 22 PM" src="https://user-images.githubusercontent.com/1930474/84466879-af277980-ac37-11ea-917c-70c5424e4cd5.png">
<img width="335" alt="Screen Shot 2020-06-11 at 10 47 33 PM" src="https://user-images.githubusercontent.com/1930474/84466880-af277980-ac37-11ea-9eee-ed2fd88d561b.png">
<img width="346" alt="Screen Shot 2020-06-11 at 10 48 00 PM" src="https://user-images.githubusercontent.com/1930474/84466882-afc01000-ac37-11ea-944d-c4c77df7be9b.png">
<img width="494" alt="Screen Shot 2020-06-11 at 10 48 14 PM" src="https://user-images.githubusercontent.com/1930474/84466883-afc01000-ac37-11ea-9457-9524123a39a1.png">


Item show page example:
<img width="1074" alt="Screen Shot 2020-06-11 at 10 50 05 PM" src="https://user-images.githubusercontent.com/1930474/84466884-b058a680-ac37-11ea-9d6c-e8009fa2c257.png">


Mobile view
<img width="212" alt="Screen Shot 2020-06-11 at 10 51 26 PM" src="https://user-images.githubusercontent.com/1930474/84466885-b0f13d00-ac37-11ea-8616-62a7302f40bf.png">


Couple examples with images smaller then 350x350
<img width="890" alt="Screen Shot 2020-06-11 at 11 07 59 PM" src="https://user-images.githubusercontent.com/1930474/84467156-7d62e280-ac38-11ea-83f6-252456fc03e5.png">
<img width="971" alt="Screen Shot 2020-06-11 at 11 08 22 PM" src="https://user-images.githubusercontent.com/1930474/84467161-7fc53c80-ac38-11ea-9d6a-98cfd453ec4b.png">


Perhaps not perfect? but big improvement to what we have current for most cases (if dimensions are really crazy like 100x900 its looks pretty bad, but thats kinda expected 🤔 ). (Also from testing resize_to_limit seems overall better then resize_to_fit and resize_to_fill from playing around)