### PR TITLE
predeploy script to reference this branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and releases in Jupiter project adheres to [Semantic Versioning](http://semver.o
 - uat configuration to accept proxy from upstream nginx-proxy [#1724](https://github.com/ualbertalib/jupiter/issues/1724)
 - Changed oaisys' updated until scope [#1816](https://github.com/ualbertalib/jupiter/issues/1816)
 - ActiveStorage::Blob now uses UUID for ids. You will need to recreate, remigrate, and reseed your DB.
+- predeploy script to reference this branch
 
 ### Added
 - script for watchtower to run from post-update hook [PR#1892](https://github.com/ualbertalib/jupiter/pull/1892)

--- a/bin/predeploy
+++ b/bin/predeploy
@@ -10,7 +10,7 @@ set -o nounset
 [[ -n "${TRACE:-}" ]] && set -o xtrace
 
 
-readonly branch_name="integration_postmigration"
+readonly branch_name="integration"
 readonly install_directory="/home/deploy/jupiter"
 
 mkdir -p "${install_directory}"


### PR DESCRIPTION
## Context

Recently we renamed all our working branches (master -> old-master-fedora, integration-postmigration -> master) and created a new integration branch for new digitization stuff.  This is what we want to see on UAT.

## What's New

Change the predeploy script to reference this branch.