### PR TITLE
Bring in rubocop-minitest gem and lint and fix any violations in our tests

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,6 +4,7 @@
 # https://github.com/bbatsov/rubocop/blob/master/config/enabled.yml
 
 require:
+  - rubocop-minitest
   - rubocop-performance
   - rubocop-rails
 

--- a/Gemfile
+++ b/Gemfile
@@ -86,8 +86,9 @@ group :development, :test do
   gem 'pry-rails'
 
   gem 'rubocop', '~> 0.92.0', require: false
-  gem 'rubocop-performance'
-  gem 'rubocop-rails'
+  gem 'rubocop-minitest', '~> 0.10', require: false
+  gem 'rubocop-performance', '~> 1.8', require: false
+  gem 'rubocop-rails', '~> 2.8', require: false
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -380,6 +380,8 @@ GEM
       unicode-display_width (>= 1.4.0, < 2.0)
     rubocop-ast (0.5.0)
       parser (>= 2.7.1.5)
+    rubocop-minitest (0.10.1)
+      rubocop (>= 0.87)
     rubocop-performance (1.8.1)
       rubocop (>= 0.87.0)
       rubocop-ast (>= 0.4.0)
@@ -550,8 +552,9 @@ DEPENDENCIES
   rollbar
   rsolr
   rubocop (~> 0.92.0)
-  rubocop-performance
-  rubocop-rails
+  rubocop-minitest (~> 0.10)
+  rubocop-performance (~> 1.8)
+  rubocop-rails (~> 2.8)
   rufus-scheduler (= 3.6.0)
   sdoc
   selenium-webdriver

--- a/test/controllers/aip/v1/aip_items_contoller_test.rb
+++ b/test/controllers/aip/v1/aip_items_contoller_test.rb
@@ -80,7 +80,7 @@ class Aip::V1::ItemsControllerTest < ActionDispatch::IntegrationTest
     graph = generate_graph_from_n3(response.body)
     rendered_graph = load_radioactive_n3_graph(radioactive_item, 'base')
 
-    assert_equal true, rendered_graph.isomorphic_with?(graph)
+    assert rendered_graph.isomorphic_with?(graph)
   end
 
   test 'should get item metadata graph with n3 serialization for embargo example' do
@@ -104,7 +104,7 @@ class Aip::V1::ItemsControllerTest < ActionDispatch::IntegrationTest
     graph = generate_graph_from_n3(response.body)
     rendered_graph = load_radioactive_n3_graph(radioactive_item, 'embargoed')
 
-    assert_equal true, rendered_graph.isomorphic_with?(graph)
+    assert rendered_graph.isomorphic_with?(graph)
   end
 
   test 'should get item metadata graph with n3 serialization for previously embargoed example' do
@@ -135,7 +135,7 @@ class Aip::V1::ItemsControllerTest < ActionDispatch::IntegrationTest
     graph = generate_graph_from_n3(response.body)
     rendered_graph = load_radioactive_n3_graph(radioactive_item, 'prev-embargoed')
 
-    assert_equal true, rendered_graph.isomorphic_with?(graph)
+    assert rendered_graph.isomorphic_with?(graph)
   end
 
   test 'should get item metadata graph with n3 serialization for rights example' do
@@ -158,7 +158,7 @@ class Aip::V1::ItemsControllerTest < ActionDispatch::IntegrationTest
     graph = generate_graph_from_n3(response.body)
     rendered_graph = load_radioactive_n3_graph(radioactive_item, 'rights')
 
-    assert_equal true, rendered_graph.isomorphic_with?(graph)
+    assert rendered_graph.isomorphic_with?(graph)
   end
 
   test 'should get item metadata graph with n3 serialization for published status example' do
@@ -180,7 +180,7 @@ class Aip::V1::ItemsControllerTest < ActionDispatch::IntegrationTest
     graph = generate_graph_from_n3(response.body)
     rendered_graph = load_radioactive_n3_graph(radioactive_item, 'published-status')
 
