### PR TITLE
Fix rubocop performance cop issue #trivial

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -160,8 +160,7 @@ Style/TrailingUnderscoreVariable:
 
 # Use %w or %W for arrays of words.
 Style/WordArray:
-  Enabled: true
-  EnforcedStyle: brackets
-  
+  Enabled: false
+
 Performance/TimesMap:
   Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -160,7 +160,8 @@ Style/TrailingUnderscoreVariable:
 
 # Use %w or %W for arrays of words.
 Style/WordArray:
-  Enabled: false
-
+  Enabled: true
+  EnforcedStyle: brackets
+  
 Performance/TimesMap:
   Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -152,7 +152,8 @@ Style/SingleLineMethods:
   Enabled: false
 
 Style/SymbolArray:
-  Enabled: false
+  Enabled: true
+  EnforcedStyle: brackets
 
 Style/TrailingUnderscoreVariable:
   Enabled: false

--- a/app/models/jupiter_core/solr_services/deferred_faceted_solr_query.rb
+++ b/app/models/jupiter_core/solr_services/deferred_faceted_solr_query.rb
@@ -41,6 +41,7 @@ class JupiterCore::SolrServices::DeferredFacetedSolrQuery
 
     criteria[:sort] = []
     criteria[:sort_order] = []
+    possible_sort_orders = %i[asc desc]
 
     attributes.each_with_index do |attr, idx|
       next if attr.blank?
@@ -68,7 +69,7 @@ class JupiterCore::SolrServices::DeferredFacetedSolrQuery
                                  # When sorting by score it only makes sense to use :desc order from the user
                                  # perspective so we ignore the order if one is given.
                                  :desc
-                               elsif order.present? && [:asc, :desc].include?(order)
+                               elsif order.present? && possible_sort_orders.include?(order)
                                  order
                                else
                                  # We could not find the order so we switch to default sort direction

--- a/app/models/jupiter_core/solr_services/deferred_faceted_solr_query.rb
+++ b/app/models/jupiter_core/solr_services/deferred_faceted_solr_query.rb
@@ -4,6 +4,10 @@ class JupiterCore::SolrServices::DeferredFacetedSolrQuery
   include Kaminari::PageScopeMethods
   include Kaminari::ConfigurationMethods::ClassMethods
 
+  POSSIBLE_SORT_ORDERS = [:asc, :desc].freeze
+
+  private_constant :POSSIBLE_SORT_ORDERS
+
   def initialize(q:, qf:, fq:, facet_map:, facet_fields:, ranges:, restrict_to_model:)
     criteria[:q] = q
     criteria[:qf] = qf # Query Fields
@@ -41,7 +45,6 @@ class JupiterCore::SolrServices::DeferredFacetedSolrQuery
 
     criteria[:sort] = []
     criteria[:sort_order] = []
-    possible_sort_orders = [:asc, :desc]
 
     attributes.each_with_index do |attr, idx|
       next if attr.blank?
@@ -69,7 +72,7 @@ class JupiterCore::SolrServices::DeferredFacetedSolrQuery
                                  # When sorting by score it only makes sense to use :desc order from the user
                                  # perspective so we ignore the order if one is given.
                                  :desc
-                               elsif order.present? && possible_sort_orders.include?(order)
+                               elsif order.present? && POSSIBLE_SORT_ORDERS.include?(order)
                                  order
                                else
                                  # We could not find the order so we switch to default sort direction

--- a/app/models/jupiter_core/solr_services/deferred_faceted_solr_query.rb
+++ b/app/models/jupiter_core/solr_services/deferred_faceted_solr_query.rb
@@ -41,7 +41,7 @@ class JupiterCore::SolrServices::DeferredFacetedSolrQuery
 
     criteria[:sort] = []
     criteria[:sort_order] = []
-    possible_sort_orders = %i[asc desc]
+    possible_sort_orders = [:asc, :desc]
 
     attributes.each_with_index do |attr, idx|
       next if attr.blank?


### PR DESCRIPTION
This small change fixed the rubocop problem introduced when merging PR #1827 

## Context

PR #1827 introduced a problem with cop [Performance/CollectionLiteralInLoop](https://docs.rubocop.org/rubocop-performance/cops_performance.html#performancecollectionliteralinloop)

## What's New

Small change replacing an array with literals with a local variable. 