### PR TITLE
Disable PCDM member of collections manipulation on Items/Theses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and releases in Jupiter project adheres to [Semantic Versioning](http://semver.o
 
 ## [Unreleased]
 
+## [1.2.23] – 2020-09-23
+- disable Item/Thesis PCDM structure manipulation that appears to be continuing to cause problems in Prod
+
 ## [1.2.22] – 2020-08-24
 - disable Collection usage of Communities for a PCDM triple in order to work around data corruption in Prod
 

--- a/lib/jupiter/version.rb
+++ b/lib/jupiter/version.rb
@@ -1,3 +1,3 @@
 module Jupiter
-  VERSION = '1.2.20'.freeze
+  VERSION = '1.2.23'.freeze
 end

--- a/test/models/thesis_test.rb
+++ b/test/models/thesis_test.rb
@@ -22,16 +22,6 @@ class ThesisTest < ActiveSupport::TestCase
     thesis.unlock_and_fetch_ldp_object do |unlocked_thesis|
       unlocked_thesis.add_to_path(community.id, collection.id)
       unlocked_thesis.save!
-      # Reload needed for dump below
-      unlocked_thesis.reload
-
-      # Dump some triples for sanity checks
-      triples = unlocked_thesis.resource.dump(:ntriples)
-      # Ensure correct type triple was saved
-      assert_match('<http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Thesis>',
-                   triples)
-      # Ensure `memberOf` was set correctly to collection ID:
-      assert_match("<http://pcdm.org/models#memberOf> <#{collection_uri}>", triples)
     end
     assert thesis.valid?
     assert_not_equal 0, Thesis.public.count

--- a/test/models/thesis_test.rb
+++ b/test/models/thesis_test.rb
@@ -22,6 +22,14 @@ class ThesisTest < ActiveSupport::TestCase
     thesis.unlock_and_fetch_ldp_object do |unlocked_thesis|
       unlocked_thesis.add_to_path(community.id, collection.id)
       unlocked_thesis.save!
+      # Reload needed for dump below
+      unlocked_thesis.reload
+
+      # Dump some triples for sanity checks
+      triples = unlocked_thesis.resource.dump(:ntriples)
+      # Ensure correct type triple was saved
+      assert_match('<http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Thesis>',
+                   triples)
     end
     assert thesis.valid?
     assert_not_equal 0, Thesis.public.count


### PR DESCRIPTION
## Context

This is continuing to cause problems in Prod w/ 404s being thrown on ingest during deposit. I think the root cause here may be a bug in ActiveFedora which sometimes writes (or returns?) triples related to the actual item in question instead of PCDM proxy objects when calls to `member_of_collections` are made. When these items are subsequently deleted, the PCDM manipulation code then calls delete not upon the proxies, but on the containing collection itself (which bypasses all validation safeguards because that's how ActiveFedora works for `delete` instead of `destroy`)

## Changes

Rip out everything related to this code. All of it is going away shortly during the migration anyways.