### PR TITLE
#1800: Add solr highlight for description/abstract fields on search r…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and releases in Jupiter project adheres to [Semantic Versioning](http://semver.o
 
 ### Added
 - Added read only mode feature [#1838](https://github.com/ualbertalib/jupiter/issues/1838)
+- Added highlighting of terms within search results descriptions [#1800](https://github.com/ualbertalib/jupiter/issues/1800)
 
 ### Changed
 - Enable Skylight in the Staging environment and remove it from the UAT environment (where it was unused, and the performance of the Docker environment is less likely to be similar to Production)
@@ -33,7 +34,7 @@ and releases in Jupiter project adheres to [Semantic Versioning](http://semver.o
 - Merge file_set and original_file AIP API entry points [#1557](https://github.com/ualbertalib/jupiter/issues/1557)
 - Skipped failing Oaisys tests [#1817](https://github.com/ualbertalib/jupiter/issues/1817)
 - webpacker resolved_paths to additional paths [#1836](https://github.com/ualbertalib/jupiter/issues/1836)
- 
+
 ### Fixed
 - Upgrade Rubocop/Erblint and fix cop violations [#1803](https://github.com/ualbertalib/jupiter/pull/1803)
 - Fixed Oaisys testing issues by modifying and adding decorators [#1816](https://github.com/ualbertalib/jupiter/issues/1816)

--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -8,7 +8,11 @@ class CollectionsController < ApplicationController
       base_restriction_key: Item.solr_exporter_class.solr_name_for(:member_of_paths, role: :pathing),
       value: @collection.path,
       params: params,
-      current_user: current_user
+      current_user: current_user,
+      highlight_fields: [
+        Item.solr_exporter_class.solr_name_for(:description, role: :search),
+        Thesis.solr_exporter_class.solr_name_for(:abstract, role: :search)
+      ]
     )
     @results = search_query_index.results
     @search_models = search_query_index.search_models

--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -9,10 +9,7 @@ class CollectionsController < ApplicationController
       value: @collection.path,
       params: params,
       current_user: current_user,
-      highlight_fields: [
-        Item.solr_exporter_class.solr_name_for(:description, role: :search),
-        Thesis.solr_exporter_class.solr_name_for(:abstract, role: :search)
-      ]
+      fulltext: true
     )
     @results = search_query_index.results
     @search_models = search_query_index.search_models

--- a/app/controllers/profile_controller.rb
+++ b/app/controllers/profile_controller.rb
@@ -11,10 +11,7 @@ class ProfileController < ApplicationController
       value: @user.id,
       params: params,
       current_user: @user,
-      highlight_fields: [
-        Item.solr_exporter_class.solr_name_for(:description, role: :search),
-        Thesis.solr_exporter_class.solr_name_for(:abstract, role: :search)
-      ]
+      fulltext: true
     )
     @results = search_query_index.results
     @search_models = search_query_index.search_models

--- a/app/controllers/profile_controller.rb
+++ b/app/controllers/profile_controller.rb
@@ -10,7 +10,11 @@ class ProfileController < ApplicationController
       base_restriction_key: Item.solr_exporter_class.solr_name_for(:owner, role: :exact_match),
       value: @user.id,
       params: params,
-      current_user: @user
+      current_user: @user,
+      highlight_fields: [
+        Item.solr_exporter_class.solr_name_for(:description, role: :search),
+        Thesis.solr_exporter_class.solr_name_for(:abstract, role: :search)
+      ]
     )
     @results = search_query_index.results
     @search_models = search_query_index.search_models

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -19,7 +19,11 @@ class SearchController < ApplicationController
     search_query_index = UserSearchService.new(
       search_models: models,
       params: params,
-      current_user: current_user
+      current_user: current_user,
+      highlight_fields: [
+        Item.solr_exporter_class.solr_name_for(:description, role: :search),
+        Thesis.solr_exporter_class.solr_name_for(:abstract, role: :search)
+      ]
     )
     @results = search_query_index.results
     @search_models = search_query_index.search_models

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -20,10 +20,7 @@ class SearchController < ApplicationController
       search_models: models,
       params: params,
       current_user: current_user,
-      highlight_fields: [
-        Item.solr_exporter_class.solr_name_for(:description, role: :search),
-        Thesis.solr_exporter_class.solr_name_for(:abstract, role: :search)
-      ]
+      fulltext: true
     )
     @results = search_query_index.results
     @search_models = search_query_index.search_models

--- a/app/helpers/search_helper.rb
+++ b/app/helpers/search_helper.rb
@@ -113,4 +113,15 @@ module SearchHelper
     last = results.offset_value + results.count
     t('search.page_range', first: first, last: last, total: results.total_count)
   end
+
+  def highlight_matches(object:, field:, highlights:)
+    return [] if highlights.blank?
+
+    field_solr_name = object.solr_exporter_class.solr_name_for(field.to_sym, role: :search).to_s
+    id = object.id.to_s
+
+    return [] unless highlights[id].key?(field_solr_name)
+
+    highlights[id][field_solr_name]
+  end
 end

--- a/app/helpers/search_helper.rb
+++ b/app/helpers/search_helper.rb
@@ -113,15 +113,4 @@ module SearchHelper
     last = results.offset_value + results.count
     t('search.page_range', first: first, last: last, total: results.total_count)
   end
-
-  def highlight_matches(object:, field:, highlights:)
-    return [] if highlights.blank?
-
-    field_solr_name = object.solr_exporter_class.solr_name_for(field.to_sym, role: :search).to_s
-    id = object.id.to_s
-
-    return [] unless highlights[id].key?(field_solr_name)
-
-    highlights[id][field_solr_name]
-  end
 end

--- a/app/jobs/embargo_expiry_job.rb
+++ b/app/jobs/embargo_expiry_job.rb
@@ -9,7 +9,7 @@ class EmbargoExpiryJob < ApplicationJob
     visibility_solr_name = Item.solr_exporter_class.solr_name_for(:visibility, role: :exact_match)
     embargo_end_date_solr_name = Item.solr_exporter_class.solr_name_for(:embargo_end_date, role: :sort)
 
-    item_results_count, item_results, _ = JupiterCore::Search.perform_solr_query(
+    item_results_count, item_results, _, _ = JupiterCore::Search.perform_solr_query(
       q: '',
       fq: "_query_:\"{!raw f=has_model_ssim}#{Item.solr_exporter_class.indexed_has_model_name}\""\
           " AND #{visibility_solr_name}:\"#{JupiterCore::Depositable::VISIBILITY_EMBARGO}\""\
@@ -17,7 +17,7 @@ class EmbargoExpiryJob < ApplicationJob
       rows: 10_000_000
     )
 
-    thesis_results_count, thesis_results, _ = JupiterCore::Search.perform_solr_query(
+    thesis_results_count, thesis_results, _, _ = JupiterCore::Search.perform_solr_query(
       q: '',
       fq: "_query_:\"{!raw f=has_model_ssim}#{Thesis.solr_exporter_class.indexed_has_model_name}\""\
           " AND #{visibility_solr_name}:\"#{JupiterCore::Depositable::VISIBILITY_EMBARGO}\""\

--- a/app/models/exporters/solr/base_exporter.rb
+++ b/app/models/exporters/solr/base_exporter.rb
@@ -126,6 +126,18 @@ class Exporters::Solr::BaseExporter
     @indexed_model_name
   end
 
+  def self.fulltext_searchable_field
+    fulltext_searchable_name
+  end
+
+  def self.fulltext_searchable_mangled_solr_name
+    solr_name_for(fulltext_searchable_field, role: :search)
+  end
+
+  def self.fulltext_searchable?(name)
+    name == fulltext_searchable_field
+  end
+
   protected
 
   # provide a consistent representation of values in Solr, based on what we were doing previously with solrizer
@@ -167,7 +179,8 @@ class Exporters::Solr::BaseExporter
 
     attr_accessor :reverse_solr_name_map, :name_to_type_map, :name_to_roles_map,
                   :name_to_solr_name_map, :name_to_custom_lambda_map, :indexed_attributes, :searched_solr_names,
-                  :facets, :ranges, :default_sort_direction, :default_sort_indexes, :default_ar_sort_args
+                  :facets, :ranges, :default_sort_direction, :default_sort_indexes, :default_ar_sort_args, 
+                  :fulltext_searchable_name
 
     protected
 
@@ -219,6 +232,14 @@ class Exporters::Solr::BaseExporter
       direction = [direction] unless direction.is_a?(Array)
       self.default_sort_indexes = index.map { |idx| solr_name_for(idx, role: :sort) }
       self.default_sort_direction = direction
+    end
+
+    # Declare a particular attribute as being searchable on fulltext and therefore providing fulltext highlighted result hits
+    # attr must already be declared text and indexed for :search
+    def fulltext_searchable(attr)
+      raise ArgumentError, "#{attr} must be indexed for :search" unless self.name_to_roles_map[attr].include?(:search)
+      raise ArgumentError, "#{attr} must be of type :text" unless self.name_to_type_map[attr] == :text
+      self.fulltext_searchable_name = attr
     end
 
     def record_type(name, type)

--- a/app/models/exporters/solr/base_exporter.rb
+++ b/app/models/exporters/solr/base_exporter.rb
@@ -179,7 +179,7 @@ class Exporters::Solr::BaseExporter
 
     attr_accessor :reverse_solr_name_map, :name_to_type_map, :name_to_roles_map,
                   :name_to_solr_name_map, :name_to_custom_lambda_map, :indexed_attributes, :searched_solr_names,
-                  :facets, :ranges, :default_sort_direction, :default_sort_indexes, :default_ar_sort_args, 
+                  :facets, :ranges, :default_sort_direction, :default_sort_indexes, :default_ar_sort_args,
                   :fulltext_searchable_name
 
     protected
@@ -237,8 +237,9 @@ class Exporters::Solr::BaseExporter
     # Declare a particular attribute as being searchable on fulltext and therefore providing fulltext highlighted result hits
     # attr must already be declared text and indexed for :search
     def fulltext_searchable(attr)
-      raise ArgumentError, "#{attr} must be indexed for :search" unless self.name_to_roles_map[attr].include?(:search)
-      raise ArgumentError, "#{attr} must be of type :text" unless self.name_to_type_map[attr] == :text
+      raise ArgumentError, "#{attr} must be indexed for :search" unless name_to_roles_map[attr].include?(:search)
+      raise ArgumentError, "#{attr} must be of type :text" unless name_to_type_map[attr] == :text
+
       self.fulltext_searchable_name = attr
     end
 

--- a/app/models/exporters/solr/item_exporter.rb
+++ b/app/models/exporters/solr/item_exporter.rb
@@ -63,6 +63,7 @@ class Exporters::Solr::ItemExporter < Exporters::Solr::BaseExporter
   custom_index :all_subjects, role: :facet, as: ->(item) { item.all_subjects }
 
   default_sort index: :title, direction: :asc
+
   fulltext_searchable :description
 
 end

--- a/app/models/exporters/solr/item_exporter.rb
+++ b/app/models/exporters/solr/item_exporter.rb
@@ -64,4 +64,5 @@ class Exporters::Solr::ItemExporter < Exporters::Solr::BaseExporter
 
   default_sort index: :title, direction: :asc
   fulltext_searchable :description
+
 end

--- a/app/models/exporters/solr/item_exporter.rb
+++ b/app/models/exporters/solr/item_exporter.rb
@@ -63,5 +63,5 @@ class Exporters::Solr::ItemExporter < Exporters::Solr::BaseExporter
   custom_index :all_subjects, role: :facet, as: ->(item) { item.all_subjects }
 
   default_sort index: :title, direction: :asc
-
+  fulltext_searchable :description
 end

--- a/app/models/exporters/solr/thesis_exporter.rb
+++ b/app/models/exporters/solr/thesis_exporter.rb
@@ -74,4 +74,6 @@ class Exporters::Solr::ThesisExporter < Exporters::Solr::BaseExporter
 
   default_sort index: :title, direction: :asc
 
+  fulltext_searchable :abstract
+
 end

--- a/app/models/jupiter_core/search.rb
+++ b/app/models/jupiter_core/search.rb
@@ -15,7 +15,7 @@ class JupiterCore::Search
   # TODO: probably someone will request not showing some of the default facets in some context,
   # so one potential path forward would be to add a facet exclusions param and subtract it out of the facet_fields
   # when creating the DeferredFacetedSolrQuery
-  def self.faceted_search(q: '', facets: [], ranges: [], models: [], as: nil)
+  def self.faceted_search(q: '', facets: [], ranges: [], models: [], as: nil, highlight_fields: [])
     raise ArgumentError, 'as: must specify a user!' if as.present? && !as.is_a?(User)
     raise ArgumentError, 'must provide at least one model to search for!' if models.blank?
 
@@ -53,7 +53,8 @@ class JupiterCore::Search
                                                             facet_map: construct_facet_map(models),
                                                             facet_fields: construct_facet_fields(models, user: as),
                                                             ranges: ranges,
-                                                            restrict_to_model: models)
+                                                            restrict_to_model: models,
+                                                            highlight_fields: highlight_fields)
   end
 
   # derive additional restriction or broadening of the visibilitily query on top of the default
@@ -74,9 +75,10 @@ class JupiterCore::Search
   end
 
   def self.perform_solr_query(q:, qf: '', fq: '', facet: false, facet_fields: [], facet_max: MAX_FACETS_RETURNED,
-                              restrict_to_model: nil, rows: MAX_RESULTS, start: nil, sort: nil)
+                              restrict_to_model: nil, rows: MAX_RESULTS, start: nil, sort: nil, highlight_fields: [])
     params = prepare_solr_query(q: q, qf: qf, fq: fq, facet: facet, facet_fields: facet_fields, facet_max: facet_max,
-                                restrict_to_model: restrict_to_model, rows: rows, start: start, sort: sort)
+                                restrict_to_model: restrict_to_model, rows: rows,
+                                start: start, sort: sort, highlight_fields: highlight_fields)
 
     response = ActiveSupport::Notifications.instrument(JUPITER_SOLR_NOTIFICATION,
                                                        name: 'solr select',
@@ -86,11 +88,11 @@ class JupiterCore::Search
 
     raise SearchFailed unless response['responseHeader']['status'] == 0
 
-    [response['response']['numFound'], response['response']['docs'], response['facet_counts']]
+    [response['response']['numFound'], response['response']['docs'], response['facet_counts'], response['highlighting']]
   end
 
   def self.prepare_solr_query(q:, qf: '', fq: '', facet: false, facet_fields: [], facet_max: MAX_FACETS_RETURNED,
-                              restrict_to_model: nil, rows: MAX_RESULTS, start: nil, sort: nil)
+                              restrict_to_model: nil, rows: MAX_RESULTS, start: nil, sort: nil, highlight_fields: [])
     query = []
     restrict_to_model = [restrict_to_model] unless restrict_to_model.is_a?(Array)
 
@@ -115,6 +117,17 @@ class JupiterCore::Search
       'facet.field': facet_fields,
       'facet.limit': facet_max
     }
+
+    if highlight_fields.present?
+      params.merge!({
+                      hl: true,
+                      'hl.fl': highlight_fields,
+                      'hl.snippets': 3,
+                      'hl.fragsize': 300,
+                      'hl.simple.pre': '<mark>',
+                      'hl.simple.post': '</mark>'
+                    })
+    end
 
     params[:start] = start if start.present?
     params[:sort] = sort if sort.present?

--- a/app/models/jupiter_core/solr_services/deferred_faceted_solr_query.rb
+++ b/app/models/jupiter_core/solr_services/deferred_faceted_solr_query.rb
@@ -8,7 +8,7 @@ class JupiterCore::SolrServices::DeferredFacetedSolrQuery
 
   private_constant :POSSIBLE_SORT_ORDERS
 
-  def initialize(q:, qf:, fq:, facet_map:, facet_fields:, ranges:, restrict_to_model:, highlight_fields:)
+  def initialize(q:, qf:, fq:, facet_map:, facet_fields:, ranges:, restrict_to_model:, fulltext_fields:)
     criteria[:q] = q
     criteria[:qf] = qf # Query Fields
     criteria[:fq] = fq # Facet Query
@@ -18,7 +18,7 @@ class JupiterCore::SolrServices::DeferredFacetedSolrQuery
     criteria[:restrict_to_model] = restrict_to_model
     criteria[:sort] = []
     criteria[:sort_order] = []
-    criteria[:highlight_fields] = highlight_fields
+    criteria[:fulltext_fields] = fulltext_fields
   end
 
   def criteria
@@ -243,7 +243,7 @@ class JupiterCore::SolrServices::DeferredFacetedSolrQuery
       rows: limit,
       start: criteria[:offset],
       sort: sort_clause,
-      highlight_fields: criteria[:highlight_fields] }
+      fulltext_fields: criteria[:fulltext_fields] }
   end
 
   def raw_model_to_model(raw_model)

