### PR TITLE
Fix a mis-named error rescue that resulted in a crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and releases in Jupiter project adheres to [Semantic Versioning](http://semver.o
 
 ## [Unreleased]
 - Make reindex rake task actually reindex all of the objects into Solr, instead of acting as a no-op
+– Fix a mis-named error rescue that resulted in a crash when the sort field wasn't known for a model
 
 ### Added
 - Mounted Oaisys engine [PR#1361](https://github.com/ualbertalib/jupiter/pull/1361)

--- a/app/models/jupiter_core/solr_services/deferred_faceted_solr_query.rb
+++ b/app/models/jupiter_core/solr_services/deferred_faceted_solr_query.rb
@@ -57,7 +57,7 @@ class JupiterCore::SolrServices::DeferredFacetedSolrQuery
                         else
                           solr_exporter.solr_name_for(attr, role: :sort)
                         end
-                      rescue ArgumentError, NameManglingError
+                      rescue ArgumentError, JupiterCore::SolrServices::NameManglingError
                         nil
                       end
 


### PR DESCRIPTION
## Context

Application 500s if you sort items by date and then switch results tabs to Collections or Communities.

## What's New

We're supposed to handle this by rescuing a NameManglingError if the sort field doesn't have a known Solr mangled index name for the model being searched – but we missed the namespace on the error in the rescue declaration, so it just crashes as an unknown class.

Part of #2009 