### PR TITLE
Master branch docker image tag name change

### DIFF
--- a/docker-compose.deployment.yml
+++ b/docker-compose.deployment.yml
@@ -51,7 +51,7 @@ services:
   # Sidekiq
   worker: &rails
     restart: always
-    image: ualbertalib/jupiter:deployment
+    image: ualbertalib/jupiter:1.x
     volumes:
       - file-storage:/app/storage/
     command: bundle exec sidekiq


### PR DESCRIPTION
Reusing `deployment` for the more active `integration_postmigration` branch.  Chose `1.x` to indicate the versions currently tracked by the `master` branch.

Related to #1680 