### PR TITLE
Default behaviour within a facet to 'OR'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and releases in Jupiter project adheres to [Semantic Versioning](http://semver.o
 - Added DOI reset feature for admins [#1739](https://github.com/ualbertalib/jupiter/issues/1739)
 – Turn off reporting things like "this excel spreadsheet isn't thumbnailable" as warnings to Rollbar [PR#2046](https://github.com/ualbertalib/jupiter/pull/2046)
 - migration to fix concatenated subjects (part 2) [#1449](https://github.com/ualbertalib/jupiter/issues/1449)
+- Default behaviour within a facet to 'OR' [#1990](https://github.com/ualbertalib/jupiter/issues/1990)
 
 ### Fixed
 - bump rubocop and fix cop violations [PR#2072](https://github.com/ualbertalib/jupiter/pull/2072)

--- a/app/models/jupiter_core/search.rb
+++ b/app/models/jupiter_core/search.rb
@@ -37,7 +37,13 @@ class JupiterCore::Search
 
     base_query << q if q.present?
     facets.each do |key, values|
-      fq << %Q(#{key}:\(#{values.collect { |value| "\"#{value}\"" }.join(' ')}\))
+      if Flipper.enabled?(:or_facets)
+        fq << %Q(#{key}:\(#{values.collect { |value| "\"#{value}\"" }.join(' ')}\))
+      else
+        values.each do |value|
+          fq << %Q(#{key}: "#{value}")
+        end
+      end
     end
     ranges.each do |key, value|
       fq << "#{key}:[#{value[:begin]} TO #{value[:end]}]"

--- a/app/models/jupiter_core/search.rb
+++ b/app/models/jupiter_core/search.rb
@@ -38,7 +38,7 @@ class JupiterCore::Search
     base_query << q if q.present?
     facets.each do |key, values|
       if Flipper.enabled?(:or_facets)
-        fq << %Q(#{key}:\(#{values.collect { |value| "\"#{value}\"" }.join(' ')}\))
+        fq << %Q(#{key}:\(#{values.collect { |value| "\"#{value}\"" }.join(' OR ')}\))
       else
         values.each do |value|
           fq << %Q(#{key}: "#{value}")

--- a/app/models/jupiter_core/search.rb
+++ b/app/models/jupiter_core/search.rb
@@ -41,7 +41,7 @@ class JupiterCore::Search
         fq << %Q(#{key}:\(#{values.collect { |value| "\"#{value}\"" }.join(' OR ')}\))
       else
         values.each do |value|
-          fq << %Q(#{key}: "#{value}")
+          fq << %Q(#{key}:"#{value}")
         end
       end
     end

--- a/app/models/jupiter_core/search.rb
+++ b/app/models/jupiter_core/search.rb
@@ -37,9 +37,7 @@ class JupiterCore::Search
 
     base_query << q if q.present?
     facets.each do |key, values|
-      values.each do |value|
-        fq << %Q(#{key}: "#{value}")
-      end
+      fq << %Q(#{key}:\(#{values.collect { |value| "\"#{value}\"" }.join(' ')}\))
     end
     ranges.each do |key, value|
       fq << "#{key}:[#{value[:begin]} TO #{value[:end]}]"

--- a/test/fixtures/items.yml
+++ b/test/fixtures/items.yml
@@ -14,6 +14,22 @@ fancy:
   subject: ['Fancy things']
   member_of_paths: <%= ["#{ActiveRecord::FixtureSet.identify(:fancy_community, :uuid)}/#{ActiveRecord::FixtureSet.identify(:fancy_collection, :uuid)}"] %>
 
+practical:
+  visibility: <%= JupiterCore::VISIBILITY_PUBLIC %>
+  owner: regular
+  title: 'Fancy Item'
+  creators: ['Joe Blow']
+  created: 'Fall 2017'
+  record_created_at: <%= 5.day.ago.to_s(:db) %>
+  updated_at: <%= 5.day.ago.to_s(:db) %>
+  date_ingested: <%= 5.day.ago %>
+  languages: <%= [CONTROLLED_VOCABULARIES[:language].english] %>
+  license: <%= CONTROLLED_VOCABULARIES[:license].attribution_4_0_international %>
+  item_type: <%= CONTROLLED_VOCABULARIES[:item_type].article %>
+  publication_status: <%= [CONTROLLED_VOCABULARIES[:publication_status].published] %>
+  subject: ['Practical things']
+  member_of_paths: <%= ["#{ActiveRecord::FixtureSet.identify(:fancy_community, :uuid)}/#{ActiveRecord::FixtureSet.identify(:fancy_collection, :uuid)}"] %>
+
 # The admin item contains a base item entry that contains one of the possible value combinations that pass all validations
 # This is a radioactive item
 admin:

--- a/test/integration/sitemap_test.rb
+++ b/test/integration/sitemap_test.rb
@@ -52,7 +52,7 @@ class SitemapTest < ActionDispatch::IntegrationTest
     assert_select 'loc', item_url(@item)
     assert_select 'lastmod', @item.updated_at.iso8601
     # not show private items
-    assert_select 'url', count: 4
+    assert_select 'url', count: 5
     assert_select 'loc', { count: 0, text: item_url(@private_item) }, 'private items should not appear in the sitemap'
   end
 

--- a/test/models/search_test.rb
+++ b/test/models/search_test.rb
@@ -2,7 +2,21 @@ require 'test_helper'
 
 class SearchTest < ActiveSupport::TestCase
 
-  test 'default behaviour within a facet is OR and between facets is AND' do
+  test 'default behaviour within a facet is AND and between facets is AND' do
+    results = JupiterCore::Search.faceted_search(models: [Item],
+                                                 facets: {
+                                                   all_subjects_sim: ['Fancy things',
+                                                                      'Practical things'],
+                                                   all_contributors_sim: ['Joe Blow']
+                                                 })
+
+    # rubocop:disable Layout/LineLength
+    assert_includes results.criteria[:fq],
+                    'all_subjects_sim:"Fancy things" AND all_subjects_sim:"Practical things" AND all_contributors_sim:"Joe Blow"'
+    # rubocop:enable Layout/LineLength
+  end
+
+  test 'default behaviour within a facet is OR and between facets is AND when feature flag is on' do
     Flipper.enable(:or_facets)
     item1 = items(:fancy)
     item2 = items(:practical)
@@ -10,16 +24,16 @@ class SearchTest < ActiveSupport::TestCase
     [item1, item2].each(&:update_solr)
     results = JupiterCore::Search.faceted_search(models: [Item],
                                                  facets: {
-                                                   'all_subjects_sim': ['Fancy things',
-                                                                        'Practical things'],
-                                                   'all_contributors_sim': ['Joe Blow']
+                                                   all_subjects_sim: ['Fancy things',
+                                                                      'Practical things'],
+                                                   all_contributors_sim: ['Joe Blow']
                                                  })
 
     assert_includes results, item1
     assert_includes results, item2
 
     assert_includes results.criteria[:fq],
-                    'all_subjects_sim:("Fancy things" "Practical things") AND all_contributors_sim:("Joe Blow")'
+                    'all_subjects_sim:("Fancy things" OR "Practical things") AND all_contributors_sim:("Joe Blow")'
     Flipper.disable(:or_facets)
   end
 

--- a/test/models/search_test.rb
+++ b/test/models/search_test.rb
@@ -1,0 +1,24 @@
+require 'test_helper'
+
+class SearchTest < ActiveSupport::TestCase
+
+  test 'default behaviour within a facet is OR and between facets is AND' do
+    item1 = items(:fancy)
+    item2 = items(:practical)
+
+    [item1, item2].each(&:update_solr)
+    results = JupiterCore::Search.faceted_search(models: [Item],
+                                                 facets: {
+                                                   'all_subjects_sim': ['Fancy things',
+                                                                        'Practical things'],
+                                                   'all_contributors_sim': ['Joe Blow']
+                                                 })
+
+    assert_includes results, item1
+    assert_includes results, item2
+
+    assert_includes results.criteria[:fq],
+                    'all_subjects_sim:("Fancy things" "Practical things") AND all_contributors_sim:("Joe Blow")'
+  end
+
+end

--- a/test/models/search_test.rb
+++ b/test/models/search_test.rb
@@ -3,6 +3,7 @@ require 'test_helper'
 class SearchTest < ActiveSupport::TestCase
 
   test 'default behaviour within a facet is OR and between facets is AND' do
+    Flipper.enable(:or_facets)
     item1 = items(:fancy)
     item2 = items(:practical)
 
@@ -19,6 +20,7 @@ class SearchTest < ActiveSupport::TestCase
 
     assert_includes results.criteria[:fq],
                     'all_subjects_sim:("Fancy things" "Practical things") AND all_contributors_sim:("Joe Blow")'
+    Flipper.disable(:or_facets)
   end
 
 end


### PR DESCRIPTION
## Context

As a user, I would like to be able to select multiple options in the author facet category, and
I would like the search logic to be "OR", so I can select same author with the variation (Jane Doe or J. Doe or Jane M. Doe etc)

Related to #1990

## What's New

The default behaviour within a facet is to 'OR'