-    assert_equal true, rendered_graph.isomorphic_with?(graph)
+    assert rendered_graph.isomorphic_with?(graph)
   end
 
   # Basic test checking if response has xml format.
@@ -193,7 +193,7 @@ class Aip::V1::ItemsControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :success
 
-    assert_equal true, check_file_order_xml(response.body)
+    assert check_file_order_xml(response.body)
   end
 
   test 'should get item file paths' do
@@ -204,7 +204,7 @@ class Aip::V1::ItemsControllerTest < ActionDispatch::IntegrationTest
     )
     assert_response :success
     json_string = response.body
-    assert_equal true, JSON::Validator.validate(
+    assert JSON::Validator.validate(
       file_paths_json_schema,
       json_string
     )
@@ -212,7 +212,7 @@ class Aip::V1::ItemsControllerTest < ActionDispatch::IntegrationTest
 
     # Check that all files actually exist
     json_response['files'].map do |file_path|
-      assert_equal true, File.file?(file_path['file_path'])
+      assert File.file?(file_path['file_path'])
     end
   end
 
@@ -244,7 +244,7 @@ class Aip::V1::ItemsControllerTest < ActionDispatch::IntegrationTest
     }
     rendered_graph = load_n3_graph(file_fixture('n3/items/file_set.n3'), variables)
 
-    assert_equal true, rendered_graph.isomorphic_with?(graph)
+    assert rendered_graph.isomorphic_with?(graph)
   end
 
   test 'should get item fixity metadata graph with n3 serialization' do
@@ -267,7 +267,7 @@ class Aip::V1::ItemsControllerTest < ActionDispatch::IntegrationTest
     }
     rendered_graph = load_n3_graph(file_fixture('n3/items/fixity.n3'), variables)
 
-    assert_equal true, rendered_graph.isomorphic_with?(graph)
+    assert rendered_graph.isomorphic_with?(graph)
   end
 
 end

--- a/test/controllers/aip/v1/aip_theses_controller_test.rb
+++ b/test/controllers/aip/v1/aip_theses_controller_test.rb
@@ -74,7 +74,7 @@ class Aip::V1::ThesesControllerTest < ActionDispatch::IntegrationTest
     graph = generate_graph_from_n3(response.body)
     rendered_graph = load_radioactive_n3_graph(radioactive_thesis, 'base')
 
-    assert_equal true, rendered_graph.isomorphic_with?(graph)
+    assert rendered_graph.isomorphic_with?(graph)
   end
 
   test 'should get thesis metadata graph with n3 serialization for embargo example' do
@@ -98,7 +98,7 @@ class Aip::V1::ThesesControllerTest < ActionDispatch::IntegrationTest
     graph = generate_graph_from_n3(response.body)
     rendered_graph = load_radioactive_n3_graph(radioactive_thesis, 'embargoed')
 
-    assert_equal true, rendered_graph.isomorphic_with?(graph)
+    assert rendered_graph.isomorphic_with?(graph)
   end
 
   test 'should get thesis metadata graph with n3 serialization for previously embargo example' do
@@ -126,7 +126,7 @@ class Aip::V1::ThesesControllerTest < ActionDispatch::IntegrationTest
     graph = generate_graph_from_n3(response.body)
     rendered_graph = load_radioactive_n3_graph(radioactive_thesis, 'prev-embargoed')
 
-    assert_equal true, rendered_graph.isomorphic_with?(graph)
+    assert rendered_graph.isomorphic_with?(graph)
   end
 
   # Basic test checking if response has xml format.
@@ -138,7 +138,7 @@ class Aip::V1::ThesesControllerTest < ActionDispatch::IntegrationTest
     )
 
     assert_response :success
-    assert_equal true, check_file_order_xml(response.body)
+    assert check_file_order_xml(response.body)
   end
 
   test 'should get thesis file paths' do
@@ -149,7 +149,7 @@ class Aip::V1::ThesesControllerTest < ActionDispatch::IntegrationTest
     )
     assert_response :success
     json_string = response.body
