### PR TITLE
Stub out `puts` and logger messages in our test suite

### DIFF
--- a/test/integration/read_only_mode_integration_test.rb
+++ b/test/integration/read_only_mode_integration_test.rb
@@ -5,36 +5,42 @@ Rails.application.load_tasks
 class ReadOnlyModeIntegrationTest < ActionDispatch::IntegrationTest
 
   test 'read only mode logs out' do
-    sign_in_as users(:regular)
-    get root_path
-    assert_select 'a#jupiter-user-nav-downdown', count: 1
-    Rake::Task['jupiter:enable_read_only_mode'].execute
-    get root_path
-    assert_select 'a#jupiter-user-nav-downdown', count: 0
-    Rake::Task['jupiter:disable_read_only_mode'].execute
+    $stdout.stub(:puts, nil) do
+      sign_in_as users(:regular)
+      get root_path
+      assert_select 'a#jupiter-user-nav-downdown', count: 1
+      Rake::Task['jupiter:enable_read_only_mode'].execute
+      get root_path
+      assert_select 'a#jupiter-user-nav-downdown', count: 0
+      Rake::Task['jupiter:disable_read_only_mode'].execute
+    end
   end
 
   test 'read only mode creates and clears announcement' do
-    sign_in_as users(:regular)
-    get root_path
-    assert_select 'div.alert', text: I18n.t('announcement_templates.read_only_mode'), count: 0
-    Rake::Task['jupiter:enable_read_only_mode'].execute
-    get search_path
-    assert_select 'div.alert', text: I18n.t('announcement_templates.read_only_mode'), count: 1
-    Rake::Task['jupiter:disable_read_only_mode'].execute
-    get root_path
-    assert_select 'div.alert', text: I18n.t('announcement_templates.read_only_mode'), count: 0
+    $stdout.stub(:puts, nil) do
+      sign_in_as users(:regular)
+      get root_path
+      assert_select 'div.alert', text: I18n.t('announcement_templates.read_only_mode'), count: 0
+      Rake::Task['jupiter:enable_read_only_mode'].execute
+      get search_path
+      assert_select 'div.alert', text: I18n.t('announcement_templates.read_only_mode'), count: 1
+      Rake::Task['jupiter:disable_read_only_mode'].execute
+      get root_path
+      assert_select 'div.alert', text: I18n.t('announcement_templates.read_only_mode'), count: 0
+    end
   end
 
   test 'cannot log in when read only mode enabled' do
-    get root_path
-    assert_select 'a.nav-item', text: I18n.t('application.navbar.links.login'), count: 1
-    Rake::Task['jupiter:enable_read_only_mode'].execute
-    get root_path
-    assert_select 'a.nav-item', text: I18n.t('application.navbar.links.login'), count: 0
-    Rake::Task['jupiter:disable_read_only_mode'].execute
-    get root_path
-    assert_select 'a.nav-item', text: I18n.t('application.navbar.links.login'), count: 1
+    $stdout.stub(:puts, nil) do
+      get root_path
+      assert_select 'a.nav-item', text: I18n.t('application.navbar.links.login'), count: 1
+      Rake::Task['jupiter:enable_read_only_mode'].execute
+      get root_path
+      assert_select 'a.nav-item', text: I18n.t('application.navbar.links.login'), count: 0
+      Rake::Task['jupiter:disable_read_only_mode'].execute
+      get root_path
+      assert_select 'a.nav-item', text: I18n.t('application.navbar.links.login'), count: 1
+    end
   end
 
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -33,6 +33,11 @@ end
 # just push all jobs to an array for verification
 Sidekiq::Testing.fake!
 
+# Stub out EZID logger to silence noise in test runner
+Ezid::Client.configure do |config|
+  config.logger = Logger.new(File::NULL)
+end
+
 class ActiveSupport::TestCase
 
   # Setup all fixtures in test/fixtures/*.yml for all tests in alphabetical order.


### PR DESCRIPTION
Noticed our test suite is getting more and more noisy. Here's a small PR to silence the logs and stdout statements.

Before:
```
➜  jupiter (integration_postmigration) ✔ rails t
Run options: --seed 33994

# Running:

...................Enabling read only mode...
Done!
Disabling read only mode...
Done!
.Enabling read only mode...
Done!
Disabling read only mode...
Done!
.Enabling read only mode...
Done!
Disabling read only mode...
Done!
...........S.......................................................................................................................................................S....................S...............................................................................................................................................I, [2020-10-06T22:04:58.598931 #44818]  INFO -- : EZID MintIdentifier -- success: doi:10.21967/fk2-ycs2-dd92
I, [2020-10-06T22:04:58.715883 #44818]  INFO -- : EZID GetIdentifierMetadata -- success: doi:10.21967/fk2-ycs2-dd92
I, [2020-10-06T22:04:58.830144 #44818]  INFO -- : EZID ModifyIdentifier -- success: doi:10.21967/fk2-ycs2-dd92
I, [2020-10-06T22:04:58.887697 #44818]  INFO -- : EZID GetIdentifierMetadata -- success: doi:10.21967/fk2-ycs2-dd92
I, [2020-10-06T22:04:58.987478 #44818]  INFO -- : EZID ModifyIdentifier -- success: doi:10.21967/fk2-ycs2-dd92
I, [2020-10-06T22:04:59.038925 #44818]  INFO -- : EZID GetIdentifierMetadata -- success: doi:10.21967/fk2-ycs2-dd92
I, [2020-10-06T22:04:59.138113 #44818]  INFO -- : EZID ModifyIdentifier -- success: doi:10.21967/fk2-ycs2-dd92
I, [2020-10-06T22:04:59.139481 #44818]  INFO -- : EZID GetIdentifierMetadata -- success: doi:10.21967/fk2-ycs2-dd92
.......................

Finished in 101.951560s, 3.6488 runs/s, 13.4868 assertions/s.
372 runs, 1375 assertions, 0 failures, 0 errors, 3 skips

You have skipped tests. Run with --verbose for details.
Coverage report generated for Integration Tests, Minitest to /Users/murny/Code/ualberta/jupiter/coverage. 2568 / 3164 LOC (81.16%) covered.
```

After:
```
jupiter (integration_postmigration) ✗ rails t
Run options: --seed 5970

# Running:

.....................................................................................S.....................................................................S...................................................................................................................S....................................................................................................

Finished in 101.223776s, 3.6750 runs/s, 13.5838 assertions/s.
372 runs, 1375 assertions, 0 failures, 0 errors, 3 skips

You have skipped tests. Run with --verbose for details.
Coverage report generated for Integration Tests, Minitest to /Users/murny/Code/ualberta/jupiter/coverage. 2568 / 3164 LOC (81.16%) covered.
```