### PR TITLE
Run new migrations and fix tests now that date_ingested is null false

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,6 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-
 ActiveRecord::Schema.define(version: 2020_05_29_230303) do
 
   # These are extensions that must be enabled in order to support this database
@@ -62,7 +61,7 @@ ActiveRecord::Schema.define(version: 2020_05_29_230303) do
     t.datetime "record_created_at"
     t.string "hydra_noid"
     t.datetime "date_ingested"
-    t.string "title"
+    t.string "title", null: false
     t.string "fedora3_uuid"
     t.string "depositor"
     t.uuid "community_id"
@@ -80,7 +79,7 @@ ActiveRecord::Schema.define(version: 2020_05_29_230303) do
     t.datetime "record_created_at"
     t.string "hydra_noid"
     t.datetime "date_ingested"
-    t.string "title"
+    t.string "title", null: false
     t.string "fedora3_uuid"
     t.string "depositor"
     t.text "description"
@@ -195,8 +194,8 @@ ActiveRecord::Schema.define(version: 2020_05_29_230303) do
     t.bigint "owner_id", null: false
     t.datetime "record_created_at"
     t.string "hydra_noid"
-    t.datetime "date_ingested"
-    t.string "title"
+    t.datetime "date_ingested", null: false
+    t.string "title", null: false
     t.string "fedora3_uuid"
     t.string "depositor"
     t.string "alternative_title"
@@ -211,7 +210,7 @@ ActiveRecord::Schema.define(version: 2020_05_29_230303) do
     t.integer "sort_year"
     t.json "embargo_history", array: true
     t.json "is_version_of", array: true
-    t.json "member_of_paths", array: true
+    t.json "member_of_paths", null: false, array: true
     t.json "subject", array: true
     t.json "creators", array: true
     t.json "contributors", array: true
@@ -254,8 +253,8 @@ ActiveRecord::Schema.define(version: 2020_05_29_230303) do
     t.bigint "owner_id", null: false
     t.datetime "record_created_at"
     t.string "hydra_noid"
-    t.datetime "date_ingested"
-    t.string "title"
+    t.datetime "date_ingested", null: false
+    t.string "title", null: false
     t.string "fedora3_uuid"
     t.string "depositor"
     t.string "alternative_title"
@@ -270,7 +269,7 @@ ActiveRecord::Schema.define(version: 2020_05_29_230303) do
     t.integer "sort_year"
     t.json "embargo_history", array: true
     t.json "is_version_of", array: true
-    t.json "member_of_paths", array: true
+    t.json "member_of_paths", null: false, array: true
     t.json "subject", array: true
     t.text "abstract"
     t.string "language"

--- a/test/fixtures/items.yml
+++ b/test/fixtures/items.yml
@@ -6,6 +6,7 @@ fancy:
   created: 'Fall 2017'
   record_created_at: <%= 5.day.ago.to_s(:db) %>
   updated_at: <%= 5.day.ago.to_s(:db) %>
+  date_ingested: <%= 5.day.ago %>
   languages: <%= [CONTROLLED_VOCABULARIES[:language].english] %>
   license: <%= CONTROLLED_VOCABULARIES[:license].attribution_4_0_international %>
   item_type: <%= CONTROLLED_VOCABULARIES[:item_type].article %>
@@ -27,7 +28,7 @@ admin:
   sort_year: '2000'
   description: 'dcterms:description1$ Arabic ناتيومرلبسفأعدقحكهجشطصزخضغذثئةظؤىءآإ Greek αβγδεζηθικλμνξοπρςστυφχψω ΑΒΓΔΕΖΗΘΙΚΛΜΝΞΟΠΡΣΤΥΦΧΨΩ Cyrillic абвгдеёжзийклмнопрстуфхцчшщъыьэюя АБВГДЕЁЖЗИЙКЛМНОПРСТУФХЦЧШЩЪЫЬЭЮЯ Lao ກ-ໝ Thai ก-๎ Burmese က-ၙ Khmer ក-៹ Korean 가-힣 Bengali অ-ৱ // Spanish áéíóúüñ French àâçèéêëîïôùûü Portuguese àáâãçéêíóôõú Hindi ऄ-ॿ Pujabi ਅ-ੴ Mandarin 海萵苣白菜冬瓜韭菜竹筍生菜大頭菜豆薯銀甜菜莧菜豌豆蒲公英蔥豌豆苗亞羅婆羅門參西葫蘆。小豆辣根土豆 Japanese アオサメロンキャベツニラ竹シュートレタスルタバガのクズイモ銀ビートアマランスエンドウタンポポねぎ'
   is_version_of: ['dcterms:isVersionOf1$ Sydorenko, Dmytro & Rankin, Robert. (2013). Simulation of O+ upflows created by electron precipitation and Alfvén waves in the ionosphere. Journal of Geophysical Research: Space Physics, 118(9), 5562-5578. http://doi.org/10.1002/jgra.50531', 'dcterms:isVersionOf2$ Another version']
