### PR TITLE
Migrate Blobs to use UUID ids

### DIFF
--- a/app/models/ar_community.rb
+++ b/app/models/ar_community.rb
@@ -31,7 +31,8 @@ class ArCommunity < ApplicationRecord
       new_attachment = ActiveStorage::Attachment.create(record: ar_community,
                                                         blob: community.logo_attachment.blob,
                                                         name: :logo,
-                                                        fileset_uuid: community.logo_attachment.fileset_uuid)
+                                                        fileset_uuid: community.logo_attachment.fileset_uuid, 
+                                                        upcoming_blob_id: community.logo_attachment.blob.upcoming_id)
       # because of the uuid id column, the record_id on new_attachment (currently of type integer), is broken
       # but that's ok. we're going to fix that with this data
       new_attachment.upcoming_record_id = ar_community.id

--- a/app/models/ar_item.rb
+++ b/app/models/ar_item.rb
@@ -114,7 +114,8 @@ class ArItem < ApplicationRecord
     # add an association between the same underlying blobs the Item uses and the new ActiveRecord version
     item.files_attachments.each do |attachment|
       new_attachment = ActiveStorage::Attachment.create(record: ar_item, blob: attachment.blob, name: :files,
-                                                        fileset_uuid: attachment.fileset_uuid)
+                                                        fileset_uuid: attachment.fileset_uuid, 
+                                                        upcoming_blob_id: attachment.blob.upcoming_id)
       # because of the uuid id column, the record_id on new_attachment (currently of type integer), is broken
       # but that's ok. we're going to fix that with this data
       new_attachment.upcoming_record_id = ar_item.id

--- a/app/models/ar_thesis.rb
+++ b/app/models/ar_thesis.rb
@@ -114,7 +114,8 @@ class ArThesis < ApplicationRecord
     # add an association between the same underlying blobs the Thesis uses and the new ActiveRecord version
     thesis.files_attachments.each do |attachment|
       new_attachment = ActiveStorage::Attachment.create(record: ar_thesis, blob: attachment.blob, name: :files,
-                                                        fileset_uuid: attachment.fileset_uuid)
+                                                        fileset_uuid: attachment.fileset_uuid,
+                                                        upcoming_blob_id: attachment.blob.upcoming_id)
       # because of the uuid id column, the record_id on new_attachment (currently of type integer), is broken
       # but that's ok. we're going to fix that with this data
       new_attachment.upcoming_record_id = ar_thesis.id

--- a/db/migrate/20190826221814_change_activestorage_records_to_uuid_part1.rb
+++ b/db/migrate/20190826221814_change_activestorage_records_to_uuid_part1.rb
@@ -7,5 +7,10 @@ class ChangeActivestorageRecordsToUuidPart1 < ActiveRecord::Migration[5.2]
     add_index :draft_theses, :upcoming_id, unique: true
     add_column :draft_items_languages, :upcoming_draft_item_id, :uuid
     add_index :draft_items_languages, :upcoming_draft_item_id
+
+    add_column :active_storage_blobs, :upcoming_id, :uuid, null: false, default: 'uuid_generate_v4()'
+    add_column :active_storage_attachments, :upcoming_blob_id, :uuid
+    add_column :draft_items, :upcoming_thumbnail_id, :uuid
+    add_column :draft_theses, :upcoming_thumbnail_id, :uuid
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_08_26_221814) do
+ActiveRecord::Schema.define(version: 2020_08_31_182732) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -25,6 +25,7 @@ ActiveRecord::Schema.define(version: 2019_08_26_221814) do
     t.string "record_type"
     t.uuid "fileset_uuid"
     t.uuid "upcoming_record_id"
+    t.uuid "upcoming_blob_id"
     t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
     t.index ["record_type", "record_id", "name", "blob_id"], name: "unique_active_storage_attachment", unique: true
   end
@@ -37,6 +38,7 @@ ActiveRecord::Schema.define(version: 2019_08_26_221814) do
     t.integer "byte_size"
     t.string "checksum"
     t.datetime "created_at"
+    t.uuid "upcoming_id", default: -> { "uuid_generate_v4()" }, null: false
     t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
   end
 
@@ -210,6 +212,7 @@ ActiveRecord::Schema.define(version: 2019_08_26_221814) do
     t.datetime "updated_at", null: false
     t.boolean "is_published_in_era", default: false
     t.uuid "upcoming_id", default: -> { "uuid_generate_v4()" }, null: false
+    t.uuid "upcoming_thumbnail_id"
     t.index ["type_id"], name: "index_draft_items_on_type_id"
     t.index ["upcoming_id"], name: "index_draft_items_on_upcoming_id", unique: true
     t.index ["user_id"], name: "index_draft_items_on_user_id"
@@ -257,6 +260,7 @@ ActiveRecord::Schema.define(version: 2019_08_26_221814) do
     t.datetime "updated_at", null: false
     t.boolean "is_published_in_era", default: false
     t.uuid "upcoming_id", default: -> { "uuid_generate_v4()" }, null: false
+    t.uuid "upcoming_thumbnail_id"
     t.index ["institution_id"], name: "index_draft_theses_on_institution_id"
     t.index ["language_id"], name: "index_draft_theses_on_language_id"
     t.index ["upcoming_id"], name: "index_draft_theses_on_upcoming_id", unique: true
@@ -298,6 +302,10 @@ ActiveRecord::Schema.define(version: 2019_08_26_221814) do
     t.string "predicate"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "read_only_modes", force: :cascade do |t|
+    t.boolean "enabled", default: false, null: false
   end
 
   create_table "types", force: :cascade do |t|

--- a/lib/tasks/jupiter.rake
+++ b/lib/tasks/jupiter.rake
@@ -58,7 +58,13 @@ namespace :jupiter do
 
     ActiveStorage::Attachment.all.each do |attachment|
       blob = ActiveStorage::Blob.find_by(id: attachment.blob_id)
-      attachment.destroy unless blob.present?
+
+      if blob.present?
+        attachment.update_columns(upcoming_blob_id: blob.upcoming_id)
+      else
+        attachment.destroy
+      end
+
       print '.'
     end
 
@@ -75,6 +81,9 @@ namespace :jupiter do
         join_record.upcoming_draft_item_id = draft_item.upcoming_id
         join_record.save!(validate: false)
       end
+
+      draft_item.update_columns(upcoming_thumbnail_id: draft_item.thumbnail&.blob&.upcoming_id)
+
       print '.'
     end
 
@@ -86,6 +95,9 @@ namespace :jupiter do
         attachment.upcoming_record_id = draft_thesis.upcoming_id
         attachment.save!
       end
+
+      draft_thesis.update_columns(upcoming_thumbnail_id: draft_thesis.thumbnail&.blob&.upcoming_id)
+
       print '.'
     end
 


### PR DESCRIPTION
Switches ActiveStorage::Blob to use UUID Ids. Handing off to Connor for testing.