### PR TITLE
Replace deprecated content_tag method

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -105,9 +105,8 @@ Rails/FindEach:
 Rails/UnknownEnv:
   Enabled: false
 
-# TODO: content_tag is deprecated, we should work to replace this with tag.<name> but the autocorrect was not helpful
 Rails/ContentTag:
-  Enabled: false
+  Enabled: true
 
 Style/AsciiComments:
   Enabled: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ and releases in Jupiter project adheres to [Semantic Versioning](http://semver.o
 - Style "Files" section as a card to keep consistent with rest of sidebar on item show page [#1676](https://github.com/ualbertalib/jupiter/issues/1676)
 - Feature Images on Item show page are being styled as Thumbnails [#1675](https://github.com/ualbertalib/jupiter/issues/1675)
 - Fix "This file is processing and will be available shortly [#1669](https://github.com/ualbertalib/jupiter/issues/1669)
+- The tag method is used replacing the content_tag method which is now deprecated [#1706]https://github.com/ualbertalib/jupiter/issues/1706
 
 ### Security
 - add `noopener noreferrer` when opening a link in a new tab [PR#1344](https://github.com/ualbertalib/jupiter/pull/1344)

--- a/app/decorators/facets/default_facet_decorator.rb
+++ b/app/decorators/facets/default_facet_decorator.rb
@@ -14,13 +14,13 @@ class Facets::DefaultFacetDecorator
     # TODO: can we move this to the view?
     if @active_facets[@solr_index].present? && @active_facets[@solr_index].include?(@value)
       @view.link_to @view.query_params_without_facet_value(@solr_index, @value), rel: 'nofollow' do
-        @view.concat(@view.content_tag(:span, @count, class: 'ml-2 badge badge-light float-right'))
+        @view.concat(@view.tag.span(@count, class: 'ml-2 badge badge-light float-right'))
         @view.concat(@view.icon('far', 'check-square', class: 'mr-2'))
         @view.concat(display)
       end
     else
       @view.link_to @view.query_params_with_facet(@solr_index, @value), rel: 'nofollow' do
-        @view.concat(@view.content_tag(:span, @count, class: 'ml-2 badge badge-light float-right'))
+        @view.concat(@view.tag.span(@count, class: 'ml-2 badge badge-light float-right'))
         @view.concat(@view.icon('far', 'square', class: 'mr-2'))
         @view.concat(display)
       end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -13,7 +13,7 @@ module ApplicationHelper
   end
 
   def help_tooltip(text)
-    content_tag(:span, icon('fas', 'question-circle'), title: text)
+    tag.span(icon('fas', 'question-circle'), title: text)
   end
 
   # Simple wrapper around time_tag and time_ago_in_words to handle nil case (otherwise time_tag 500s)

--- a/app/helpers/font_awesome_helper.rb
+++ b/app/helpers/font_awesome_helper.rb
@@ -15,7 +15,7 @@ module FontAwesomeHelper
                              "#{style} fa-#{name}"
                            end
 
-    html = content_tag(:i, nil, html_options)
+    html = tag.i(nil, html_options)
     html << ' ' << text.to_s if text.present?
     html
   end

--- a/app/helpers/search_helper.rb
+++ b/app/helpers/search_helper.rb
@@ -83,13 +83,13 @@ module SearchHelper
     name = model.name.downcase.to_sym
     if @search_models.include? model
       count = @results.total_count
-      text = content_tag(:h2, t("search.tab_header_#{name}_with_count", count: count), class: 'h5')
+      text = tag.h2(t("search.tab_header_#{name}_with_count", count: count), class: 'h5')
       classes += ' active'
     else
-      text = content_tag(:h2, t("search.tab_header_#{name}"), class: 'h5')
+      text = tag.h2(t("search.tab_header_#{name}"), class: 'h5')
     end
-    content_tag(:li, content_tag(:a, text, class: classes, href: search_path(query_params_with_tab(name))),
-                class: 'nav-item')
+    tag.li(tag.a(text, class: classes, href: search_path(query_params_with_tab(name))),
+           class: 'nav-item')
   end
   # rubocop:enable Rails/HelperInstanceVariable
 

--- a/app/views/admin/theses/draft/_progress_bar.html.erb
+++ b/app/views/admin/theses/draft/_progress_bar.html.erb
@@ -17,12 +17,13 @@
     </ul>
   </nav>
   <div class="progress">
-    <%= content_tag :div,
-                    progress_bar_text,
-                    class: "progress-bar w-#{progress_bar_percentage}",
-                    role: 'progressbar',
-                    'aria-valuenow' => progress_bar_percentage,
-                    'aria-valuemin' => '0',
-                    'aria-valuemax' => '100' %>
+    <%= tag.div progress_bar_text,
+                class: "progress-bar w-#{progress_bar_percentage}",
+                role: 'progressbar',
+                aria: {
+                  valuenow: progress_bar_percentage,
+                  valuemin: '0',
+                  valuemax: '100' 
+                } %>
   </div>
 </section>

--- a/app/views/admin/theses/draft/_progress_bar.html.erb
+++ b/app/views/admin/theses/draft/_progress_bar.html.erb
@@ -23,7 +23,7 @@
                 aria: {
                   valuenow: progress_bar_percentage,
                   valuemin: '0',
-                  valuemax: '100' 
+                  valuemax: '100'
                 } %>
   </div>
 </section>

--- a/app/views/items/draft/_progress_bar.html.erb
+++ b/app/views/items/draft/_progress_bar.html.erb
@@ -17,12 +17,13 @@
     </ul>
   </nav>
   <div class="progress">
-    <%= content_tag :div,
-                    progress_bar_text,
-                    class: "progress-bar w-#{progress_bar_percentage}",
-                    role: 'progressbar',
-                    'aria-valuenow' => progress_bar_percentage,
-                    'aria-valuemin' => '0',
-                    'aria-valuemax' => '100' %>
+    <%= tag.div progress_bar_text,
+                class: "progress-bar w-#{progress_bar_percentage}",
+                role: 'progressbar',
+                aria: { 
+                  valuenow: progress_bar_percentage,
+                  valuemin: '0',
+                  valuemax: '100' 
+                } %>
   </div>
 </section>

--- a/app/views/items/draft/_progress_bar.html.erb
+++ b/app/views/items/draft/_progress_bar.html.erb
@@ -20,10 +20,10 @@
     <%= tag.div progress_bar_text,
                 class: "progress-bar w-#{progress_bar_percentage}",
                 role: 'progressbar',
-                aria: { 
+                aria: {
                   valuenow: progress_bar_percentage,
                   valuemin: '0',
-                  valuemax: '100' 
+                  valuemax: '100'
                 } %>
   </div>
 </section>

--- a/app/views/kaminari/_page.html.erb
+++ b/app/views/kaminari/_page.html.erb
@@ -1,6 +1,6 @@
 <% if page.current? %>
   <li class="page-item active">
-    <%= content_tag :a, page, data: { remote: remote }, rel: page.rel, class: 'page-link' %>
+    <%= tag.a page, data: { remote: remote }, rel: page.rel, class: 'page-link' %>
   </li>
 <% else %>
   <li class="page-item">


### PR DESCRIPTION
## Context

content_tag is deprecated. We are now using tag.<name>. The cop checking for content_tag use has been activated.

Related to #1706 

## What's New

Replaced content_tag with tag.
