### PR TITLE
Enable Skylight on Staging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and releases in Jupiter project adheres to [Semantic Versioning](http://semver.o
 
 ## [Unreleased]
 
+### Changed
+- Enable Skylight in the Staging environment and remove it from the UAT environment (where it was unused, and the performance of the
+Docker environment is less likely to be similar to Production)
+
 ### Fixed
 - bump rubocop and fix cop violations [PR#1845](https://github.com/ualbertalib/jupiter/pull/1845)
 - bump rubocop-performance and fix cop violations [PR#1850](https://github.com/ualbertalib/jupiter/pull/1850)

--- a/config/application.rb
+++ b/config/application.rb
@@ -37,7 +37,7 @@ module Jupiter
     config.active_job.queue_adapter = :sidekiq
 
     # Run skylight in Staging for performance metric monitoring pre-launch
-    config.skylight.environments << "staging"
+    config.skylight.environments << 'staging'
 
     config.redis_key_prefix = "jupiter.#{Rails.env}."
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -36,8 +36,8 @@ module Jupiter
     # Set ActiveJob adapter
     config.active_job.queue_adapter = :sidekiq
 
-    # Run skylight in UAT for performance metric monitoring pre-launch
-    config.skylight.environments += ['uat']
+    # Run skylight in Staging for performance metric monitoring pre-launch
+    config.skylight.environments << "staging"
 
     config.redis_key_prefix = "jupiter.#{Rails.env}."
 


### PR DESCRIPTION
## Context

We definitely have some asset-related performance issues on Staging, and need to do some profiling to see what's up.

## What's New

Enable Skylight in the staging Rails environment. Also removes "UAT" as an enabled environment, since we were never actually giving it the skylight tokens on UAT, and the performance measures are less likely to be representative.