### PR TITLE
try to better resolve issue with logo_id constraints when deleting items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and releases in Jupiter project adheres to [Semantic Versioning](http://semver.o
 ## [Unreleased]
 - Make reindex rake task actually reindex all of the objects into Solr, instead of acting as a no-op
 – Fix a mis-named error rescue that resulted in a crash when the sort field wasn't known for a model
+– Try to better handle the logo deletion circular constraint (next step: dropping it entirely)
 
 ## [2.0.1] - 2020-12-14
 

--- a/app/controllers/admin/items_controller.rb
+++ b/app/controllers/admin/items_controller.rb
@@ -15,7 +15,20 @@ class Admin::ItemsController < Admin::AdminController
     end
 
     begin
-      @item.logo_id = nil
+      # rubocop:disable Rails/SkipsModelValidations
+      # HACK: bit of a silly hack (write a nil directly to the colum) to get around this hack where destroying
+      # the item tries to destroy the attachments, which then errors out because the attachment id is
+      # still referenced by the item that's about to be destroyed.
+      #
+      # TODO: investigate further why this happens (seems inconsistent with the settings for
+      # the constraint:
+      #  +add_foreign_key "items", "active_storage_attachments", column: "logo_id", on_delete: :nullify+
+      # which should allow this to work?) and consider dropping the constraint
+      # entirely if this is unreliable on PostgreSQL
+
+      @item.update_columns(logo_id: nil)
+
+      # rubocop:enable Rails/SkipsModelValidations
       @item.destroy!
       flash[:notice] = t('.deleted')
     rescue StandardError => e

--- a/app/controllers/admin/items_controller.rb
+++ b/app/controllers/admin/items_controller.rb
@@ -16,7 +16,7 @@ class Admin::ItemsController < Admin::AdminController
 
     begin
       # rubocop:disable Rails/SkipsModelValidations
-      # HACK: bit of a silly hack (write a nil directly to the colum) to get around this hack where destroying
+      # HACK: bit of a silly hack (write a nil directly to the column) to get around this hack where destroying
       # the item tries to destroy the attachments, which then errors out because the attachment id is
       # still referenced by the item that's about to be destroyed.
       #


### PR DESCRIPTION
## Context

1. Items have attachments.
2. Items have a logo_id, which is the id of the attachment that represents the item's "logo".
3. logo_id has a constraint to make sure it points at attachments that actually exist.
4. The logo_id constraint is "on delete nullify", so when you delete an attachment, it should become null.

Nevertheless, when you try to delete an item, it tries to delete its attachments first, and then that fails, because the attachment is referenced by the logo_id on the item – the item that is about to be deleted, and the logo_id that should be nullified by the attachment delete.

I don't know why this happens.

## What's New

Try to make this not happen. Directly bypass everything and write a null on the logo_id column before deleting the item and therefore trigger a delete of the attachments.