--- a/app/models/jupiter_core/solr_services/deferred_faceted_solr_query.rb
+++ b/app/models/jupiter_core/solr_services/deferred_faceted_solr_query.rb
@@ -114,12 +114,12 @@ class JupiterCore::SolrServices::DeferredFacetedSolrQuery
     each do |object|
       fulltext_hits = []
 
-      if @highlights.any? && object.solr_exporter_class.fulltext_searchable_field.present?
+      if @highlights&.any? && object.solr_exporter_class.fulltext_searchable_field.present?
         fulltext_solr_field = object.solr_exporter_class.fulltext_searchable_mangled_solr_name
 
         if @highlights[object.id].key?(fulltext_solr_field)
-          fulltext_hits = @highlights[object.id][fulltext_solr_field].map do |hit|
-            JupiterCore::SolrServices::FulltextResult.new(highlight_text: hit)
+          fulltext_hits = @highlights[object.id][fulltext_solr_field].map do |fulltext_hit|
+            JupiterCore::SolrServices::FulltextResult.new(highlight_text: fulltext_hit)
           end
         end
       end

--- a/app/models/jupiter_core/solr_services/fulltext_result.rb
+++ b/app/models/jupiter_core/solr_services/fulltext_result.rb
@@ -1,0 +1,13 @@
+class JupiterCore::SolrServices::FulltextResult
+
+  attr_reader :highlight_text
+
+  def initialize(highlight_text:)
+    @highlight_text = highlight_text
+  end
+
+  def to_partial_path
+    'fulltext_result'
+  end
+
+end

