### PR TITLE
webpacker resolved_paths deprecated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and releases in Jupiter project adheres to [Semantic Versioning](http://semver.o
 ### Changed
 - Merge file_set and original_file AIP API entry points [#1557](https://github.com/ualbertalib/jupiter/issues/1557)
 - Skipped failing Oaisys tests [#1817](https://github.com/ualbertalib/jupiter/issues/1817)
+- webpacker resolved_paths to additional paths [#1836](https://github.com/ualbertalib/jupiter/issues/1836)
  
 ### Fixed
 - Upgrade Rubocop/Erblint and fix cop violations [#1803](https://github.com/ualbertalib/jupiter/pull/1803)

--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -11,7 +11,7 @@ default: &default
 
   # Additional paths webpack should lookup modules
   # ['app/assets', 'engine/foo/app/assets']
-  resolved_paths: []
+  additional_paths : []
 
   # Reload manifest.json on all requests so we reload latest compiled packs
   cache_manifest: false


### PR DESCRIPTION
## Context

https://stackoverflow.com/a/63530034 explains that resolved_paths has been deprecated and should be replaced by additional_paths.  This fixes the error that is triggered by `rake assets:precompile`

Related to https://github.com/ualbertalib/jupiter/issues/1836

## What's New
Replace `resolved_paths` with `additional_paths` in webpacker config.