### PR TITLE
Skip broken item causing fedora migration rake task to fail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,11 @@ All notable changes to Jupiter project will be documented in this file. Jupiter 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and releases in Jupiter project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2.0.0.pre2.6] 2020-07-20
 
 ### Fixed
-- docker image can be built and deployed
+- docker image can be built and deployed [PR#1757](https://github.com/ualbertalib/jupiter/pull/1757)
+- Skip broken item causing fedora migration rake task to fail [PR#1766](https://github.com/ualbertalib/jupiter/pull/1766)
 
 ## [2.0.0.pre2.5] 2020-07-03
 

--- a/lib/tasks/jupiter.rake
+++ b/lib/tasks/jupiter.rake
@@ -100,7 +100,8 @@ namespace :jupiter do
     puts 'Migrating Items...'
 
     Item.all.each do |item|
-      ArItem.from_item(item)
+      # Skip broken item.
+      ArItem.from_item(item) unless item.id == '4b3e0c51-33f7-4de9-97ad-d8bd298a8e92'
       print '.'
     end
 


### PR DESCRIPTION
Skip broken item (4b3e0c51-33f7-4de9-97ad-d8bd298a8e92) which was causing the jupiter:get_me_off_of_fedora rake task to fail.