--- a/app/services/user_search_service.rb
+++ b/app/services/user_search_service.rb
@@ -6,15 +6,18 @@ class UserSearchService
 
   attr_reader :search_models
 
-  def initialize(current_user:, base_restriction_key: nil, value: nil,
-                 search_models: [Item, Thesis], params: nil)
-    raise ArgumentError, 'Must supply both a key and value' if @base_restriction_key.present? && @value.blank?
+  def initialize(current_user:, params:, base_restriction_key: nil, value: nil, # rubocop:disable Metrics/ParameterLists
+                 search_models: [Item, Thesis], highlight_fields: [])
+    if base_restriction_key.present? && value.blank?
+      raise ArgumentError, 'Must supply both a base_restriction_key and a value'
+    end
 
     @base_restriction_key = base_restriction_key
     @value = value
     @search_models = search_models
     @search_params = search_params(params)
     @current_user = current_user
+    @highlight_fields = highlight_fields
   end
 
   def results
@@ -26,7 +29,8 @@ class UserSearchService
     facets[@base_restriction_key] = [@value] if @base_restriction_key.present?
 
     search_options = { q: query, models: search_models, as: @current_user,
-                       facets: facets, ranges: @search_params[:ranges] }
+                       facets: facets, ranges: @search_params[:ranges],
+                       highlight_fields: @highlight_fields }
 
     # Sort by relevance if a search term is present and no explicit sort field has been chosen
     sort_fields = @search_params[:sort]