-    assert_equal true, JSON::Validator.validate(
+    assert JSON::Validator.validate(
       file_paths_json_schema,
       json_string
     )
@@ -157,7 +157,7 @@ class Aip::V1::ThesesControllerTest < ActionDispatch::IntegrationTest
 
     # Check that all files actually exist
     json_response['files'].map do |file|
-      assert_equal true, File.file?(file['file_path'])
+      assert File.file?(file['file_path'])
     end
   end
 
@@ -186,7 +186,7 @@ class Aip::V1::ThesesControllerTest < ActionDispatch::IntegrationTest
     }
     rendered_graph = load_n3_graph(file_fixture('n3/theses/file_set.n3'), variables)
 
-    assert_equal true, rendered_graph.isomorphic_with?(graph)
+    assert rendered_graph.isomorphic_with?(graph)
   end
 
   test 'should get thesis fixity metadata graph with n3 serialization' do
@@ -210,7 +210,7 @@ class Aip::V1::ThesesControllerTest < ActionDispatch::IntegrationTest
     }
     rendered_graph = load_n3_graph(file_fixture('n3/theses/fixity.n3'), variables)
 
-    assert_equal true, rendered_graph.isomorphic_with?(graph)
+    assert rendered_graph.isomorphic_with?(graph)
   end
 
 end

--- a/test/controllers/downloads_controller_test.rb
+++ b/test/controllers/downloads_controller_test.rb
@@ -26,8 +26,8 @@ class DownloadsControllerTest < ActionDispatch::IntegrationTest
                            file_name: @file.filename)
 
     assert_response :success
-    assert_equal @response.media_type, 'text/plain'
-    assert_equal @response.headers['Content-Disposition'], 'inline'
+    assert_equal('text/plain', @response.media_type)
+    assert_equal('inline', @response.headers['Content-Disposition'])
     assert_includes @response.body, 'A nice, brief file, with some great text.'
   end
 
@@ -36,8 +36,8 @@ class DownloadsControllerTest < ActionDispatch::IntegrationTest
                                file_set_id: @file.fileset_uuid)
 
     assert_response :success
-    assert_equal @response.media_type, 'text/plain'
-    assert_equal @response.headers['Content-Disposition'], 'attachment'
+    assert_equal('text/plain', @response.media_type)
+    assert_equal('attachment', @response.headers['Content-Disposition'])
     assert_includes @response.body, 'A nice, brief file, with some great text.'
   end
 

--- a/test/helpers/page_layout_helper_test.rb
+++ b/test/helpers/page_layout_helper_test.rb
@@ -97,16 +97,11 @@ class PageLayoutHelperTest < ActionView::TestCase
 
   # thumbnail_path
 
-  def mupdf_exists?
-    ActiveStorage::Previewer::MuPDFPreviewer.mutool_exists?
-  end
-
-  def poppler_exists?
-    ActiveStorage::Previewer::PopplerPDFPreviewer.pdftoppm_exists?
-  end
-
   test 'thumbnail_path should return preview for pdf (Invariable but Previewable)' do
-    skip 'this test requires the dependency MuPDF or Poppler to be installed' unless mupdf_exists? || poppler_exists?
+    unless ActiveStorage::Previewer::PopplerPDFPreviewer.pdftoppm_exists? ||
+           ActiveStorage::Previewer::MuPDFPreviewer.mutool_exists?
+      skip 'this test requires the dependency MuPDF or Poppler to be installed'
+    end
 
     item = items(:fancy)
     File.open(file_fixture('pdf-sample.pdf'), 'r') do |file|

--- a/test/integration/collection_show_test.rb
+++ b/test/integration/collection_show_test.rb
@@ -32,8 +32,8 @@ class CollectionShowTest < ActionDispatch::IntegrationTest
 
     # Delete collection link
     delete = css_select "a[href='#{admin_community_collection_path(@community, @collection)}']"
-    assert_equal delete.count, 1
-    assert_equal delete.first.attributes['data-method'].to_s, 'delete'
+    assert_equal(1, delete.count)
+    assert_equal('delete', delete.first.attributes['data-method'].to_s)
 
     # Items are shown
     assert_select '.jupiter-results ul.list-group .list-group-item', count: 2
