### PR TITLE
Now catching and ignoring ArgumentError in coerce_value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,22 @@ and releases in Jupiter project adheres to [Semantic Versioning](http://semver.o
 
 ## [Unreleased]
 
+## [2.0.0.pre2.5] 2020-07-03
+
+### Fixed
+- Now catching and ignoring ArgumentError in coerce_value [PR#1742](https://github.com/ualbertalib/jupiter/pull/1742)
+
+## [2.0.0.pre2.4] 2020-06-29
+
+### Fixed
+- Bumped sidekiq-unique-jobs as our version was yanked [PR#1738](https://github.com/ualbertalib/jupiter/pull/1738)
+
+## [2.0.0.pre2.3] 2020-06-26
+
 ### Fixed
 - Now ignoring strings of length 4 for dates in coerce_value [PR#1700](https://github.com/ualbertalib/jupiter/pull/1700)
+
+## [2.0.0.pre2.2] 2020-06-22
 
 ### Changed
 - Beefed up AR migrations by stating that certain attributes cannot be null [PR#1704](https://github.com/ualbertalib/jupiter/pull/1704)

--- a/app/models/jupiter_core/locked_ldp_object.rb
+++ b/app/models/jupiter_core/locked_ldp_object.rb
@@ -504,8 +504,12 @@ class JupiterCore::LockedLdpObject
       when :json_array
         JSON.parse(value)
       when :date
-        if value.is_a?(String) && value.length != 4
-          Time.zone.parse(value)
+        if value.is_a?(String)
+          begin
+            Time.zone.parse(value)
+          rescue ArgumentError
+            # Invalid date value, ignore.
+          end
         elsif value.is_a?(DateTime)
           value
         elsif value.is_a?(Date) || value.is_a?(Time)

--- a/app/models/jupiter_core/locked_ldp_object.rb
+++ b/app/models/jupiter_core/locked_ldp_object.rb
@@ -509,6 +509,7 @@ class JupiterCore::LockedLdpObject
             Time.zone.parse(value)
           rescue ArgumentError
             # Invalid date value, ignore.
+            nil
           end
         elsif value.is_a?(DateTime)
           value


### PR DESCRIPTION
We had many invalid dates in our production data ('1994', '[2000]', 'c1984', and even '[1977?]'). This should prevent the rake task from choking on those by catching the exception.