--- a/app/services/user_search_service.rb
+++ b/app/services/user_search_service.rb
@@ -7,7 +7,7 @@ class UserSearchService
   attr_reader :search_models
 
   def initialize(current_user:, params:, base_restriction_key: nil, value: nil, # rubocop:disable Metrics/ParameterLists
-                 search_models: [Item, Thesis], highlight_fields: [])
+                 search_models: [Item, Thesis], fulltext: false)
     if base_restriction_key.present? && value.blank?
       raise ArgumentError, 'Must supply both a base_restriction_key and a value'
     end
@@ -17,7 +17,7 @@ class UserSearchService
     @search_models = search_models
     @search_params = search_params(params)
     @current_user = current_user
-    @highlight_fields = highlight_fields
+    @fulltext = fulltext
   end
 
   def results
@@ -30,7 +30,7 @@ class UserSearchService
 
     search_options = { q: query, models: search_models, as: @current_user,
                        facets: facets, ranges: @search_params[:ranges],
-                       highlight_fields: @highlight_fields }
+                       fulltext: @fulltext }
 
     # Sort by relevance if a search term is present and no explicit sort field has been chosen
     sort_fields = @search_params[:sort]

--- a/app/views/application/_fulltext_result.html.erb
+++ b/app/views/application/_fulltext_result.html.erb
@@ -1,0 +1,1 @@
+<p><%= fulltext_result.highlight_text.html_safe %></p>