@@ -43,7 +43,7 @@ class CollectionShowTest < ActionDispatch::IntegrationTest
       item_links = css_select ".jupiter-results ul.list-group .list-group-item a[href='#{item_path(item)}']"
 
       # Thumbnail, text link, and delete link
-      assert_equal item_links.count, 2
+      assert_equal(2, item_links.count)
       # Thumbnail link to item
       assert_includes item_links.first.inner_html, 'img-thumbnail'
       # Text link to item
@@ -52,7 +52,7 @@ class CollectionShowTest < ActionDispatch::IntegrationTest
       # Link to delete item
       delete_link = css_select ".jupiter-results ul.list-group .list-group-item a[href='#{admin_item_path(item)}']"
       assert_match 'Delete', delete_link.last.text
-      assert_equal delete_link.last.attributes['data-method'].to_s, 'delete'
+      assert_equal('delete', delete_link.last.attributes['data-method'].to_s)
 
       # Link to edit item
       assert_select "ul.list-group .list-group-item a[href='#{edit_item_path(item)}']", text: 'Edit'
@@ -85,7 +85,7 @@ class CollectionShowTest < ActionDispatch::IntegrationTest
     @items.each do |item|
       item_links = css_select ".jupiter-results ul.list-group .list-group-item a[href='#{item_path(item)}']"
       # Only thumbnail and text link expected
-      assert_equal item_links.count, 2
+      assert_equal(2, item_links.count)
       # Thumbnail link to item
       assert_includes item_links.first.inner_html, 'img-thumbnail'
       # Link to item

--- a/test/integration/community_show_test.rb
+++ b/test/integration/community_show_test.rb
@@ -112,7 +112,7 @@ class CommunityShowTest < ActionDispatch::IntegrationTest
     sign_in_as user
     get community_url(@community1, format: :json)
     body = JSON.parse(response.body)
-    assert_equal body['collections'].count, 1
+    assert_equal(1, body['collections'].count)
     assert_includes body['collections'].map { |c| c['id'] }, @collection1.id
   end
 
@@ -121,7 +121,7 @@ class CommunityShowTest < ActionDispatch::IntegrationTest
     sign_in_as user
     get community_url(@community1, format: :json)
     body = JSON.parse(response.body)
-    assert_equal body['collections'].count, 2
+    assert_equal(2, body['collections'].count)
     assert_includes body['collections'].map { |c| c['id'] }, @collection1.id
     assert_includes body['collections'].map { |c| c['id'] }, @collection2.id
   end

--- a/test/integration/user_activity_test.rb
+++ b/test/integration/user_activity_test.rb
@@ -19,7 +19,7 @@ class UserActivityTest < ActionDispatch::IntegrationTest
       end
       user.reload
       assert_equal user.last_seen_at.to_s, now1
-      assert_equal user.last_seen_ip, '127.0.0.1'
+      assert_equal('127.0.0.1', user.last_seen_ip)
       assert_equal user.last_sign_in_at.to_s, now1
     end
 
@@ -34,7 +34,7 @@ class UserActivityTest < ActionDispatch::IntegrationTest
       end
       user.reload
       assert_equal user.last_seen_at.to_s, now2
-      assert_equal user.last_seen_ip, '127.0.0.1'
+      assert_equal('127.0.0.1', user.last_seen_ip)
       assert_equal user.last_sign_in_at.to_s, now2
       assert_equal user.previous_sign_in_at, now1
     end

--- a/test/models/announcement_test.rb
+++ b/test/models/announcement_test.rb
@@ -13,12 +13,12 @@ class AnnouncementTest < ActiveSupport::TestCase
   end
 
   test 'current announcements scope' do
-    assert Announcement.current.count == 1
+    assert_equal(1, Announcement.current.count)
     assert_includes Announcement.current, announcements(:current_announcement)
   end
 
   test 'past announcements scope' do
