### PR TITLE
Bumps sidekiq from 5.2.8 to 5.2.9.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ gem 'rdf-vocab', '~> 3.1.5'
 # Database stuff
 gem 'connection_pool'
 gem 'pg', '~> 1.2.3'
-gem 'redis', '~> 4.2'
+gem 'redis', '~> 4.1'
 gem 'rsolr'
 
 # Authentication

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -296,7 +296,7 @@ GEM
     pundit (1.1.0)
       activesupport (>= 3.0.0)
     raabro (1.1.6)
-    rack (2.0.9)
+    rack (2.2.3)
     rack-protection (2.0.8.1)
       rack
     rack-proxy (0.6.5)
@@ -354,7 +354,7 @@ GEM
     rdf-xsd (3.1.0)
       rdf (~> 3.1)
     rdoc (6.2.1)
-    redis (4.2.1)
+    redis (4.1.4)
     regexp_parser (1.7.1)
     request_store (1.5.0)
       rack (>= 1.4)
@@ -401,11 +401,11 @@ GEM
     semantic_range (2.3.0)
     shoulda-matchers (4.3.0)
       activesupport (>= 4.2.0)
-    sidekiq (5.2.8)
+    sidekiq (5.2.9)
       connection_pool (~> 2.2, >= 2.2.2)
-      rack (< 2.1.0)
+      rack (~> 2.0)
       rack-protection (>= 1.5.0)
-      redis (>= 3.3.5, < 5)
+      redis (>= 3.3.5, < 4.2)
     sidekiq-cron (1.2.0)
       fugit (~> 1.1)
       sidekiq (>= 4.2.1)
@@ -537,7 +537,7 @@ DEPENDENCIES
   rdf (~> 3.1.3)
   rdf-n3
   rdf-vocab (~> 3.1.5)
-  redis (~> 4.2)
+  redis (~> 4.1)
   rollbar
   rsolr
   rubocop (~> 0.86.0)


### PR DESCRIPTION
## Context
Github has been alerting us that rack is out of date.  Turns out this was because sidekiq 5.2.8 locked rack.  By downgrading redis and upgrading rack we'll clear this alert.  Sidekiq is the part of our application that is using redis so it makes sense to update in lockstep with that project.

Same versions that the integration_migration_phase1 branch was updated to #1738

## What's new
Redis is downgraded, sidekiq and rack are upgraded.

<details>
<summary>Changelog</summary>
<p><em>Sourced from <a href="https://github.com/mperham/sidekiq/blob/master/Changes.md">sidekiq's changelog</a>.</em></p>
<blockquote>
<h2>5.2.9</h2>
<ul>
<li>Release Rack lock due to a cascade of CVEs. [#4566] Pro-tip: don't lock Rack.</li>
</ul>
</blockquote>
</details>