### PR TITLE
Enable SSL for UAT

### DIFF
--- a/config/environments/uat.rb
+++ b/config/environments/uat.rb
@@ -1,4 +1,4 @@
-Rails.application.routes.default_url_options = { host: 'uat.library.ualberta.ca', port: 80, protocol: 'http' }
+Rails.application.routes.default_url_options = { host: 'uat.library.ualberta.ca', port: 443, protocol: 'https' }
 
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.

--- a/config/environments/uat.rb
+++ b/config/environments/uat.rb
@@ -38,7 +38,7 @@ Rails.application.configure do
   # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for NGINX
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+  config.force_ssl = true
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.

--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -2,6 +2,7 @@ upstream jupiter {
   server web:3000;
 }
 
+  return 301 https://$server_name$request_uri;
 
 server {
 

--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -5,7 +5,7 @@ upstream jupiter {
 
 server {
 
-  listen 80 ssl;
+  listen 443 ssl;
 
   client_max_body_size 4G;
   keepalive_timeout 10;
@@ -23,11 +23,18 @@ server {
   try_files $uri/index.html $uri @jupiter;
 
   location @jupiter {
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header Host $http_host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Host $http_host;
+    proxy_set_header X-Forwarded-Port $server_port;
+    proxy_set_header X-Forwarded-Server $host;
+    proxy_set_header X-Forwarded-Ssl on;
+    proxy_set_header X-Forwarded-Proto https;
+    proxy_set_header Origin https://$http_host;
     proxy_redirect off;
+    proxy_pass http://web:3000;
 
-    proxy_pass http://jupiter;
     # limit_req zone=one;
     access_log /var/log/nginx.access.log;
     error_log /var/log/nginx.error.log;

--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -10,8 +10,8 @@ server {
   client_max_body_size 4G;
   keepalive_timeout 10;
 
-  ssl_certificate     /etc/nginx/certs/server.crt;
-  ssl_certificate_key /etc/nginx/certs/server.key;
+  ssl_certificate     /etc/nginx/certs/library.ualberta.ca.crt;
+  ssl_certificate_key /etc/nginx/certs/library.ualberta.ca.key;
   ssl_protocols       TLSv1 TLSv1.1 TLSv1.2;
   ssl_ciphers         HIGH:!aNULL:!MD5;
 
@@ -33,7 +33,7 @@ server {
     proxy_set_header X-Forwarded-Proto https;
     proxy_set_header Origin https://$http_host;
     proxy_redirect off;
-    proxy_pass http://web:3000;
+    proxy_pass http://jupiter;
 
     # limit_req zone=one;
     access_log /var/log/nginx.access.log;

--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -15,13 +15,13 @@ server {
   client_max_body_size 4G;
   keepalive_timeout 10;
 
-  ssl_certificate     /etc/nginx/certs/library.ualberta.ca.bundle.crt;
+  ssl_certificate /etc/nginx/certs/library.ualberta.ca.bundle.crt;
   ssl_certificate_key /etc/nginx/certs/library.ualberta.ca.key;
-  ssl_protocols       TLSv1 TLSv1.1 TLSv1.2;
-  ssl_ciphers         HIGH:!aNULL:!MD5;
+  ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+  ssl_ciphers HIGH:!aNULL:!MD5;
 
   error_page 500 502 504 /500.html;
-  error_page 497  301 =307 https://$host:$server_port$request_uri;
+  error_page 497 301 =307 https://$host:$server_port$request_uri;
 
   server_name $HOSTNAME jupiter;
   root /app/public;
@@ -56,7 +56,7 @@ server {
     return 410;
   }
 
-  if ($request_method !~ ^(GET|HEAD|PUT|PATCH|POST|DELETE|OPTIONS)$ ){
+  if ($request_method !~ ^(GET|HEAD|PUT|PATCH|POST|DELETE|OPTIONS)$ ) {
     return 405;
   }
 }

--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -5,12 +5,18 @@ upstream jupiter {
 
 server {
 
-  listen 80;
+  listen 80 ssl;
 
   client_max_body_size 4G;
   keepalive_timeout 10;
 
+  ssl_certificate     /etc/nginx/certs/server.crt;
+  ssl_certificate_key /etc/nginx/certs/server.key;
+  ssl_protocols       TLSv1 TLSv1.1 TLSv1.2;
+  ssl_ciphers         HIGH:!aNULL:!MD5;
+
   error_page 500 502 504 /500.html;
+  error_page 497  301 =307 https://$host:$server_port$request_uri;
 
   server_name $HOSTNAME jupiter;
   root /app/public;

--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -2,7 +2,11 @@ upstream jupiter {
   server web:3000;
 }
 
+server {
+  listen 80;
+  server_name $HOSTNAME;
   return 301 https://$server_name$request_uri;
+}
 
 server {
 
@@ -11,7 +15,7 @@ server {
   client_max_body_size 4G;
   keepalive_timeout 10;
 
-  ssl_certificate     /etc/nginx/certs/library.ualberta.ca.crt;
+  ssl_certificate     /etc/nginx/certs/library.ualberta.ca.bundle.crt;
   ssl_certificate_key /etc/nginx/certs/library.ualberta.ca.key;
   ssl_protocols       TLSv1 TLSv1.1 TLSv1.2;
   ssl_ciphers         HIGH:!aNULL:!MD5;

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -71,3 +71,4 @@ services:
       - assets:/app/public/
     ports:
       - "80:80"
+      - "443:443"

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -67,7 +67,7 @@ services:
     env_file: .env_deployment
     volumes:
       - ./config/nginx.conf:/etc/nginx/conf.d/default.conf
-      - ~/deploy/UALcert:/etc/nginx/certs
+      - ../UALcert:/etc/nginx/certs
       - assets:/app/public/
     ports:
       - "80:80"

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -67,6 +67,7 @@ services:
     env_file: .env_deployment
     volumes:
       - ./config/nginx.conf:/etc/nginx/conf.d/default.conf
+      - ~/deploy/UALcert:/etc/nginx/certs
       - assets:/app/public/
     ports:
       - "80:80"


### PR DESCRIPTION
## Context
I’ve sometimes run across instances where a “thing” works in http but fails under https. We want to be able to see this working on UAT.

Related to #1723 

## What's New

References to certs. Added [X-Forwarded-For headers](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For) to nginx configuration.  Port forwarding for nginx 443 in the docker-compose. Updated the default_url options. Force ssl.