-    assert Announcement.past.count == 2
+    assert_equal(2, Announcement.past.count)
     assert_includes Announcement.past, announcements(:past_announcement)
     assert_includes Announcement.past, announcements(:another_past_announcement)
   end

--- a/test/models/community_test.rb
+++ b/test/models/community_test.rb
@@ -25,16 +25,16 @@ class CommunityTest < ActiveSupport::TestCase
                           filename: 'image-sample.jpeg', content_type: 'image/jpeg'
 
     assert community.logo.is_a?(ActiveStorage::Attached::One)
-    assert_equal community.logo.filename, 'image-sample.jpeg'
-    assert_equal community.logo.blob.content_type, 'image/jpeg'
-    assert_equal community.logo.blob.byte_size, 12_086
+    assert_equal('image-sample.jpeg', community.logo.filename.to_s)
+    assert_equal('image/jpeg', community.logo.blob.content_type)
+    assert_equal(12_086, community.logo.blob.byte_size)
 
     # Find file on disk
     key = community.logo.blob.key
     assert key.is_a?(String)
     file_path = ActiveStorage::Blob.service.root + "/#{key[0..1]}/#{key[2..3]}/#{key}"
-    assert File.exist?(file_path)
-    assert_equal community.logo.blob.checksum, 'GxpIjJsC4KnRoBKNjWnkJA=='
+    assert_path_exists(file_path)
+    assert_equal('GxpIjJsC4KnRoBKNjWnkJA==', community.logo.blob.checksum)
   end
 
   test 'an updated logo replaces the old one' do
@@ -42,11 +42,11 @@ class CommunityTest < ActiveSupport::TestCase
     community.logo.attach io: File.open(file_fixture('image-sample.jpeg')),
                           filename: 'sample1.jpeg', content_type: 'image/jpeg'
 
-    assert_equal community.logo.filename, 'sample1.jpeg'
+    assert_equal('sample1.jpeg', community.logo.filename.to_s)
 
     community.logo.attach io: File.open(file_fixture('image-sample.jpeg')),
                           filename: 'sample2.jpeg', content_type: 'image/jpeg'
-    assert_equal community.logo.filename, 'sample2.jpeg'
+    assert_equal('sample2.jpeg', community.logo.filename.to_s)
   end
 
 end

--- a/test/models/item_test.rb
+++ b/test/models/item_test.rb
@@ -21,7 +21,7 @@ class ItemTest < ActiveSupport::TestCase
       end
     end
     assert item.valid?
-    assert Item.public_items.map(&:id).include?(item.id)
+    assert_includes Item.public_items.map(&:id), item.id
 
     assert_difference -> { Item.public_items.count }, -1 do
       item.tap do |unlocked_item|
@@ -309,7 +309,7 @@ class ItemTest < ActiveSupport::TestCase
     item = Item.new(created: 'Fall 2015')
     item.valid?
     assert_not item.errors[:sort_year].present?
-    assert_equal item.sort_year, 2015
+    assert_equal(2015, item.sort_year)
   end
 
   # Preservation queue handling

--- a/test/models/language_test.rb
+++ b/test/models/language_test.rb
@@ -9,8 +9,8 @@ class LanguageTest < ActiveSupport::TestCase
 
   test 'should give the translated version of the name' do
     english_language = languages(:english)
-    assert_equal english_language.name, 'english'
-    assert_equal english_language.translated_name, 'English'
+    assert_equal('english', english_language.name)
+    assert_equal('English', english_language.translated_name)
   end
 
 end

--- a/test/models/thesis_test.rb
+++ b/test/models/thesis_test.rb
@@ -156,7 +156,7 @@ class ThesisTest < ActiveSupport::TestCase
 
   test 'item_type_with_status_code gets set correctly' do
     thesis = Thesis.new
-    assert_equal thesis.item_type_with_status_code, :thesis
+    assert_equal(:thesis, thesis.item_type_with_status_code)
   end
 
   test 'a title is required' do
