### PR TITLE
Add spring gem back to jupiter

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -97,7 +97,11 @@ group :development do
   gem 'binding_of_caller'
 
   gem 'brakeman'
+
   gem 'listen', '>= 3.0.5', '< 3.3'
+  gem 'spring'
+  gem 'spring-watcher-listen', '~> 2.0.0'
+
   gem 'web-console', '>= 3.3.0'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -449,6 +449,10 @@ GEM
     sparql-client (3.1.0)
       net-http-persistent (~> 3.1)
       rdf (~> 3.1)
+    spring (2.1.1)
+    spring-watcher-listen (2.0.1)
+      listen (>= 2.7, < 4.0)
+      spring (>= 1.2, < 3.0)
     sprockets (4.0.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -563,6 +567,8 @@ DEPENDENCIES
   simplecov
   sinatra (~> 2.1.0)
   skylight
+  spring
+  spring-watcher-listen (~> 2.0.0)
   uuidtools
   vcr (= 5.0)
   voight_kampff

--- a/bin/rails
+++ b/bin/rails
@@ -1,4 +1,9 @@
 #!/usr/bin/env ruby
+begin
+  load File.expand_path('spring', __dir__)
+rescue LoadError => e
+  raise unless e.message.include?('spring')
+end
 APP_PATH = File.expand_path('../config/application', __dir__)
 require_relative '../config/boot'
 require 'rails/commands'

--- a/bin/rake
+++ b/bin/rake
@@ -1,4 +1,9 @@
 #!/usr/bin/env ruby
+begin
+  load File.expand_path('spring', __dir__)
+rescue LoadError => e
+  raise unless e.message.include?('spring')
+end
 require_relative '../config/boot'
 require 'rake'
 Rake.application.run

--- a/bin/spring
+++ b/bin/spring
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 
-# This file loads spring without using Bundler, in order to be fast.
+# This file loads Spring without using Bundler, in order to be fast.
 # It gets overwritten when you run the `spring binstub` command.
 
 unless defined?(Spring)


### PR DESCRIPTION
Noticed when we were debugging Matt's Attachment issue last week we no longer have Spring in our gemfile. Spring is a default rails gem. 

This is a PR to add this back or at least start a discussion. If we decide we don't want it, let's completely remove spring from Jupiter (we still have it's binstub in jupiter, etc).

What is spring? 

> Spring is a Rails application preloader. It speeds up development by keeping your application running in the background so you don't need to boot it every time you run a test, rake task or migration.

More info: https://github.com/rails/spring

On jupiter I see around 5 seconds in savings when running rake/test/rails commands.

As an example I ran a few `time rails test` with and without spring. It seems on average with spring (when spring is warm) its around 67 seconds and without spring around 73 seconds to run the test suite.

Note:
One caveat with adding spring back is spring and simplecov do not play nicely together at all! I tried the tips simplecov suggests, but ultimately couldn't get it to work. As a result simplecov will incorrectly report very low test coverage when spring is enabled as shown:

`Coverage report generated for Minitest to /Users/e88838/Code/jupiter/coverage. 46 / 4667 LOC (0.99%) covered.`

You can always disable spring to get the real test coverage:
`DISABLE_SPRING=1  bin/rails test`

`Coverage report generated for Minitest to /Users/e88838/Code/jupiter/coverage. 2568 / 3164 LOC (81.16%) covered.`
