### PR TITLE
added two solr exporters for ar community and ar collection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to Jupiter project will be documented in this file. Jupiter 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and releases in Jupiter project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- Added solr exporters for ar community and ar collection [#1782](https://github.com/ualbertalib/jupiter/issues/1782)
+
 ## [2.0.0.pre2.6] 2020-07-20
 
 ### Fixed

--- a/app/models/ar_collection.rb
+++ b/app/models/ar_collection.rb
@@ -1,5 +1,7 @@
 class ArCollection < ApplicationRecord
 
+  has_solr_exporter Exporters::Solr::ArCollectionExporter
+
   acts_as_rdfable do |config|
     config.community_id has_predicate: ::TERMS[:ual].path
     config.description has_predicate: ::RDF::Vocab::DC.description

--- a/app/models/ar_community.rb
+++ b/app/models/ar_community.rb
@@ -1,5 +1,7 @@
 class ArCommunity < ApplicationRecord
 
+  has_solr_exporter Exporters::Solr::ArCommunityExporter
+
   acts_as_rdfable do |config|
     config.description has_predicate: ::RDF::Vocab::DC.description
     config.creators has_predicate: ::RDF::Vocab::DC.creator

--- a/app/models/exporters/solr/ar_collection_exporter.rb
+++ b/app/models/exporters/solr/ar_collection_exporter.rb
@@ -1,0 +1,27 @@
+class Exporters::Solr::ArCollectionExporter < Exporters::Solr::BaseExporter
+
+  index :title, role: [:search, :sort]
+
+  # UAL attributes
+  index :fedora3_uuid, role: :exact_match
+  index :depositor, role: [:search]
+
+  index :community_id, type: :path, role: :pathing
+
+  index :description, role: [:search]
+  index :restricted, type: :boolean, role: :exact_match
+  index :creators, role: :exact_match
+
+  # TODO: refactor this next line and move the title into Fedora, if we're still on Fedora at that point.
+  #
+  # We got lucky in that there are not expected to be a large number of Collections in this phase of Jupiter
+  # but using +additional_search_index+ to store data that isn't recreatable solely by inspecting this object's
+  # Fedora record creates data-ordering issues that are complicated to work around during Solr-index recovery
+  # scenarios. See recover.rake for information on the particular problems this is causing and why we want to
+  # eliminate it.
+  custom_index :community_title, role: :sort,
+                                 as: lambda { |collection|
+                                       ArCommunity.find(collection.community_id).title if collection.community_id.present?
+                                     }
+
+end

--- a/app/models/exporters/solr/ar_community_exporter.rb
+++ b/app/models/exporters/solr/ar_community_exporter.rb
@@ -1,0 +1,12 @@
+class Exporters::Solr::ArCommunityExporter < Exporters::Solr::BaseExporter
+
+  index :title, role: [:search, :sort]
+
+  # UAL attributes
+  index :fedora3_uuid, role: :exact_match
+  index :depositor, role: [:search]
+
+  index :description, role: [:search]
+  index :creators, role: :exact_match
+
+end


### PR DESCRIPTION
#1782

Added missing solr exporters so that after migration the collections and communities show up.
After:
![Screenshot from 2020-08-10 14-44-24](https://user-images.githubusercontent.com/14242562/89830604-b5dc4b00-db19-11ea-96f6-8f79bf4d97c3.png)
![Screenshot from 2020-08-10 14-44-16](https://user-images.githubusercontent.com/14242562/89830605-b674e180-db19-11ea-9020-934f11a4f732.png)

