### PR TITLE
Revert "Bump ransack from 2.4.1 to 2.4.2"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -339,7 +339,7 @@ GEM
       thor (>= 0.20.3, < 2.0)
     rainbow (3.0.0)
     rake (13.0.1)
-    ransack (2.4.2)
+    ransack (2.4.1)
       activerecord (>= 5.2.4)
       activesupport (>= 5.2.4)
       i18n


### PR DESCRIPTION
Reverts ualbertalib/jupiter#2113

Ransack v2.4.2 drops support for Ruby v2.5.

Production is still running this version so we need to support Ruby 2.5. So reverting this