### PR TITLE
Don't send failures to SessionController in development environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and releases in Jupiter project adheres to [Semantic Versioning](http://semver.o
 – Turn off reporting things like "this excel spreadsheet isn't thumbnailable" as warnings to Rollbar [PR#2046](https://github.com/ualbertalib/jupiter/pull/2046)
 - migration to fix concatenated subjects (part 2) [#1449](https://github.com/ualbertalib/jupiter/issues/1449)
 - Catch and log embargo expiry job save errors [#1989](https://github.com/ualbertalib/jupiter/issues/1989)
+- Don't send failures to SessionController in development environment [omniauth#1030](https://github.com/omniauth/omniauth/issues/1030) 
 
 ### Fixed
 - bump rubocop and fix cop violations [PR#2072](https://github.com/ualbertalib/jupiter/pull/2072)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and releases in Jupiter project adheres to [Semantic Versioning](http://semver.o
 – Turn off reporting things like "this excel spreadsheet isn't thumbnailable" as warnings to Rollbar [PR#2046](https://github.com/ualbertalib/jupiter/pull/2046)
 - migration to fix concatenated subjects (part 2) [#1449](https://github.com/ualbertalib/jupiter/issues/1449)
 - Catch and log embargo expiry job save errors [#1989](https://github.com/ualbertalib/jupiter/issues/1989)
-- Don't send failures to SessionController in development environment [omniauth#1030](https://github.com/omniauth/omniauth/issues/1030) 
+- Don't send failures to SessionController in development environment [PR#2121](https://github.com/ualbertalib/jupiter/pull/2121) 
 
 ### Fixed
 - bump rubocop and fix cop violations [PR#2072](https://github.com/ualbertalib/jupiter/pull/2072)

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -19,7 +19,7 @@ Rails.application.config.middleware.use OmniAuth::Builder do
   # By default in development mode, omniauth raises an exception when authentication fails
   # comment this line if you want to see the stacktrace from the actual provider when in `development`
   # Uncomment the line below to turn this behavior off
-  on_failure { |env| SessionsController.action(:failure).call(env) }
+  on_failure { |env| SessionsController.action(:failure).call(env) } unless Rails.env.development?
 
   OmniAuth.config.allowed_request_methods = [:post]
   OmniAuth.config.logger = Rails.logger


### PR DESCRIPTION
## Context

Since bumping omniauth from 1.9.1 to 2.0.1 in our application all development errors have become failures. For example I purposefully introduce an error to a view. It is caught by omniauth and calls fail which means that we can no longer use better_errors to debug.

![image](https://user-images.githubusercontent.com/1220762/105909195-7977ab00-5fe4-11eb-8d82-3d9182ac4337.png)

Opened a ticket with omniauth to see if they have any suggestions.

Related to .https://github.com/omniauth/omniauth/issues/1030

## What's New

Don't send failures to SessionController in development environment.