### PR TITLE
Resolve N+1 on Attachments in Search Results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and releases in Jupiter project adheres to [Semantic Versioning](http://semver.o
 ### Fixed
 - bump rubocop and fix cop violations [PR#1845](https://github.com/ualbertalib/jupiter/pull/1845)
 - bump rubocop-performance and fix cop violations [PR#1850](https://github.com/ualbertalib/jupiter/pull/1850)
+- N+1 query issue with attachments to models in search results [PR#1881](https://github.com/ualbertalib/jupiter/pull/1881)
 
 ## [2.0.1.pre2] - 2020-09-01
 

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -17,6 +17,9 @@ class Collection < JupiterCore::Depositable
     self.visibility = JupiterCore::VISIBILITY_PUBLIC
   end
 
+  # We have no attachments, so the scope is just the class itself.
+  def self.eager_attachment_scope; self; end
+
   def path
     "#{community_id}/#{id}"
   end

--- a/app/models/community.rb
+++ b/app/models/community.rb
@@ -22,6 +22,10 @@ class Community < JupiterCore::Depositable
     self.visibility = JupiterCore::VISIBILITY_PUBLIC
   end
 
+  def self.eager_attachment_scope
+    with_attached_logo
+  end
+
   # this method can be used on the SolrCached object OR the ActiveFedora object
   def member_collections
     collections

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -52,6 +52,40 @@ class Item < JupiterCore::Doiable
   validates :member_of_paths, community_and_collection_existence: true
   validates :visibility_after_embargo, known_visibility: { only: VISIBILITIES_AFTER_EMBARGO }
 
+  # This is stored in solr: combination of item_type and publication_status
+  def item_type_with_status_code
+    return nil if item_type.blank?
+
+    # Return the item type code unless it's an article, then append publication status code
+    item_type_code = CONTROLLED_VOCABULARIES[:item_type].from_uri(item_type)
+    return item_type_code unless item_type_code == :article
+    return nil if publication_status.blank?
+
+    publication_status_code = CONTROLLED_VOCABULARIES[:publication_status].from_uri(publication_status.first)
+    # Next line of code means that 'article_submitted' exists, but 'article_draft' doesn't ("There can be only one!")
+    publication_status_code = :submitted if publication_status_code == :draft
+    "#{item_type_code}_#{publication_status_code}".to_sym
+  rescue ArgumentError
+    nil
+  end
+
+  def all_subjects
+    subject + temporal_subjects.to_a + spatial_subjects.to_a
+  end
+
+  def populate_sort_year
+    self.sort_year = Date.parse(created).year.to_i if created.present?
+  rescue ArgumentError
+    # date was un-parsable, try to pull out the first 4 digit number as a year
+    capture = created.scan(/\d{4}/)
+    self.sort_year = capture[0].to_i if capture.present?
+  end
+
+  def add_to_path(community_id, collection_id)
+    self.member_of_paths ||= []
+    self.member_of_paths += ["#{community_id}/#{collection_id}"]
+  end
+
   def self.from_draft(draft_item)
     item = Item.find(draft_item.uuid) if draft_item.uuid.present?
     item ||= Item.new(id: draft_item.uuid)
@@ -124,42 +158,12 @@ class Item < JupiterCore::Doiable
     item
   end
 
-  # This is stored in solr: combination of item_type and publication_status
-  def item_type_with_status_code
-    return nil if item_type.blank?
-
-    # Return the item type code unless it's an article, then append publication status code
-    item_type_code = CONTROLLED_VOCABULARIES[:item_type].from_uri(item_type)
-    return item_type_code unless item_type_code == :article
-    return nil if publication_status.blank?
-
-    publication_status_code = CONTROLLED_VOCABULARIES[:publication_status].from_uri(publication_status.first)
-    # Next line of code means that 'article_submitted' exists, but 'article_draft' doesn't ("There can be only one!")
-    publication_status_code = :submitted if publication_status_code == :draft
-    "#{item_type_code}_#{publication_status_code}".to_sym
-  rescue ArgumentError
-    nil
-  end
-
-  def all_subjects
-    subject + temporal_subjects.to_a + spatial_subjects.to_a
-  end
-
-  def populate_sort_year
-    self.sort_year = Date.parse(created).year.to_i if created.present?
-  rescue ArgumentError
-    # date was un-parsable, try to pull out the first 4 digit number as a year
-    capture = created.scan(/\d{4}/)
-    self.sort_year = capture[0].to_i if capture.present?
-  end
-
-  def add_to_path(community_id, collection_id)
-    self.member_of_paths ||= []
-    self.member_of_paths += ["#{community_id}/#{collection_id}"]
-  end
-
   def self.valid_visibilities
     super + [VISIBILITY_EMBARGO]
+  end
+
+  def self.eager_attachment_scope
+    with_attached_files
   end
 
 end

--- a/app/models/jupiter_core/depositable.rb
+++ b/app/models/jupiter_core/depositable.rb
@@ -205,7 +205,7 @@ class JupiterCore::Depositable < ApplicationRecord
   # any new model would silently be an N+1 on attachments until somebody noticed the missing implementation. Better
   # to fail fast and noisly during development when we've forgotten to be efficient.
   def self.eager_attachment_scope
-    raise MissingImplementationError, 'Depositable models must implement <Class>.with_eagerly_loaded_attachments'
+    raise MissingImplementationError, 'Depositable models must implement <Class>.eager_attachment_scope'
   end
 
   # We intend +eager_attachment_scope+ to be the protected method inheritors implement, while the public interface

--- a/app/models/jupiter_core/depositable.rb
+++ b/app/models/jupiter_core/depositable.rb
@@ -1,3 +1,5 @@
+class MissingImplementationError < StandardError; end
+
 class JupiterCore::Depositable < ApplicationRecord
 
   self.abstract_class = true
@@ -189,5 +191,26 @@ class JupiterCore::Depositable < ApplicationRecord
   def self.safe_attributes
     attribute_names.map(&:to_sym) - [:id]
   end
+
+  # Since we need a generic way to specify the scope by which a model will eagerly fetch attachments,
+  # and since the ActiveStorage auto-generated scopes "bake-in" the name of the eager-loading method
+  # (eg, for +class Foo; has_one_attached :document; end+, the eager-loading method is Foo.with_attached_document),
+  # we introduce a shim method that all inheritors must implement that the search infrastructure can
+  # rely upon. This also gives us the nice ability to refine the eager-load scope in the future if it makes sense,
+  # eg) we might return something like +self.with_attached_files.where(front_page: true)+ to only eagerly load
+  # the logo attachment for a record with a very large number of attachments like a newspaper, where we are only
+  # rendering a search result.
+  #
+  # Depositables with no attachments should simply choose to return +self+. This is not made the default, else
+  # any new model would silently be an N+1 on attachments until somebody noticed the missing implementation. Better
+  # to fail fast and noisly during development when we've forgotten to be efficient.
+  def self.eager_attachment_scope
+    raise MissingImplementationError, 'Depositable models must implement <Class>.with_eagerly_loaded_attachments'
+  end
+
+  # We intend +eager_attachment_scope+ to be the protected method inheritors implement, while the public interface
+  # for consumers (primarily the search infrastructure) is +with_eagerly_loaded_attachments+
+  class << self; self; end.send :protected, :eager_attachment_scope
+  def self.with_eagerly_loaded_attachments; eager_attachment_scope; end
 
 end

--- a/app/models/jupiter_core/solr_services/deferred_faceted_solr_query.rb
+++ b/app/models/jupiter_core/solr_services/deferred_faceted_solr_query.rb
@@ -118,7 +118,7 @@ class JupiterCore::SolrServices::DeferredFacetedSolrQuery
               #
               # TODO: This is inefficient and we should look at batching up IDs
               arclass = res['has_model_ssim'].first.sub(/^Ar/, '').constantize
-              arclass.find(res['id'])
+              arclass.with_eagerly_loaded_attachments.find(res['id'])
             rescue ActiveRecord::RecordNotFound
               # This _should_ only crop up in tests, where truncation of tables is bypassing callbacks that clean up
               # solr. BUT, I want to track this just in case.

--- a/app/models/thesis.rb
+++ b/app/models/thesis.rb
@@ -42,6 +42,19 @@ class Thesis < JupiterCore::Doiable
     :thesis
   end
 
+  def populate_sort_year
+    self.sort_year = Date.parse(graduation_date).year.to_i if graduation_date.present?
+    rescue ArgumentError
+      # date was unparsable, try to pull out the first 4 digit number as a year
+      capture = graduation_date.scan(/\d{4}/)
+      self.sort_year = capture[0].to_i if capture.present?
+  end
+
+  def add_to_path(community_id, collection_id)
+    self.member_of_paths ||= []
+    self.member_of_paths += ["#{community_id}/#{collection_id}"]
+  end
+
   def self.from_draft(draft_thesis)
     thesis = Thesis.find(draft_thesis.uuid) if draft_thesis.uuid.present?
     thesis ||= Thesis.new
@@ -117,21 +130,12 @@ class Thesis < JupiterCore::Doiable
     thesis
   end
 
-  def populate_sort_year
-    self.sort_year = Date.parse(graduation_date).year.to_i if graduation_date.present?
-    rescue ArgumentError
-      # date was unparsable, try to pull out the first 4 digit number as a year
-      capture = graduation_date.scan(/\d{4}/)
-      self.sort_year = capture[0].to_i if capture.present?
-  end
-
-  def add_to_path(community_id, collection_id)
-    self.member_of_paths ||= []
-    self.member_of_paths += ["#{community_id}/#{collection_id}"]
-  end
-
   def self.valid_visibilities
     super + [VISIBILITY_EMBARGO]
+  end
+
+  def self.eager_attachment_scope
+    with_attached_files
   end
 
 end


### PR DESCRIPTION
## Context

With the switch from Fedora to PostgreSQL, we're increasing pressure on the DB server, and consequently turning up some old inefficiencies that can now be addressed.

Previously, search results involved making:
1) one Solr query containing all of the data needed to render the results minus information about the attachments
2) 10 queries to Solr to fetch the attachments for the 10 results on the page.

Now, we are making:

1) one Solr query, giving us the IDs of the resulting model instances
2) 10 queries for the model instances
3) 10*N more queries for the model instances' attachments, where N is the number of attachments each instance has