--- a/app/views/application/_item.html.erb
+++ b/app/views/application/_item.html.erb
@@ -47,16 +47,9 @@
     </p>
 
     <% if item.description.present? %>
-      <% highlight_matches = highlight_matches(object: item, field: :description, highlights: local_assigns[:highlights]) %>
-      <% if highlight_matches.empty? %>
-        <p>
-          <%= jupiter_truncate item.description %>
-        </p>
-      <% else %>
-        <% highlight_matches.each do |match| %>
-          <p><%= match.html_safe %></p>
-        <% end %>
-      <% end %>
+      <p>
+        <%= render(highlights) || jupiter_truncate(item.description) %>
+      </p>
     <% end %>
   </div>
 </div>

--- a/app/views/application/_item.html.erb
+++ b/app/views/application/_item.html.erb
@@ -45,10 +45,18 @@
       <%# TODO: the search path may need to be revisited %>
       <%= safe_join(item.creators&.map { |creator| search_link_for(item, :all_contributors, value: creator) }, ', ') %>
     </p>
+
     <% if item.description.present? %>
-      <p>
-        <%= jupiter_truncate item.description %>
-      </p>
+      <% highlight_matches = highlight_matches(object: item, field: :description, highlights: local_assigns[:highlights]) %>
+      <% if highlight_matches.empty? %>
+        <p>
+          <%= jupiter_truncate item.description %>
+        </p>
+      <% else %>
+        <% highlight_matches.each do |match| %>
+          <p><%= match.html_safe %></p>
+        <% end %>
+      <% end %>
     <% end %>
   </div>
 </div>

