### PR TITLE
Stub out `puts` and logger messages in our test suite

### DIFF
--- a/test/integration/read_only_mode_integration_test.rb
+++ b/test/integration/read_only_mode_integration_test.rb
@@ -5,36 +5,42 @@ Rails.application.load_tasks
 class ReadOnlyModeIntegrationTest < ActionDispatch::IntegrationTest
 
   test 'read only mode logs out' do
-    sign_in_as users(:regular)
-    get root_path
-    assert_select 'a#jupiter-user-nav-downdown', count: 1
-    Rake::Task['jupiter:enable_read_only_mode'].execute
-    get root_path
-    assert_select 'a#jupiter-user-nav-downdown', count: 0
-    Rake::Task['jupiter:disable_read_only_mode'].execute
+    $stdout.stub(:puts, nil) do
+      sign_in_as users(:regular)
+      get root_path
+      assert_select 'a#jupiter-user-nav-downdown', count: 1
+      Rake::Task['jupiter:enable_read_only_mode'].execute
+      get root_path
+      assert_select 'a#jupiter-user-nav-downdown', count: 0
+      Rake::Task['jupiter:disable_read_only_mode'].execute
+    end
   end
 
   test 'read only mode creates and clears announcement' do
-    sign_in_as users(:regular)
-    get root_path
-    assert_select 'div.alert', text: I18n.t('announcement_templates.read_only_mode'), count: 0
-    Rake::Task['jupiter:enable_read_only_mode'].execute
-    get search_path
-    assert_select 'div.alert', text: I18n.t('announcement_templates.read_only_mode'), count: 1
-    Rake::Task['jupiter:disable_read_only_mode'].execute
-    get root_path
-    assert_select 'div.alert', text: I18n.t('announcement_templates.read_only_mode'), count: 0
+    $stdout.stub(:puts, nil) do
+      sign_in_as users(:regular)
+      get root_path
+      assert_select 'div.alert', text: I18n.t('announcement_templates.read_only_mode'), count: 0
+      Rake::Task['jupiter:enable_read_only_mode'].execute
+      get search_path
+      assert_select 'div.alert', text: I18n.t('announcement_templates.read_only_mode'), count: 1
+      Rake::Task['jupiter:disable_read_only_mode'].execute
+      get root_path
+      assert_select 'div.alert', text: I18n.t('announcement_templates.read_only_mode'), count: 0
+    end
   end
 
   test 'cannot log in when read only mode enabled' do
-    get root_path
-    assert_select 'a.nav-item', text: I18n.t('application.navbar.links.login'), count: 1
-    Rake::Task['jupiter:enable_read_only_mode'].execute
-    get root_path
-    assert_select 'a.nav-item', text: I18n.t('application.navbar.links.login'), count: 0
-    Rake::Task['jupiter:disable_read_only_mode'].execute
-    get root_path
-    assert_select 'a.nav-item', text: I18n.t('application.navbar.links.login'), count: 1
+    $stdout.stub(:puts, nil) do
+      get root_path
+      assert_select 'a.nav-item', text: I18n.t('application.navbar.links.login'), count: 1
+      Rake::Task['jupiter:enable_read_only_mode'].execute
+      get root_path
+      assert_select 'a.nav-item', text: I18n.t('application.navbar.links.login'), count: 0
+      Rake::Task['jupiter:disable_read_only_mode'].execute
+      get root_path
+      assert_select 'a.nav-item', text: I18n.t('application.navbar.links.login'), count: 1
+    end
   end
 
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -33,6 +33,11 @@ end
 # just push all jobs to an array for verification
 Sidekiq::Testing.fake!
 
+# Stub out EZID logger to silence noise in test runner
+Ezid::Client.configure do |config|
+  config.logger = Logger.new(File::NULL)
+end
+
 class ActiveSupport::TestCase
 
   # Setup all fixtures in test/fixtures/*.yml for all tests in alphabetical order.


### PR DESCRIPTION
Previously https://github.com/ualbertalib/jupiter/pull/1918 before branch changes