### PR TITLE
fix 301 redirect on UAT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and releases in Jupiter project adheres to [Semantic Versioning](http://semver.o
  
 ### Fixed
 - Upgrade Rubocop/Erblint and fix cop violations [#1803](https://github.com/ualbertalib/jupiter/pull/1803)
+- UAT nginx port 80 redirect []()
 
 ## [2.0.1.pre1] - 2020-07-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and releases in Jupiter project adheres to [Semantic Versioning](http://semver.o
  
 ### Fixed
 - Upgrade Rubocop/Erblint and fix cop violations [#1803](https://github.com/ualbertalib/jupiter/pull/1803)
-- UAT nginx port 80 redirect []()
+- UAT nginx port 80 redirect [PR#1893](https://github.com/ualbertalib/jupiter/pull/1839)
 
 ## [2.0.1.pre1] - 2020-07-22
 

--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -5,7 +5,7 @@ upstream jupiter {
 server {
   listen 80;
   server_name $HOSTNAME;
-  return 301 https://$server_name$request_uri;
+  return 301 https://$host$request_uri;
 }
 
 server {
@@ -38,6 +38,7 @@ server {
     proxy_set_header X-Forwarded-Proto https;
     proxy_set_header Origin https://$http_host;
     proxy_redirect off;
+    
     proxy_pass http://jupiter;
 
     # limit_req zone=one;


### PR DESCRIPTION
### Context

$server_name ends up being the docker container id, which is decidedly not helpful to the outside world and not routable.  host is what we really want.

Related to #1723