--- a/app/views/application/_results.html.erb
+++ b/app/views/application/_results.html.erb
@@ -78,9 +78,9 @@
 
       <div class='jupiter-results-list' id="results">
         <ul class="list-group">
-          <% results.each do |result| %>
+          <% results.each_with_fulltext_results do |result, fulltext_hits| %>
             <li class="list-group-item list-group-item-action">
-              <%= render result, highlights: results.highlights %>
+              <%= render result, highlights: fulltext_hits %>
             </li>
           <% end %>
         </ul>

--- a/app/views/application/_results.html.erb
+++ b/app/views/application/_results.html.erb
@@ -80,7 +80,7 @@
         <ul class="list-group">
           <% results.each do |result| %>
             <li class="list-group-item list-group-item-action">
-              <%= render result %>
+              <%= render result, highlights: results.highlights %>
             </li>
           <% end %>
         </ul>

--- a/app/views/application/_thesis.html.erb
+++ b/app/views/application/_thesis.html.erb
@@ -48,16 +48,9 @@
     </p>
 
     <% if thesis.abstract.present? %>
-      <% highlight_matches = highlight_matches(object: thesis, field: :abstract, highlights: local_assigns[:highlights]) %>
-      <% if highlight_matches.empty? %>
-        <p>
-          <%= jupiter_truncate thesis.abstract %>
-        </p>
-      <% else %>
-        <% highlight_matches.each do |match| %>
-          <p><%= match.html_safe %></p>
-        <% end %>
-      <% end %>
+      <p>
+        <%= render(highlights) || jupiter_truncate(thesis.abstract) %>
+      </p>
     <% end %>
   </div>
 </div>

--- a/app/views/application/_thesis.html.erb
+++ b/app/views/application/_thesis.html.erb
@@ -46,10 +46,18 @@
       <%# TODO: the search path may need to be revisited %>
       <%= search_link_for(thesis, :all_contributors, value: thesis.dissertant) %>
     </p>
+
     <% if thesis.abstract.present? %>
-      <p>
-        <%= jupiter_truncate thesis.abstract %>
-      </p>
+      <% highlight_matches = highlight_matches(object: thesis, field: :abstract, highlights: local_assigns[:highlights]) %>
+      <% if highlight_matches.empty? %>
+        <p>
+          <%= jupiter_truncate thesis.abstract %>
+        </p>
+      <% else %>
+        <% highlight_matches.each do |match| %>
+          <p><%= match.html_safe %></p>
+        <% end %>
+      <% end %>
     <% end %>
   </div>
 </div>

--- a/test/controllers/search_controller_test.rb
+++ b/test/controllers/search_controller_test.rb
@@ -62,4 +62,11 @@ class SearchControllerTest < ActionDispatch::IntegrationTest
     assert_no_match(/<a href="\/items\/#{@item4.id}">/, response.body)
   end
 