This is excessive. 

This PR aims to address point 3 (point 2 may be addressed separately at some point as per https://github.com/ualbertalib/jupiter/blob/291ebcc6bdb17049523941df25a44c31831b6baa/app/models/jupiter_core/solr_services/deferred_faceted_solr_query.rb#L119 but note the significant challenge here is that not all Solr results will necessarily come from the same DB table, so batching it up into a single query is likely impossible unless we unify `Item` and `Thesis`)

A complicating factor here is that the ActiveStorage API names the eager-load scope according to the attached model so, for instance, `Item`(and `Thesis`), which `has_many_attached :files`, has an eager-loading scope of `with_attached_files`, whereas `Community`, which `has_one_attached :logo`, has an eager-loading scope of `with_attached_logo`. And Collection has no eager-loading scope at all, because it lacks any attachments.

`DeferredFacetedSolrQuery` potentially deals with results containing all of the above models at runtime, with no knowledge of which scope to call when making a query for the record in the result:

https://github.com/ualbertalib/jupiter/blob/291ebcc6bdb17049523941df25a44c31831b6baa/app/models/jupiter_core/solr_services/deferred_faceted_solr_query.rb#L120-L121

## What's New

We introduce two new Class methods in the `Depositable` superclass (which all Solr-searchable models must inherit from).

1) A protected method, `self.eager_attachment_scope`, which should return a model-specific call to the correct scope for the kind of attachment specific to the model (so eg. `Item` returns `self. with_attached_files`). By default this method blows up noisily when called, to force us to remember to override it correctly in all subclasses. Models like `Collection` simply make this method a no-op by choosing to return `self`.

2) A public method, `self.with_eagerly_loaded_attachments`, which simply gives the models' client code a nicer DSLy method for accessing the scope.

`DeferredFacetedSolrQuery` is then altered to use the scope on all classes during reification of search results.

(unrelatedly, I also shifted the methods around in `Item` and `Thesis` to group all instance methods and class methods together, because they were kind of a random mess)