### PR TITLE
phase1 docker image can be built and deployed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and releases in Jupiter project adheres to [Semantic Versioning](http://semver.o
 
 ## [Unreleased]
 
+### Fixed
+- docker image can be built and deployed
+
 ## [2.0.0.pre2.5] 2020-07-03
 
 ### Fixed

--- a/Dockerfile.deployment
+++ b/Dockerfile.deployment
@@ -1,4 +1,4 @@
-FROM ruby:2.5.0
+FROM ruby:2.6
 LABEL maintainer="University of Alberta Libraries"
 
 # Need to add jessie-backports repo so we can get FFMPEG, doesn't come with jessie debian by default
@@ -37,6 +37,10 @@ RUN apt-get update -qq \
 ENV APP_ROOT /app
 RUN mkdir -p $APP_ROOT
 WORKDIR $APP_ROOT
+
+# Update bundler
+RUN gem update --system
+RUN gem install bundler:2.1.4
 
 # Preinstall gems in an earlier layer so we don't reinstall every time any file changes.
 COPY Gemfile  $APP_ROOT

--- a/bin/predeploy
+++ b/bin/predeploy
@@ -10,7 +10,7 @@ set -o nounset
 [[ -n "${TRACE:-}" ]] && set -o xtrace
 
 
-readonly branch_name="master"
+readonly branch_name="integration_migration_phase1"
 readonly install_directory="/home/deploy/jupiter"
 
 mkdir -p "${install_directory}"

--- a/docker-compose.deployment.yml
+++ b/docker-compose.deployment.yml
@@ -51,7 +51,7 @@ services:
   # Sidekiq
   worker: &rails
     restart: always
-    image: ualbertalib/jupiter:deployment
+    image: ualbertalib/jupiter:2.0.0.pre
     volumes:
       - file-storage:/app/storage/
     command: bundle exec sidekiq

--- a/lib/jupiter/version.rb
+++ b/lib/jupiter/version.rb
@@ -1,3 +1,3 @@
 module Jupiter
-  VERSION = '1.2.17'.freeze
+  VERSION = '2.0.0.pre'.freeze
 end


### PR DESCRIPTION
## Context

This is if anyone wants to deploy this branch as a docker image and run the `rake jupiter:get_me_off_of_fedora`

Related to #1680

## What's New

A bump to the built with bundler version in Gemfile.lock required a newer version of bundler. Fixed this in the Dockerfile.deployment

Changed the predeploy script to look to this branch for getting the docker-compose with the correct docker image.

Bumped the version to 2.0.0.pre so that when/if this is deployed we'll know which version is running.