### PR TITLE
Turn off reporting this meaningless warning to Rollbar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and releases in Jupiter project adheres to [Semantic Versioning](http://semver.o
 ## [Unreleased]
 
 – Remove entirely unnecessary config file.
+– Turn off reporting things like "this excel spreadsheet isn't thumbnailable" as warnings to Rollbar
 
 ## [2.0.2] - 2020-12-17
 

--- a/config/initializers/rollbar.rb
+++ b/config/initializers/rollbar.rb
@@ -31,6 +31,9 @@ Rollbar.configure do |config|
   # You can also specify a callable, which will be called with the exception instance.
   # config.exception_level_filters.merge!('MyCriticalException' => lambda { |e| 'critical' })
 
+  config.exception_level_filters['ActionController::RoutingError'] = 'ignore'
+  config.exception_level_filters['ActiveStorage::UnrepresentableError'] = 'ignore'
+
   # Enable asynchronous reporting (uses girl_friday or Threading if girl_friday
   # is not installed)
   # config.use_async = true
@@ -38,8 +41,6 @@ Rollbar.configure do |config|
   # config.async_handler = Proc.new { |payload|
   #  Thread.new { Rollbar.process_from_async_handler(payload) }
   # }
-
-  config.exception_level_filters['ActionController::RoutingError'] = 'ignore'
 
   # Enable asynchronous reporting (using sucker_punch)
   # config.use_sucker_punch


### PR DESCRIPTION
## Context

Rollbar is kind of unusable right now if you don't filter out warnings, because we send a `ActiveStorage::UnrepresentableError` warning every time someone views an item that has a file as its "logo" which isn't able to be turned into a thumbnail. The problem is that this is in almost all cases totally normal – we know that you can't thumbnail an Excel Spreadsheet, and we have a fallback to display a generic logo for these cases, so this doesn't need to be reported.

## What's New

Tell Rollbar gem to stop reporting this error.

## Other Options

I'm also somewhat tempted to remove this: 

https://github.com/ualbertalib/jupiter/blob/34b64ff31403e94b2c2e76589edb5cb970ddbc58/app/helpers/page_layout_helper.rb#L52-L53

which warns when a jpg or png or whatever can't be thumbnailed because it's unparseable/corrupted – this *is* a real error, but there's really nothing we can or do do to resolve this, so it just seems like noise. Thoughts?