### PR TITLE
Change ActiveStorage::Blobs to use UUID ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and releases in Jupiter project adheres to [Semantic Versioning](http://semver.o
 - Enable Skylight in the Staging environment and remove it from the UAT environment (where it was unused, and the performance of the Docker environment is less likely to be similar to Production)
 - uat configuration to accept proxy from upstream nginx-proxy [#1724](https://github.com/ualbertalib/jupiter/issues/1724)
 - Changed oaisys' updated until scope [#1816](https://github.com/ualbertalib/jupiter/issues/1816)
+- ActiveStorage::Blob now uses UUID for ids. You will need to recreate, remigrate, and reseed your DB.
 
 ### Added
 - script for watchtower to run from post-update hook [PR#1892](https://github.com/ualbertalib/jupiter/pull/1892)

--- a/app/helpers/page_layout_helper.rb
+++ b/app/helpers/page_layout_helper.rb
@@ -46,6 +46,7 @@ module PageLayoutHelper
 
   def thumbnail_path(logo, args = { resize_to_limit: [100, 100], auto_orient: true })
     return nil if logo.blank?
+
     Rails.application.routes.url_helpers.rails_representation_path(logo.representation(args).processed)
   rescue StandardError => e
     logger.warn("#{logo.record_type} with id: #{logo.record_id} and thumbnail #{logo.name} threw an error.")

--- a/app/helpers/page_layout_helper.rb
+++ b/app/helpers/page_layout_helper.rb
@@ -46,24 +46,10 @@ module PageLayoutHelper
 
   def thumbnail_path(logo, args = { resize_to_limit: [100, 100], auto_orient: true })
     return nil if logo.blank?
-
-    # images have variants
-    Rails.application.routes.url_helpers.rails_representation_path(logo.variant(args).processed)
-  rescue ActiveStorage::InvariableError
-    begin
-      # pdfs and video have previews
-      Rails.application.routes.url_helpers.rails_representation_path(logo.preview(args).processed)
-    # ActiveStorage::UnpreviewableError and sometimes MiniMagick::Error gets thrown here
-    rescue StandardError => e
-      logger.warn("#{logo.record_type} with id: #{logo.record_id} and thumnail #{logo.name} \
-      threw an error after ActiveStorage::InvariableError.")
-      Rollbar.warn("#{logo.record_type} with id: #{logo.record_id} and thumnail #{logo.name} \
-      threw an error after ActiveStorage::InvariableError.", e)
-      nil
-    end
+    Rails.application.routes.url_helpers.rails_representation_path(logo.representation(args).processed)
   rescue StandardError => e
-    logger.warn("#{logo.record_type} with id: #{logo.record_id} and thumnail #{logo.name} threw an error.")
-    Rollbar.warn("#{logo.record_type} with id: #{logo.record_id} and thumnail #{logo.name} threw an error.", e)
+    logger.warn("#{logo.record_type} with id: #{logo.record_id} and thumbnail #{logo.name} threw an error.")
+    Rollbar.warn("#{logo.record_type} with id: #{logo.record_id} and thumbnail #{logo.name} threw an error.", e)
     nil
   end
 

--- a/db/migrate/20190826221814_change_activestorage_records_to_uuid_part1.rb
+++ b/db/migrate/20190826221814_change_activestorage_records_to_uuid_part1.rb
@@ -7,5 +7,10 @@ class ChangeActivestorageRecordsToUuidPart1 < ActiveRecord::Migration[5.2]
     add_index :draft_theses, :upcoming_id, unique: true
     add_column :draft_items_languages, :upcoming_draft_item_id, :uuid
     add_index :draft_items_languages, :upcoming_draft_item_id
+
+    add_column :active_storage_blobs, :upcoming_id, :uuid, null: false, default: 'uuid_generate_v4()'
+    add_column :active_storage_attachments, :upcoming_blob_id, :uuid
+    add_column :draft_items, :upcoming_thumbnail_id, :uuid
+    add_column :draft_theses, :upcoming_thumbnail_id, :uuid
   end
 end

--- a/db/migrate/20190826235029_change_activestorage_records_to_uuid_part2.rb
+++ b/db/migrate/20190826235029_change_activestorage_records_to_uuid_part2.rb
@@ -33,5 +33,6 @@ class ChangeActivestorageRecordsToUuidPart2 < ActiveRecord::Migration[5.2]
 
     change_column_null :active_storage_attachments, :blob_id, false
     add_foreign_key :active_storage_attachments, :active_storage_blobs, column: :blob_id
+    add_index :active_storage_attachments, :blob_id
   end
 end

--- a/db/migrate/20190826235029_change_activestorage_records_to_uuid_part2.rb
+++ b/db/migrate/20190826235029_change_activestorage_records_to_uuid_part2.rb
@@ -7,15 +7,31 @@ class ChangeActivestorageRecordsToUuidPart2 < ActiveRecord::Migration[5.2]
     remove_column :active_storage_attachments, :record_id
     rename_column :active_storage_attachments, :upcoming_record_id, :record_id
 
+    remove_column :active_storage_attachments, :blob_id
+    rename_column :active_storage_attachments, :upcoming_blob_id, :blob_id
+
     remove_column :draft_items, :id
     rename_column :draft_items, :upcoming_id, :id
     execute 'ALTER TABLE draft_items ADD PRIMARY KEY (id);'
+
+    remove_column :draft_items, :thumbnail_id
+    rename_column :draft_items, :upcoming_thumbnail_id, :thumbnail_id
 
     remove_column :draft_theses, :id
     rename_column :draft_theses, :upcoming_id, :id
     execute 'ALTER TABLE draft_theses ADD PRIMARY KEY (id);'
 
+    remove_column :draft_theses, :thumbnail_id
+    rename_column :draft_theses, :upcoming_thumbnail_id, :thumbnail_id
+
     remove_column :draft_items_languages, :draft_item_id
     rename_column :draft_items_languages, :upcoming_draft_item_id, :draft_item_id
+
+    remove_column :active_storage_blobs, :id
+    rename_column :active_storage_blobs, :upcoming_id, :id
+    execute 'ALTER TABLE active_storage_blobs ADD PRIMARY KEY (id);'
+
+    change_column_null :active_storage_attachments, :blob_id, false
+    add_foreign_key :active_storage_attachments, :active_storage_blobs, column: :blob_id
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -19,15 +19,14 @@ ActiveRecord::Schema.define(version: 2020_08_31_182732) do
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name"
-    t.bigint "blob_id", null: false
     t.datetime "created_at"
     t.string "record_type"
     t.uuid "fileset_uuid"
     t.uuid "record_id"
-    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
+    t.uuid "blob_id", null: false
   end
 
-  create_table "active_storage_blobs", force: :cascade do |t|
+  create_table "active_storage_blobs", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
     t.string "key"
     t.string "filename"
     t.string "content_type"
@@ -93,7 +92,6 @@ ActiveRecord::Schema.define(version: 2020_08_31_182732) do
     t.uuid "uuid"
     t.integer "status", default: 0, null: false
     t.integer "wizard_step", default: 0, null: false
-    t.integer "thumbnail_id"
     t.string "title"
     t.string "alternate_title"
     t.date "date_created"
@@ -116,6 +114,7 @@ ActiveRecord::Schema.define(version: 2020_08_31_182732) do
     t.json "citations", array: true
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.uuid "thumbnail_id"
     t.index ["id"], name: "index_draft_items_on_id", unique: true
     t.index ["type_id"], name: "index_draft_items_on_type_id"
     t.index ["user_id"], name: "index_draft_items_on_user_id"
@@ -135,7 +134,6 @@ ActiveRecord::Schema.define(version: 2020_08_31_182732) do
     t.integer "status", default: 0, null: false
     t.integer "wizard_step", default: 0, null: false
     t.bigint "user_id", null: false
-    t.integer "thumbnail_id"
     t.string "title"
     t.string "alternate_title"
     t.string "creator"
@@ -159,6 +157,7 @@ ActiveRecord::Schema.define(version: 2020_08_31_182732) do
     t.json "committee_members", array: true
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.uuid "thumbnail_id"
     t.index ["id"], name: "index_draft_theses_on_id", unique: true
     t.index ["institution_id"], name: "index_draft_theses_on_institution_id"
     t.index ["language_id"], name: "index_draft_theses_on_language_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -24,6 +24,7 @@ ActiveRecord::Schema.define(version: 2020_08_31_182732) do
     t.uuid "fileset_uuid"
     t.uuid "record_id"
     t.uuid "blob_id", null: false
+    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
   end
 
   create_table "active_storage_blobs", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|

--- a/lib/tasks/jupiter.rake
+++ b/lib/tasks/jupiter.rake
@@ -33,6 +33,8 @@ namespace :jupiter do
     puts 'done!'
   end
 
+  # rubocop:disable Rails/SkipsModelValidations
+  # what if, Rubocop, skipping validations were the entire point?
   desc 'sayonara ActiveFedora'
   task :get_me_off_of_fedora, [:batch_size] => :environment do |_, args|
     desired_batch_size = args.batch_size.to_i ||= 1000
@@ -58,7 +60,7 @@ namespace :jupiter do
       end
 
       draft_item.update_columns(upcoming_thumbnail_id: draft_item.thumbnail&.blob&.upcoming_id)
-      
+
       print '.'
     end
 
@@ -111,6 +113,7 @@ namespace :jupiter do
     puts
     puts 'Finished!'
   end
+  # rubocop:enable Rails/SkipsModelValidations
 
   desc 'enable read only mode'
   task enable_read_only_mode: :environment do

--- a/lib/tasks/jupiter.rake
+++ b/lib/tasks/jupiter.rake
@@ -37,6 +37,13 @@ namespace :jupiter do
   task :get_me_off_of_fedora, [:batch_size] => :environment do |_, args|
     desired_batch_size = args.batch_size.to_i ||= 1000
     puts
+    puts 'Preparing Attachments'
+    ActiveStorage::Attachment.find_each(batch_size: desired_batch_size) do |attachment|
+      attachment.update_columns(upcoming_blob_id: attachment.blob&.upcoming_id)
+
+      print '.'
+    end
+
     puts 'Preparing Draft Item ...'
 
     DraftItem.find_each(batch_size: desired_batch_size) do |draft_item|
@@ -49,6 +56,9 @@ namespace :jupiter do
         join_record.upcoming_draft_item_id = draft_item.upcoming_id
         join_record.save!
       end
+
+      draft_item.update_columns(upcoming_thumbnail_id: draft_item.thumbnail&.blob&.upcoming_id)
+      
       print '.'
     end
 
@@ -60,6 +70,9 @@ namespace :jupiter do
         attachment.upcoming_record_id = draft_thesis.upcoming_id
         attachment.save!
       end
+
+      draft_thesis.update_columns(upcoming_thumbnail_id: draft_thesis.thumbnail&.blob&.upcoming_id)
+
       print '.'
     end
 

--- a/test/fixtures/active_storage/attachments.yml
+++ b/test/fixtures/active_storage/attachments.yml
@@ -2,4 +2,4 @@ logo:
   name: 'files'
   record_type: 'Item'
   record_id: <%= ActiveRecord::FixtureSet.identify(:fancy) %>
-  blob_id: <%= ActiveRecord::FixtureSet.identify(:jpeg) %>
+  blob_id: 'e34bbd2e-c819-491b-9f60-e0b1c9b7b2ee'

--- a/test/fixtures/active_storage/blobs.yml
+++ b/test/fixtures/active_storage/blobs.yml
@@ -1,4 +1,5 @@
 jpeg:
+  id: 'e34bbd2e-c819-491b-9f60-e0b1c9b7b2ee'
   key: '12345'
   filename: 'image-sample.jpeg'
   content_type: 'image/jpeg'


### PR DESCRIPTION
Switch the post-migration branch to use UUID Ids for `ActiveStorage::Blob`s. Resolves an issue where PDF or video blobs would fail to correctly track their attached `preview_image`, because `ActiveStorage::Attachment`'s `record_id` expects a UUID. 

This was causing an enormous amount of regeneration of thumbnails (4x per thumbnail) on the new staging environment (a typical search result page was taking ~8 seconds to render).

You will need to recreate and remigrate your DB after this is merged.