### PR TITLE
Initialize disabled ReadOnlyMode in seeds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and releases in Jupiter project adheres to [Semantic Versioning](http://semver.o
 
 ## [Unreleased]
 
+### Added
+- Initialize disabled ReadOnlyMode [#2100](https://github.com/ualbertalib/jupiter/issues/2100)
+
 ### Removed
 – Remove entirely unnecessary config file. [PR#2044](https://github.com/ualbertalib/jupiter/pull/2044)
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -18,6 +18,8 @@ if Rails.env.development? || Rails.env.uat?
 
   puts 'Starting seeding of dev database...'
 
+  ReadOnlyMode.create(enabled: false)
+
   # start fresh
   [Announcement, ActiveStorage::Blob, ActiveStorage::Attachment,
    Identity, User, Type, Language, Institution].each(&:destroy_all)


### PR DESCRIPTION
## Context

`ReadOnlyMode.create(enabled: false)` is in a migration but that doesn't get set in development if you're running `db:prepare` or `db:setup`.

Related to #2100 https://github.com/ualbertalib/jupiter/issues/1838

## What's New

Initialized disabled ReadOnlyMode in seeds.