### PR TITLE
Revert "Bump bootsnap from 1.4.6 to 1.4.7"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -116,7 +116,7 @@ GEM
     bindex (0.8.1)
     binding_of_caller (0.8.0)
       debug_inspector (>= 0.0.1)
-    bootsnap (1.4.7)
+    bootsnap (1.4.6)
       msgpack (~> 1.0)
     brakeman (4.8.2)
     builder (3.2.4)


### PR DESCRIPTION
Reverts ualbertalib/jupiter#1775

This is causing problems using the docker image built on this branch.  I'm also seeing errors on my local development environment:

```
Traceback (most recent call last):
bin/rails: Bootsnap::LoadPathCache::FallbackScan
...
/home/pgwillia/.asdf/installs/ruby/2.6.6/lib/ruby/gems/2.6.0/gems/bootsnap-1.4.7/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:23:in `require': Could not load the 'listen' gem. Add `gem 'listen'` to the development group of your Gemfile (LoadError)
```