### PR TITLE
Fix issue where non-existent download links 500 instead of 404ing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and releases in Jupiter project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+– Fix issue where we improperly 500'd when a file download URL referenced a non-existent fileset UUID, instead of 404ing
 - Make reindex rake task actually reindex all of the objects into Solr, instead of acting as a no-op
 – Fix a mis-named error rescue that resulted in a crash when the sort field wasn't known for a model
 

--- a/app/controllers/downloads_controller.rb
+++ b/app/controllers/downloads_controller.rb
@@ -36,7 +36,7 @@ class DownloadsController < ApplicationController
 
   def load_and_authorize_file
     @file = ActiveStorage::Attachment.find_by(fileset_uuid: params[:file_set_id])
-    raise JupiterCore::ObjectNotFound unless @file.record_id == params[:id]
+    raise JupiterCore::ObjectNotFound unless (@file.present? && (@file.record_id == params[:id]))
 
     authorize @file.record, :download?
   end

--- a/app/controllers/downloads_controller.rb
+++ b/app/controllers/downloads_controller.rb
@@ -36,7 +36,7 @@ class DownloadsController < ApplicationController
 
   def load_and_authorize_file
     @file = ActiveStorage::Attachment.find_by(fileset_uuid: params[:file_set_id])
-    raise JupiterCore::ObjectNotFound unless (@file.present? && (@file.record_id == params[:id]))
+    raise JupiterCore::ObjectNotFound unless @file.present? && (@file.record_id == params[:id])
 
     authorize @file.record, :download?
   end


### PR DESCRIPTION
## Context

Just a noisy but not very impactful bug, where if you take an item that 404s, like https://era.library.ualberta.ca/items/12345, and then try to download a non-existent file belonging to it, like https://era.library.ualberta.ca/items/12345/download/43a918c3-5eec-4ae9-addc-024e91fb6232, we 500 instead of 404ing

## What's New

Check that the item record exists and if not 404, instead of blindly derefrencing it.