@@ -187,7 +187,7 @@ class ThesisTest < ActiveSupport::TestCase
     thesis = Thesis.new(graduation_date: 'Fall 2015')
     thesis.valid?
     assert_not thesis.errors[:sort_year].present?
-    assert_equal thesis.sort_year, 2015
+    assert_equal(2015, thesis.sort_year)
   end
 
 end

--- a/test/models/type_test.rb
+++ b/test/models/type_test.rb
@@ -8,8 +8,8 @@ class TypeTest < ActiveSupport::TestCase
 
   test 'should give the translated version of the name' do
     book_type = types(:book)
-    assert_equal book_type.name, 'book'
-    assert_equal book_type.translated_name, 'Book'
+    assert_equal('book', book_type.name)
+    assert_equal('Book', book_type.translated_name)
   end
 
 end

--- a/test/policies/admin_policy_test.rb
+++ b/test/policies/admin_policy_test.rb
@@ -4,7 +4,7 @@ class AdminPolicyTest < ActiveSupport::TestCase
 
   test 'should deny normal user' do
     current_user = users(:regular)
-    assert_equal false, AdminPolicy.new(current_user, :admin).access?
+    assert_not AdminPolicy.new(current_user, :admin).access?
   end
 
   test 'should allow admin user' do

--- a/test/services/user_search_service_test.rb
+++ b/test/services/user_search_service_test.rb
@@ -40,7 +40,7 @@ class UserSearchServiceTest < ActiveSupport::TestCase
     )
 
     assert_instance_of JupiterCore::SolrServices::DeferredFacetedSolrQuery, search.results
-    assert_equal search.results.count, 3
+    assert_equal(3, search.results.count)
   end
 
   test 'should filter search results by visibility of current_user' do
@@ -52,7 +52,7 @@ class UserSearchServiceTest < ActiveSupport::TestCase
       params: params
     )
 
-    assert_equal search.results.count, 2
+    assert_equal(2, search.results.count)
     assert_not_includes search.results, @admin_private_item
   end
 
@@ -69,7 +69,7 @@ class UserSearchServiceTest < ActiveSupport::TestCase
     )
 
     # Only Fancy item is owned by regular user
-    assert_equal search.results.count, 1
+    assert_equal(1, search.results.count)
     assert_equal search.results.first.id, @regular_user_item.id
   end
 
@@ -84,11 +84,11 @@ class UserSearchServiceTest < ActiveSupport::TestCase
     )
 
     # Only Admin item has "French" in its description
-    assert_equal search.results.count, 1
+    assert_equal(1, search.results.count)
 
     search.results.each_with_fulltext_results do |result, fulltext_hits|
       assert_equal result.id, @admin_item.id
-      assert_equal fulltext_hits.count, 1
+      assert_equal(1, fulltext_hits.count)
       assert_match(
         /<mark>French<\/mark>/,
         fulltext_hits.first.highlight_text

--- a/test/system/thumbnail_resetting_test.rb
+++ b/test/system/thumbnail_resetting_test.rb
@@ -51,9 +51,9 @@ class ThumbnailResettingTest < ApplicationSystemTestCase
     assert_text I18n.t('items.draft.successful_deposit')
 
     # Assert that statements in above comments are true.
-    assert first_thumbnail_id != second_thumbnail_id
-    assert first_thumbnail_id != third_thumbnail_id
-    assert second_thumbnail_id == third_thumbnail_id
+    assert_not_equal first_thumbnail_id, second_thumbnail_id
+    assert_not_equal first_thumbnail_id, third_thumbnail_id
+    assert_equal second_thumbnail_id, third_thumbnail_id
 
     logout_user
   end


### PR DESCRIPTION
Learned about `rubocop-minitest` gem while reading Rubocop 1.0 announcement. 

Seemed pretty cool as I always get things wrong with minitest's API (for example assert args order.... is it `assert(expected, actual)` or `assert(actual, expected)` 🤔 ?) . Now this gem will autocorrect it for you!

Gem github and style guide is here:

- https://github.com/rubocop-hq/rubocop-minitest
- https://docs.rubocop.org/rubocop-minitest/