### PR TITLE
add tmp/cache to docker ignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,6 +3,7 @@
 *.md
 
 tmp
+tmp/cache
 !tmp/pids/.keep
 log
 coverage/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and releases in Jupiter project adheres to [Semantic Versioning](http://semver.o
 
 ## [Unreleased]
 
+### Added
+- tmp/cache to docker ignore [#1680](https://github.com/ualbertalib/jupiter/issues/1680)
+
 ## [2.0.1.pre1] - 2020-07-22
 
 ### Added


### PR DESCRIPTION
## Context

to avoid `Errno::EACCES: Permission denied @ rb_sysopen - /app/tmp/cache/bootsnap-load-path-cache.1.18857.tmp` error don't copy in that cache!

Related to #1680

## What's New

Ignore tmp/cache directory when building docker images.