+  test 'should render highlights on search result page' do
+    get search_url, params: { search: 'French' }
+    assert_response :success
+
+    assert_match(/<mark>French<\/mark>/, response.body)
+  end
+
 end

--- a/test/services/user_search_service_test.rb
+++ b/test/services/user_search_service_test.rb
@@ -85,12 +85,15 @@ class UserSearchServiceTest < ActiveSupport::TestCase
 
     # Only Admin item has "French" in its description
     assert_equal search.results.count, 1
-    assert_equal search.results.highlights.count, 1
-    assert_equal search.results.first.id, @admin_item.id
-    assert_match(
-      /<mark>French<\/mark>/,
-      search.results.highlights[@admin_item.id][Item.solr_exporter_class.fulltext_searchable_mangled_solr_name].first
-    )
+
+    search.results.each_with_fulltext_results do |result, fulltext_hits|
+      assert_equal result.id, @admin_item.id
+      assert_equal fulltext_hits.count, 1
+      assert_match(
+        /<mark>French<\/mark>/,
+        fulltext_hits.first.highlight_text
+      )
+    end
   end
 
 end

--- a/test/services/user_search_service_test.rb
+++ b/test/services/user_search_service_test.rb
@@ -76,21 +76,21 @@ class UserSearchServiceTest < ActiveSupport::TestCase
   test 'should return search results with highlights' do
     current_user = users(:regular)
     params = ActionController::Parameters.new(search: 'French')
-    highlight_field = Item.solr_exporter_class.solr_name_for(:description, role: :search)
 
     search = UserSearchService.new(
       current_user: current_user,
       params: params,
-      highlight_fields: [
-        highlight_field
-      ]
+      fulltext: true
     )
 
     # Only Admin item has "French" in its description
     assert_equal search.results.count, 1
     assert_equal search.results.highlights.count, 1
     assert_equal search.results.first.id, @admin_item.id
-    assert_match(/<mark>French<\/mark>/, search.results.highlights[@admin_item.id][highlight_field].first)
+    assert_match(
+      /<mark>French<\/mark>/,
+      search.results.highlights[@admin_item.id][Item.solr_exporter_class.fulltext_searchable_mangled_solr_name].first
+    )
   end
 
 end

--- a/test/services/user_search_service_test.rb
+++ b/test/services/user_search_service_test.rb
@@ -1,0 +1,96 @@
+require 'test_helper'
+
+class UserSearchServiceTest < ActiveSupport::TestCase
+
+  setup do
+    @regular_user_item = items(:fancy)
+    @admin_item = items(:admin)
+    @admin_private_item = items(:private_item)
+
+    [@regular_user_item, @admin_item, @admin_private_item].each(&:update_solr)
+  end
+
+  test 'should raise ArgumentError when not given correct arguments' do
+    assert_raise(ArgumentError) do
+      UserSearchService.new
+    end
+  end
+
+  test 'should raise ArgumentError if base_restriction_key is given with no value' do
+    current_user = users(:regular)
+    params = ActionController::Parameters.new(search: 'Item')
+    base_restriction_key = Item.solr_exporter_class.solr_name_for(:owner, role: :exact_match)
+
+    assert_raise(ArgumentError) do
+      UserSearchService.new(
+        current_user: current_user,
+        params: params,
+        base_restriction_key: base_restriction_key
+      )
+    end
+  end
+
+  test 'should return search results when given correct arguments' do
+    current_user = users(:admin)
+    params = ActionController::Parameters.new(search: 'Item')
+
+    search = UserSearchService.new(
+      current_user: current_user,
+      params: params
+    )
+
+    assert_instance_of JupiterCore::SolrServices::DeferredFacetedSolrQuery, search.results
+    assert_equal search.results.count, 3
+  end
+
+  test 'should filter search results by visibility of current_user' do
+    current_user = users(:regular)
+    params = ActionController::Parameters.new(search: 'Item')
+
+    search = UserSearchService.new(
+      current_user: current_user,
+      params: params
+    )
+
+    assert_equal search.results.count, 2
+    assert_not_includes search.results, @admin_private_item
+  end
+
+  test 'should limit results by base_restriction_key and value' do
+    current_user = users(:regular)
+    params = ActionController::Parameters.new(search: 'Item')
+    base_restriction_key = Item.solr_exporter_class.solr_name_for(:owner, role: :exact_match)
+
+    search = UserSearchService.new(
+      current_user: current_user,
+      params: params,
+      base_restriction_key: base_restriction_key,
+      value: current_user.id
+    )
+
+    # Only Fancy item is owned by regular user
+    assert_equal search.results.count, 1
+    assert_equal search.results.first.id, @regular_user_item.id
+  end
+
+  test 'should return search results with highlights' do
+    current_user = users(:regular)
+    params = ActionController::Parameters.new(search: 'French')
+    highlight_field = Item.solr_exporter_class.solr_name_for(:description, role: :search)
+
+    search = UserSearchService.new(
+      current_user: current_user,
+      params: params,
+      highlight_fields: [
+        highlight_field
+      ]
+    )
+
+    # Only Admin item has "French" in its description
+    assert_equal search.results.count, 1
+    assert_equal search.results.highlights.count, 1
+    assert_equal search.results.first.id, @admin_item.id
+    assert_match(/<mark>French<\/mark>/, search.results.highlights[@admin_item.id][highlight_field].first)
+  end
+
+end

