### PR TITLE
post-update run some rake update commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and releases in Jupiter project adheres to [Semantic Versioning](http://semver.o
 - Enable Skylight in the Staging environment and remove it from the UAT environment (where it was unused, and the performance of the Docker environment is less likely to be similar to Production)
 - uat configuration to accept proxy from upstream nginx-proxy [#1724](https://github.com/ualbertalib/jupiter/issues/1724)
 
+### Added
+- script for watchtower to run from post-update hook [PR#1892](https://github.com/ualbertalib/jupiter/pull/1892)
+
 ### Fixed
 - bump rubocop and fix cop violations [PR#1845](https://github.com/ualbertalib/jupiter/pull/1845)
 - bump rubocop-performance and fix cop violations [PR#1850](https://github.com/ualbertalib/jupiter/pull/1850)

--- a/bin/predeploy
+++ b/bin/predeploy
@@ -16,6 +16,7 @@ readonly install_directory="/home/deploy/jupiter"
 mkdir -p "${install_directory}"
 curl -o "${install_directory}/deploy" "https://raw.githubusercontent.com/ualbertalib/jupiter/${branch_name}/bin/deploy"
 curl -o "${install_directory}/docker-compose.yml" "https://raw.githubusercontent.com/ualbertalib/jupiter/${branch_name}/docker-compose.production.yml"
+curl -o "${install_directory}/watchtower-post-update"  "https://raw.githubusercontent.com/ualbertalib/jupiter/${branch_name}/bin/watchtower-post-update"
 
 mkdir -p "${install_directory}/config"
 curl -o "${install_directory}/config/nginx.conf" "https://raw.githubusercontent.com/ualbertalib/jupiter/${branch_name}/config/nginx.conf"

--- a/bin/watchtower-post-update.sh
+++ b/bin/watchtower-post-update.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+rake db:migrate
+rake assets:precompile

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: '3.3'
 
 volumes:
   postgres:
@@ -60,6 +60,8 @@ services:
       - assets:/app/public/
       - file-storage:/app/storage/
     command: bundle exec puma -e uat
+    labels:
+      com.centurylinklabs.watchtower.lifecycle.post-update: "watchtower-post-update.sh"
 
   nginx:
     restart: always


### PR DESCRIPTION
## Context

It is possible to execute pre/post-check and pre/post-update commands inside every container [updated by watchtower](https://containrrr.dev/watchtower/lifecycle-hooks/).

We used to do this by running the deploy script manually for each update.  Now that we're using watchtower the update
happens automagically but we still need these follow on tasks completed.

Related to https://github.com/ualbertalib/jupiter/issues/1722

## What's New

A script which runs `rake db:migrate` and `rake assets:precompile` and the label which tells watchtower's hook what to run.