### PR TITLE
UAT VIRTUAL_HOSTS configuration on just the containers that need it

### DIFF
--- a/.env_deployment_sample
+++ b/.env_deployment_sample
@@ -21,7 +21,3 @@ POSTGRES_USER=jupiter
 # Nginx environment variables
 HOSTNAME=localhost
 SKYLIGHT_AUTHENTICATION=secretauthenticationtoken
-
-VIRTUAL_HOST=era.localhost
-VIRTUAL_PROTO=https
-VIRTUAL_PORT=443

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and releases in Jupiter project adheres to [Semantic Versioning](http://semver.o
 - Changed oaisys' updated until scope [#1816](https://github.com/ualbertalib/jupiter/issues/1816)
 - ActiveStorage::Blob now uses UUID for ids. You will need to recreate, remigrate, and reseed your DB.
 - predeploy script to reference this branch
+- UAT VIRTUAL_HOSTS configuration on just the containers that need it
 
 ### Added
 - script for watchtower to run from post-update hook [PR#1892](https://github.com/ualbertalib/jupiter/pull/1892)

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -23,6 +23,7 @@ services:
     image: solr:6.6
     environment:
       - VIRTUAL_HOST=solr.era.uat.library.ualberta.ca
+      - HTTPS_METHOD=nohttps
     ports:
       - "8983"
     volumes:
@@ -69,10 +70,14 @@ services:
     depends_on:
       - web
     env_file: .env_deployment
+    environment:
+      - VIRTUAL_HOST=era.uat.library.ualberta.ca
+      - VIRTUAL_PROTO=https
+      - VIRTUAL_PORT=443
+      - HTTPS_METHOD=noredirect
     volumes:
       - ./config/nginx.conf:/etc/nginx/conf.d/default.conf
-      - ../UALcert:/etc/nginx/certs
+      - ../UATcert:/etc/nginx/certs
       - assets:/app/public/
     ports:
-      - "80"
       - "443"


### PR DESCRIPTION
## Context

Sometimes when containers were updated by watchtower the VIRTUAL_HOSTS values in the .env_deployment files would apply to several containers.  This mean that sometimes it would try to route to the web container directly instead of nginx (and not work).

There is still a gotcha with solr.era.uat.library.ualberta.ca being redirected to https by HSTS.  To get around this try visiting in a private window or "Clear Cookies and Site Data".

## What's New

apply [VIRTUAL_HOSTS configuration](https://github.com/nginx-proxy/nginx-proxy#multiple-ports) on just the containers that need it.