### PR TITLE
Fix issue with reporting preservation errors for expected behaviour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and releases in Jupiter project adheres to [Semantic Versioning](http://semver.o
 - Rails 6 sidekiq queues
 - Add stylelint to Jupiter [#1120](https://github.com/ualbertalib/jupiter/issues/1430
 - migration to fix concatenated subjects (part 1) [#1449](https://github.com/ualbertalib/jupiter/issues/1449)
+- fix bad logic on preservation errors
 
 ### Changed
 - bump rubocop-rails to 2.4.1 Rails/FilePath default changed to slashes [PR#1398](https://github.com/ualbertalib/jupiter/pull/1398)

--- a/app/models/jupiter_core/depositable.rb
+++ b/app/models/jupiter_core/depositable.rb
@@ -178,21 +178,8 @@ class JupiterCore::Depositable < ApplicationRecord
     self.embargo_history << embargo_history_item
   end
 
-  def push_item_id_for_preservation
-    if preserve == false
-      Rails.logger.warn("Could not preserve #{id}")
-      Rollbar.error("Could not preserve #{id}")
-    end
-
-    true
-  rescue StandardError => e
-    # we trap errors in writing to the Redis queue in order to avoid crashing the save process for the user.
-    Rollbar.error("Error occured in push_item_id_for_preservation, Could not preserve #{id}", e)
-    true
-  end
-
   # rubocop:disable Style/GlobalVars
-  def preserve
+  def push_item_id_for_preservation
     queue_name = Rails.application.secrets.preservation_queue_name
 
     $queue ||= ConnectionPool.new(size: 1, timeout: 5) { Redis.current }
@@ -201,9 +188,11 @@ class JupiterCore::Depositable < ApplicationRecord
       connection.zadd queue_name, Time.now.to_f, id
     end
 
-  # rescue all preservation errors so that the user can continue to use the application normally
+    true
   rescue StandardError => e
-    Rollbar.error("Could not preserve #{id}", e)
+    # we trap errors in writing to the Redis queue in order to avoid crashing the save process for the user.
+    Rollbar.error("Error occurred in push_item_id_for_preservation, Could not preserve #{id}", e)
+    true
   end
   # rubocop:enable Style/GlobalVars
 


### PR DESCRIPTION
## Context

I was watching several hundred the "Could not preserve" warnings roll in on Rollbar earlier when I happened to notice Tricia comment:

> Changed this to warning because of the noise it generates without necessarily being an error. See the PMPY logs for the error source

> This error occurs when the item is already in the preservation queue. This could be a succession of multiple saves within a short period of time, ...

PMPY was designed to use a sorted set for the queue, with the idea that when you added something that was already in the queue, the higher timestamp would "push it to the back" of the queue instead of adding it a second time, ensuring that a succession of quick multiple saves only resulted in one preservation event. So why are we throwing an error in Rollbar for something that we designed the system to handle?

## What's New

The semantics of the Redis `ZADD` command are that it returns the number of items it added to the queue. In particular, if an ID is already in the queue, ZADD updates the ID's score with the new timestamp we send (meaning it moves to the back of the queue, because time is ever-increasing), and returns 0, because it didn't add anything new to the queue. We were then taking that return value and comparing it to false, and since 0 is falsey, that test was true, so we sent an error to Rollbar to complain that we had successfully done what we set out to do in the first place.

![Jim looks at the camera](https://i.giphy.com/media/HbjDTy6gfBXMI/giphy.gif?cid=ecf05e47996x1jhiyy6re7k0ppr4a622op7ycucb5z2946xc&rid=giphy.gif)

This fixes that.