-  languages: <%= [CONTROLLED_VOCABULARIES[:language].no_linguistic_content, CONTROLLED_VOCABULARIES[:language].french] %> 
+  languages: <%= [CONTROLLED_VOCABULARIES[:language].no_linguistic_content, CONTROLLED_VOCABULARIES[:language].french] %>
   related_link: 'dcterms:relation1$ http://doi.org/10.1007/xxxxxx-xxx-xxxx-x'
   source: 'dcterms:source1$ Some source'
   spatial_subjects: ['dcterms:spatial1$ Canada', 'dcterms:spatial2$ Nicaragua']
@@ -45,13 +46,14 @@ admin:
   date_ingested: '2000-01-01T00:00:00.007Z'
   record_created_at: '2000-01-01T00:00:00.007Z'
   updated_at: <%= 5.day.from_now.to_s(:db) %>
-  
+
 private_item:
   visibility: <%= JupiterCore::VISIBILITY_PRIVATE %>
   owner: admin
   title: 'Private Item'
   creators: ['Joe Blow']
   created: 'Fall 2017'
+  date_ingested: <%= 5.day.ago %>
   record_created_at: <%= 5.day.ago.to_s(:db) %>
   languages: <%= [CONTROLLED_VOCABULARIES[:language].english] %>
   license: <%= CONTROLLED_VOCABULARIES[:license].attribution_4_0_international %>
@@ -66,6 +68,7 @@ old_license:
   title: 'Admin Item'
   creators: ['Joe Blow']
   created: 'Winter 2017'
+  date_ingested: <%= 5.day.ago %>
   record_created_at: <%= 5.day.ago.to_s(:db) %>
   languages: <%= [CONTROLLED_VOCABULARIES[:language].english] %>
   license: <%= CONTROLLED_VOCABULARIES[:old_license].attribution_3_0_international %>
@@ -79,6 +82,7 @@ authenticated_item:
   title: 'Authenticated Item'
   creators: ['Joe Blow']
   created: 'Fall 2017'
+  date_ingested: <%= 5.day.ago %>
   record_created_at: <%= 5.day.ago.to_s(:db) %>
   languages: <%= [CONTROLLED_VOCABULARIES[:language].english] %>
   license: <%= CONTROLLED_VOCABULARIES[:license].attribution_4_0_international %>

--- a/test/fixtures/thesis.yml
+++ b/test/fixtures/thesis.yml
@@ -4,6 +4,7 @@ nice:
   title: 'Nice Item'
   dissertant: 'Joe Blow'
   graduation_date: '2019'
+  date_ingested: <%= 5.day.ago %>
   record_created_at: <%= 5.day.ago.to_s(:db) %>
   updated_at: <%= 5.day.ago.to_s(:db) %>
   abstract: 'This is my abstract'
@@ -15,6 +16,7 @@ admin:
   title: 'Admin Thesis'
   dissertant: 'Joe Blow'
   graduation_date: '2019'
+  date_ingested: <%= 5.day.ago %>
   record_created_at: <%= 5.day.from_now.to_s(:db) %>
   updated_at: <%= 5.day.ago.to_s(:db) %>
   abstract: 'This is my abstract'
@@ -26,6 +28,7 @@ private:
   title: 'Private thesis'
   dissertant: 'Joe Blow'
   graduation_date: '2019'
+  date_ingested: <%= 5.day.ago %>
   record_created_at: <%= 5.day.ago.to_s(:db) %>
   updated_at: <%= 10.day.ago.to_s(:db) %>
   abstract: 'This is my abstract'
@@ -37,6 +40,7 @@ fancy:
   title: 'Fancy Item'
   dissertant: 'Joe Blow'
   graduation_date: '2019'
+  date_ingested: <%= 5.day.ago %>
   record_created_at: <%= 5.day.ago.to_s(:db) %>
   abstract: 'This is my abstract'
   member_of_paths: <%= ["#{ActiveRecord::FixtureSet.identify(:thesis, :uuid)}/#{ActiveRecord::FixtureSet.identify(:thesis, :uuid)}"] %>
@@ -49,6 +53,7 @@ embargoed:
   title: 'Embargoed Item'
   dissertant: 'Joe Blow'
   graduation_date: '2019'
+  date_ingested: <%= 5.day.ago %>
   record_created_at: <%= 5.day.ago.to_s(:db) %>
   abstract: 'This is my abstract'
   member_of_paths: <%= ["#{ActiveRecord::FixtureSet.identify(:thesis, :uuid)}/#{ActiveRecord::FixtureSet.identify(:embargoed_thesis, :uuid)}"] %>


### PR DESCRIPTION
If you run migrations in integration_postmigration branch, tests will failure as date_ingested is now null false for items and theses. This PR fixes this by making sure our item/thesis fixtures are setting date_ingested field.