### PR TITLE
Disabling Collection checking of Communities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to Jupiter project will be documented in this file. Jupiter 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and releases in Jupiter project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.2.22] – 2020-08-24
+- disable Collection usage of Communities for a PCDM triple in order to work around data corruption in Prod
 
 ## [1.2.21] – 2020–05-28
 - bump kaminari from 1.1.1 to 1.2.1 [CVE-2020-11082](https://github.com/advisories/GHSA-r5jw-62xg-j433)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to Jupiter project will be documented in this file. Jupiter 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and releases in Jupiter project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
 ## [1.2.22] – 2020-08-24
 - disable Collection usage of Communities for a PCDM triple in order to work around data corruption in Prod
 

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -59,17 +59,6 @@ class Collection < JupiterCore::LockedLdpObject
       self.visibility = JupiterCore::VISIBILITY_PUBLIC
     end
 
-    before_save do
-      if community_id_changed?
-        # This adds the `pcdm::memberOf` predicate, pointing to the community
-        self.member_of_collections = []
-        # TODO: can this be streamlined so that a fetch from Fedora isn't needed?
-        community.unlock_and_fetch_ldp_object do |unlocked_community|
-          self.member_of_collections += [unlocked_community]
-        end
-      end
-    end
-
     def can_be_destroyed?
       return true if member_objects.count == 0
 

--- a/app/policies/community_policy.rb
+++ b/app/policies/community_policy.rb
@@ -8,4 +8,16 @@ class CommunityPolicy < LockedLdpObjectPolicy
     true
   end
 
+  def update?
+    false
+  end
+
+  def edit?
+    false
+  end
+
+  def destroy?
+    false
+  end
+
 end

--- a/test/integration/community_show_test.rb
+++ b/test/integration/community_show_test.rb
@@ -40,15 +40,6 @@ class CommunityShowTest < ActionDispatch::IntegrationTest
     assert_select 'img.img-thumbnail', count: 1
     assert_select 'div.img-thumbnail i.fa', count: 0
 
-    # Community delete, edit and create new collection buttons should be shown
-    assert_select 'a[href=?]',
-                  admin_community_path(@community1),
-                  text: I18n.t('delete')
-
-    assert_select 'a[href=?]',
-                  edit_admin_community_path(@community1),
-                  text: I18n.t('edit')
-
     assert_select 'a[href=?]',
                   new_admin_community_collection_path(@community1),
                   text: I18n.t('communities.show.create_collection')
@@ -80,10 +71,6 @@ class CommunityShowTest < ActionDispatch::IntegrationTest
     # Community delete, edit and create new collection buttons should not be shown
     assert_select 'a[href=?]',
                   admin_community_path(@community1),
-                  false
-
-    assert_select 'a[href=?]',
-                  edit_admin_community_path(@community1),
                   false
 
     assert_select 'a[href=?]',

--- a/test/models/collection_test.rb
+++ b/test/models/collection_test.rb
@@ -41,19 +41,4 @@ class CollectionTest < ActiveSupport::TestCase
                            id: community_id)
   end
 
-  test 'member_of gets set on save' do
-    community_uri = nil
-    community = Community.new_locked_ldp_object(title: 'Community', owner: 1).unlock_and_fetch_ldp_object do |uo|
-      uo.save!
-      community_uri = uo.uri
-    end
-    Collection.new_locked_ldp_object(title: 'foo', owner: users(:regular).id,
-                                     community_id: community.id).unlock_and_fetch_ldp_object do |uo|
-      uo.save!
-      uo.reload
-      # Make sure the triple has the right predicate and object
-      assert_match(/#{::Hydra::PCDM::Vocab::PCDMTerms.memberOf}.*#{community_uri}/, uo.resource.dump(:ntriples))
-    end
-  end
-
 end

--- a/test/policies/community_policy_test.rb
+++ b/test/policies/community_policy_test.rb
@@ -10,9 +10,9 @@ class CommunityPolicyTest < ActiveSupport::TestCase
     assert CommunityPolicy.new(current_user, community).create?
     assert CommunityPolicy.new(current_user, community).new?
     assert CommunityPolicy.new(current_user, community).show?
-    assert CommunityPolicy.new(current_user, community).edit?
-    assert CommunityPolicy.new(current_user, community).update?
-    assert CommunityPolicy.new(current_user, community).destroy?
+    assert_not CommunityPolicy.new(current_user, community).edit?
+    assert_not CommunityPolicy.new(current_user, community).update?
+    assert_not CommunityPolicy.new(current_user, community).destroy?
   end
 
   test 'general user should only be able to see index and show of communities' do


### PR DESCRIPTION
Disabling due to issue with many communities in Prod having become corrupted in Fedora, blocking Collection creation. Unnecessary once Fedora is migrated away from. 

Also disables updating and editing of Communities since that's currently broken for any of the impacted Communities, and deleting of Communities since that seems related to the issue in the first place (although the bug seems unlikely to have come through the interactive layers).