### PR TITLE
Fix reindexing task accidental no-op

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and releases in Jupiter project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Make reindex rake task actually reindex all of the objects into Solr, instead of acting as a no-op
 
 ### Added
 - Mounted Oaisys engine [PR#1361](https://github.com/ualbertalib/jupiter/pull/1361)
@@ -53,7 +54,7 @@ and releases in Jupiter project adheres to [Semantic Versioning](http://semver.o
 - ActiveStorage::Blob now uses UUID for ids. You will need to recreate, remigrate, and reseed your DB.
 - Ensure Thesis Department and supervisor are indexed for faceting (they were in Fedora, missed in initial
   work to port to Postgres)
-  
+
 ### Fixed
 - failing tests [#1376](https://github.com/ualbertalib/jupiter/issues/1376)
 - Fix Sprockets v4.0.0 upgrade problem with how Sass Variables were being defined [#1406](https://github.com/ualbertalib/jupiter/issues/1406)

--- a/lib/tasks/jupiter.rake
+++ b/lib/tasks/jupiter.rake
@@ -5,8 +5,22 @@ namespace :jupiter do
   task :reindex, [:batch_size] => :environment do |_, args|
     desired_batch_size = args.batch_size.to_i ||= 1000
     puts 'Reindexing all Items and Theses...'
-    Item.find_each(batch_size: desired_batch_size, &:save!)
-    Thesis.find_each(batch_size: desired_batch_size, &:save!)
+
+    count = 0
+    Item.find_each(batch_size: desired_batch_size) do |item|
+      item.update_solr
+      count += 1
+      print '.' if count % 20 == 0
+    end
+    puts "Reindexed #{count} Items. Moving on to Theses..."
+
+    count = 0
+    Thesis.find_each(batch_size: desired_batch_size) do |thesis|
+      thesis.update_solr
+      count += 1
+      print '.' if count % 20 == 0
+    end
+
     puts 'Reindex completed!'
   end
 

--- a/lib/tasks/jupiter.rake
+++ b/lib/tasks/jupiter.rake
@@ -12,7 +12,10 @@ namespace :jupiter do
       count += 1
       print '.' if count % 20 == 0
     end
+
+    puts
     puts "Reindexed #{count} Items. Moving on to Theses..."
+    puts
 
     count = 0
     Thesis.find_each(batch_size: desired_batch_size) do |thesis|
@@ -20,7 +23,7 @@ namespace :jupiter do
       count += 1
       print '.' if count % 20 == 0
     end
-
+    puts "Reindexed #{count} Theses."
     puts 'Reindex completed!'
   end
 


### PR DESCRIPTION
## Context

When we tried to reindex Theses on New Prod, nothing happened (and happened very quickly!). Effectively, we tried to rely on re-saving the objects to update the Solr index for them, but Rails is smart enough to know that the objects aren't dirty, and no-ops the save call.

## What's New

Directly call `update_solr` rather than try to rely on it being called-back from the `save` in the reindex task. Also added some output as it runs, just to keep people from getting nervous about it maybe having locked up during long runs.
