### PR TITLE
uat configuration to accept proxy from upstream nginx-proxy

### DIFF
--- a/.env_deployment_sample
+++ b/.env_deployment_sample
@@ -21,3 +21,7 @@ POSTGRES_USER=jupiter
 # Nginx environment variables
 HOSTNAME=localhost
 SKYLIGHT_AUTHENTICATION=secretauthenticationtoken
+
+VIRTUAL_HOST=era.localhost
+VIRTUAL_PROTO=https
+VIRTUAL_PORT=443

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@ and releases in Jupiter project adheres to [Semantic Versioning](http://semver.o
 ## [Unreleased]
 
 ### Changed
-- Enable Skylight in the Staging environment and remove it from the UAT environment (where it was unused, and the performance of the
-Docker environment is less likely to be similar to Production)
+- Enable Skylight in the Staging environment and remove it from the UAT environment (where it was unused, and the performance of the Docker environment is less likely to be similar to Production)
+- uat configuration to accept proxy from upstream nginx-proxy [#1724](https://github.com/ualbertalib/jupiter/issues/1724)
 
 ### Fixed
 - bump rubocop and fix cop violations [PR#1845](https://github.com/ualbertalib/jupiter/pull/1845)

--- a/config/environments/uat.rb
+++ b/config/environments/uat.rb
@@ -1,4 +1,4 @@
-Rails.application.routes.default_url_options = { host: 'uat.library.ualberta.ca', port: 443, protocol: 'https' }
+Rails.application.routes.default_url_options = { host: 'era.uat.library.ualberta.ca', protocol: 'https' }
 
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -21,8 +21,10 @@ services:
   solr:
     restart: always
     image: solr:6.6
+    environment:
+      - VIRTUAL_HOST=solr.era.uat.library.ualberta.ca
     ports:
-      - "8983:8983"
+      - "8983"
     volumes:
       - solr:/opt/solr/server/solr/mycores
       - ./solr/config:/config

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -70,5 +70,5 @@ services:
       - ../UALcert:/etc/nginx/certs
       - assets:/app/public/
     ports:
-      - "80:80"
-      - "443:443"
+      - "80"
+      - "443"


### PR DESCRIPTION
## Context

Names are so much easier to remember that port numbers.  Let's use subdomains of *.uat.library.ualberta.ca and [nginx-proxy](https://github.com/nginx-proxy/nginx-proxy)/docker-gen to do this proxying to different docker containers in our different projects.
https://github.com/ualbertalib/di_internal/pull/96

Closes #1724

## What's New
Don't do the port mapping anymore and add the environment variables for nginx-proxy