--- a/test/system/deposit_item_test.rb
+++ b/test/system/deposit_item_test.rb
@@ -74,7 +74,7 @@ class DepositItemTest < ApplicationSystemTestCase
 
     # Check to make sure there isn't any embargo_history
     item_id = current_url.split('/').last
-    _, item_results, _ = JupiterCore::Search.perform_solr_query(q: item_id, fq: "id:#{item_id}", rows: 1)
+    _, item_results, _, _ = JupiterCore::Search.perform_solr_query(q: item_id, fq: "id:#{item_id}", rows: 1)
     assert_nil item_results.first['embargo_history_ssim']
 
     # verify editing
@@ -104,7 +104,7 @@ class DepositItemTest < ApplicationSystemTestCase
     assert_selector '#draft_item_visibility_open_access:checked'
 
     # Ensure embargo_history is now present
-    _, item_results, _ = JupiterCore::Search.perform_solr_query(q: item_id, fq: "id:#{item_id}", rows: 1)
+    _, item_results, _, _ = JupiterCore::Search.perform_solr_query(q: item_id, fq: "id:#{item_id}", rows: 1)
     assert_not_nil item_results.first['embargo_history_ssim']
 
     logout_user

--- a/test/system/deposit_thesis_test.rb
+++ b/test/system/deposit_thesis_test.rb
@@ -71,7 +71,7 @@ class DepositThesisTest < ApplicationSystemTestCase
 
     # Check to make sure there isn't any embargo_history
     item_id = current_url.split('/').last
-    _, item_results, _ = JupiterCore::Search.perform_solr_query(q: item_id, fq: "id:#{item_id}", rows: 1)
+    _, item_results, _, _ = JupiterCore::Search.perform_solr_query(q: item_id, fq: "id:#{item_id}", rows: 1)
     assert_nil item_results.first['embargo_history_ssim']
 
     # verify editing
@@ -101,7 +101,7 @@ class DepositThesisTest < ApplicationSystemTestCase
     assert_selector '#draft_thesis_visibility_open_access:checked'
 
     # Ensure embargo_history is now present
-    _, item_results, _ = JupiterCore::Search.perform_solr_query(q: item_id, fq: "id:#{item_id}", rows: 1)
+    _, item_results, _, _ = JupiterCore::Search.perform_solr_query(q: item_id, fq: "id:#{item_id}", rows: 1)
     assert_not_nil item_results.first['embargo_history_ssim']
     logout_user
   end


### PR DESCRIPTION
#1800 

Adds solr highlighting to item description/thesis abstract fields on search results (for search, profile and collection search pages)

Highlighting in action:

Search page:
![image](https://user-images.githubusercontent.com/1930474/94376840-627a8800-00da-11eb-92db-397379571f20.png)
![image](https://user-images.githubusercontent.com/1930474/94376774-f26c0200-00d9-11eb-991d-9cb37dc13964.png)

Profile page:
![image](https://user-images.githubusercontent.com/1930474/94376760-dbc5ab00-00d9-11eb-9a7c-42d6ec186ee2.png)

Collection show page:
![image](https://user-images.githubusercontent.com/1930474/94376779-00ba1e00-00da-11eb-9597-df3e93d3630e.png)
