### PR TITLE
Cute 2.0.1pre1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and releases in Jupiter project adheres to [Semantic Versioning](http://semver.o
 
 ## [Unreleased]
 
-## [1.3.0] - 2020-07-21
+## [2.0.1.pre1] - 2020-07-22
 
 ### Added
 - Mounted Oaisys engine [PR#1361](https://github.com/ualbertalib/jupiter/pull/1361)

--- a/lib/jupiter/version.rb
+++ b/lib/jupiter/version.rb
@@ -1,3 +1,3 @@
 module Jupiter
-  VERSION = '1.3.0'.freeze
+  VERSION = '2.0.1.pre1'.freeze
 end


### PR DESCRIPTION
Called the release 1.3.0 when it should've been called 2.0.1.pre1.