### PR TITLE
docker image can be built and deployed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ and releases in Jupiter project adheres to [Semantic Versioning](http://semver.o
 - Fix "This file is processing and will be available shortly [#1669](https://github.com/ualbertalib/jupiter/issues/1669)
 - The tag method is used replacing the content_tag method which is now deprecated [#1706](https://github.com/ualbertalib/jupiter/issues/1706)
 - Use #resize_to_limit instead of #resize for thumbnail/images in Jupiter [#1698](https://github.com/ualbertalib/jupiter/issues/1698)
+- docker image can be built and deployed on UAT [#1680](https://github.com/ualbertalib/jupiter/issues/1680)
 
 ### Security
 - add `noopener noreferrer` when opening a link in a new tab [PR#1344](https://github.com/ualbertalib/jupiter/pull/1344)

--- a/Dockerfile.deployment
+++ b/Dockerfile.deployment
@@ -1,4 +1,4 @@
-FROM ruby:2.5.0
+FROM ruby:2.6
 LABEL maintainer="University of Alberta Library"
 
 # Need to add jessie-backports repo so we can get FFMPEG, doesn't come with jessie debian by default
@@ -38,10 +38,14 @@ ENV APP_ROOT /app
 RUN mkdir -p $APP_ROOT
 WORKDIR $APP_ROOT
 
-# Preinstall gems in an earlier layer so we don't reinstall every time any file changes.
-COPY Gemfile  $APP_ROOT
-COPY Gemfile.lock $APP_ROOT
-RUN bundle install --without development test --jobs=3 --retry=3
+# Update bundler
+RUN gem update --system
+RUN gem install bundler:2.1.4
+
+# Install standard gems
+COPY Gemfile* /app/
+RUN bundle config --global frozen 1 && \
+    bundle install -j4 --retry 3
 
 # *NOW* we copy the codebase in
 COPY . $APP_ROOT

--- a/Gemfile
+++ b/Gemfile
@@ -65,7 +65,7 @@ gem 'rollbar'
 
 # OAI-PMH
 gem 'builder_deferred_tagging', github: 'ualbertalib/builder_deferred_tagging', tag: 'v0.01'
-gem 'oaisys', github: 'ualbertalib/oaisys', ref: 'd0e3f515472b304c6b728c01ddbda99a50af91a8'
+gem 'oaisys', github: 'ualbertalib/oaisys', ref: '68affbf4ca98bd81928b4650a85d0b5230f3d47e'
 
 # Seeds
 group :development, :test, :uat do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,8 +17,8 @@ GIT
 
 GIT
   remote: https://github.com/ualbertalib/oaisys.git
-  revision: d0e3f515472b304c6b728c01ddbda99a50af91a8
-  ref: d0e3f515472b304c6b728c01ddbda99a50af91a8
+  revision: 68affbf4ca98bd81928b4650a85d0b5230f3d47e
+  ref: 68affbf4ca98bd81928b4650a85d0b5230f3d47e
   specs:
     oaisys (0.1.0)
       builder (~> 3.0)

--- a/bin/deploy
+++ b/bin/deploy
@@ -4,7 +4,7 @@ docker rmi $(docker images -f "dangling=true" -q)
 
 docker-compose pull web
 
-docker-compose up -d
+docker-compose up -d --remove-orphans
 
 docker-compose run --rm web rake db:migrate
 docker-compose run --rm web rake assets:precompile

--- a/bin/predeploy
+++ b/bin/predeploy
@@ -10,12 +10,12 @@ set -o nounset
 [[ -n "${TRACE:-}" ]] && set -o xtrace
 
 
-readonly branch_name="master"
+readonly branch_name="integration_postmigration"
 readonly install_directory="/home/deploy/jupiter"
 
 mkdir -p "${install_directory}"
 curl -o "${install_directory}/deploy" "https://raw.githubusercontent.com/ualbertalib/jupiter/${branch_name}/bin/deploy"
-curl -o "${install_directory}/docker-compose.yml" "https://raw.githubusercontent.com/ualbertalib/jupiter/${branch_name}/docker-compose.deployment.yml"
+curl -o "${install_directory}/docker-compose.yml" "https://raw.githubusercontent.com/ualbertalib/jupiter/${branch_name}/docker-compose.production.yml"
 
 mkdir -p "${install_directory}/config"
 curl -o "${install_directory}/config/nginx.conf" "https://raw.githubusercontent.com/ualbertalib/jupiter/${branch_name}/config/nginx.conf"

--- a/config/initializers/oaisys.rb
+++ b/config/initializers/oaisys.rb
@@ -11,5 +11,5 @@ Rails.application.config.after_initialize do
   Oaisys::Engine.config.top_level_sets_model = Community
   Oaisys::Engine.config.set_model = Collection
   Oaisys::Engine.config.redis_url = Rails.application.secrets.redis_url
-  Oaisys::Engine.config.redis = Oaisys::RedisConnection.new
+  Oaisys::Engine.config.redis = Oaisys::RedisConnection.new unless ENV['RAILS_ENV'] == 'uat'
 end

--- a/config/initializers/oaisys.rb
+++ b/config/initializers/oaisys.rb
@@ -11,5 +11,5 @@ Rails.application.config.after_initialize do
   Oaisys::Engine.config.top_level_sets_model = Community
   Oaisys::Engine.config.set_model = Collection
   Oaisys::Engine.config.redis_url = Rails.application.secrets.redis_url
-  Oaisys::Engine.config.redis = Oaisys::RedisConnection.new unless ENV['RAILS_ENV'] == 'uat'
+  Oaisys::Engine.config.redis = Oaisys::RedisConnection.new
 end

--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -27,7 +27,7 @@ server {
     error_log /var/log/nginx.error.log;
   }
 
-  location ^~ /assets/ {
+  location ^~ /packs/ {
     gzip_static on;
     expires max;
     add_header Cache-Control public;

--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -83,6 +83,30 @@ test:
   # Compile test packs to a separate directory
   public_output_path: packs-test
 
+uat:
+  <<: *default
+
+  # Production depends on precompilation of packs prior to booting for performance.
+  compile: false
+
+  # Extract and emit a css file
+  extract_css: true
+
+  # Cache manifest.json for performance
+  cache_manifest: true
+
+staging:
+  <<: *default
+
+  # Production depends on precompilation of packs prior to booting for performance.
+  compile: false
+
+  # Extract and emit a css file
+  extract_css: true
+
+  # Cache manifest.json for performance
+  cache_manifest: true
+
 production:
   <<: *default
 

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -55,7 +55,7 @@ services:
   web:
     <<: *rails
     volumes:
-      - assets:/app/public/assets/
+      - assets:/app/public/packs/
       - file-storage:/app/storage/
     command: bundle exec puma -e uat
 
@@ -67,6 +67,6 @@ services:
     env_file: .env_deployment
     volumes:
       - ./config/nginx.conf:/etc/nginx/conf.d/default.conf
-      - assets:/app/public/assets/
+      - assets:/app/public/packs/
     ports:
       - "80:80"

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -55,7 +55,7 @@ services:
   web:
     <<: *rails
     volumes:
-      - assets:/app/public/packs/
+      - assets:/app/public/
       - file-storage:/app/storage/
     command: bundle exec puma -e uat
 
@@ -67,6 +67,6 @@ services:
     env_file: .env_deployment
     volumes:
       - ./config/nginx.conf:/etc/nginx/conf.d/default.conf
-      - assets:/app/public/packs/
+      - assets:/app/public/
     ports:
       - "80:80"


### PR DESCRIPTION
## Context

This is to deploy the integration_postmigration branch as a docker image on uat.library.ualberta.ca

Related to #1680

## What's New

A bump to the "built with bundler" version in Gemfile.lock required a newer version of bundler. Fixed this in Dockerfile.deployment

Changed the predeploy script to look to this branch for getting the docker-compose with the correct docker image.

When `assets:precompile` happens Redis may not be running so ignore the Oaisys initializer that tries to create a new redis connection.

Added webpacker (to replace sprockets) so needed some tweaks to work with the new /public/packs setup.

Bumped the version to 2.0.0.pre so that when/if this is deployed we'll know which version is running.