### PR TITLE
expose jquery via window global instead of 3rd party package

### DIFF
--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -19,6 +19,9 @@ import 'jquery-multidownload/jquery-multidownload';
 import '../styles/application.scss';
 import '../src/application';
 
+// Expose jquery so RJS (e.g: js.erb templates) works properly
+window.$ = $;
+
 require.context('../images', true);
 
 ActiveStorage.start();

--- a/config/webpack/environment.js
+++ b/config/webpack/environment.js
@@ -21,15 +21,4 @@ environment.plugins.prepend(
   }),
 );
 
-/**
- * To use jQuery in views
- */
-environment.loaders.append('expose', {
-  test: require.resolve('jquery'),
-  use: [{
-    loader: 'expose-loader',
-    options: '$',
-  }],
-});
-
 module.exports = environment;

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "core-js": "^3.6.5",
     "dropzone": "^5.7.1",
     "easy-autocomplete": "^1.3.5",
-    "expose-loader": "^0.7.5",
     "jquery": "^3.5.1",
     "jquery-multidownload": "^4.0.1",
     "popper.js": "^1.16.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3041,11 +3041,6 @@ expand-tilde@^2.0.0, expand-tilde@^2.0.2:
   dependencies:
     homedir-polyfill "^1.0.1"
 
-expose-loader@^0.7.5:
-  version "0.7.5"
-  resolved "https://registry.yarnpkg.com/expose-loader/-/expose-loader-0.7.5.tgz#e29ea2d9aeeed3254a3faa1b35f502db9f9c3f6f"
-  integrity sha512-iPowgKUZkTPX5PznYsmifVj9Bob0w2wTHVkt/eYNPSzyebkUgIedmskf/kcfEIWpiWjg3JRjnW+a17XypySMuw==
-
 express@^4.17.1:
   version "4.17.1"
   resolved "https://registry.yarnpkg.com/express/-/express-4.17.1.tgz#4491fc38605cf51f8629d39c2b5d026f98a4c134"


### PR DESCRIPTION
Seems like we don't need this `expose-loader` package and we can simply just expose jQuery via the `window` global variable. 

For context, we need jQuery exposed outside of webpack, so we can use RJS (e.g: `*.js.erb` view templates) which we have in a few places (for example we use RJS heavily in admin users index for ajaxing sorting/filter/searching of its table of users)

This saves us from dealing with updating and maintaining this entire package in the future. For instance, trying to keep it upgraded here: https://github.com/ualbertalib/jupiter/pull/1735

#trivial