### PR TITLE
script to launch watchtower

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and releases in Jupiter project adheres to [Semantic Versioning](http://semver.o
 
 ### Added
 - tmp/cache to docker ignore [#1680](https://github.com/ualbertalib/jupiter/issues/1680)
+- script to launch watchtower [#1722](https://github.com/ualbertalib/jupiter/issues/1722)
 
 ## [2.0.1.pre1] - 2020-07-22
 

--- a/bin/predeploy
+++ b/bin/predeploy
@@ -13,6 +13,8 @@ set -o nounset
 readonly branch_name="integration_postmigration"
 readonly install_directory="/home/deploy/jupiter"
 
+curl -o "watchtower" "https://raw.githubusercontent.com/ualbertalib/jupiter/${branch_name}/bin/watchtower"
+
 mkdir -p "${install_directory}"
 curl -o "${install_directory}/deploy" "https://raw.githubusercontent.com/ualbertalib/jupiter/${branch_name}/bin/deploy"
 curl -o "${install_directory}/docker-compose.yml" "https://raw.githubusercontent.com/ualbertalib/jupiter/${branch_name}/docker-compose.production.yml"

--- a/bin/watchtower
+++ b/bin/watchtower
@@ -1,0 +1,12 @@
+## this file comes from the Jupiter project  "https://raw.githubusercontent.com/ualbertalib/jupiter/${branch_name}/bin/watchtower"
+## it will start the watchtower container which polls docker hub for the latest image of the running docker containers
+## to review watchtower activity use `docker logs watchtower`
+
+docker stop watchtower && docker rm watchtower
+
+docker run -d \
+    --name watchtower \
+    -v /var/run/docker.sock:/var/run/docker.sock \
+    containrrr/watchtower \
+    --interval 30 \
+    --cleanup


### PR DESCRIPTION
## Context

We want to start practicing Continuous Deployment.  Watchtower is a docker container that polls docker hub for updated images for the containers that are running locally.  This script will be responsible for running the watchtower container.

Related to #1722

## What's New
Added watchtower script and using predeploy script to retrieve it.