### PR TITLE
WIP Use markdown to style some of our descriptions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,6 +58,7 @@ gem 'jbuilder' # generate JSON objects
 gem 'kaminari' # Pagination
 gem 'paper_trail' # Track object changes
 gem 'ransack', '= 2.4.1' # ActiveRecord search/filter
+gem 'redcarpet', '~> 3.5', '>= 3.5.1' # Markdown to (X)HTML parser
 gem 'uuidtools'
 gem 'voight_kampff' # bot detection
 gem 'wicked' # Multi-step wizard

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -373,6 +373,7 @@ GEM
       rdf (~> 3.1)
       rexml (~> 3.2)
     rdoc (6.3.0)
+    redcarpet (3.5.1)
     redis (4.1.4)
     regexp_parser (2.0.3)
     request_store (1.5.0)
@@ -569,6 +570,7 @@ DEPENDENCIES
   rdf-isomorphic (~> 3.1.1)
   rdf-n3 (= 3.1.1)
   rdf-vocab (~> 3.1.10)
+  redcarpet (~> 3.5, >= 3.5.1)
   redis (~> 4.1)
   rollbar
   rsolr

--- a/app/helpers/markdown_helper.rb
+++ b/app/helpers/markdown_helper.rb
@@ -1,0 +1,13 @@
+module MarkdownHelper
+  def markdown(text)
+    Jupiter::RenderMarkdown.render(text).html_safe
+  rescue StandardError
+    text.html_safe
+  end
+
+  def strip_markdown(text)
+    Jupiter::StripMarkdown.render(text).html_safe
+  rescue StandardError
+    text.html_safe
+  end
+end

--- a/app/helpers/page_layout_helper.rb
+++ b/app/helpers/page_layout_helper.rb
@@ -37,7 +37,8 @@ module PageLayoutHelper
     if description.present?
       @page_description = description.squish
     elsif @page_description.present?
-      truncate(strip_tags(@page_description), length: 140, separator: ' ', omission: '...', escape: false)
+      truncate(strip_tags(strip_markdown(@page_description)), length: 140, separator: ' ', omission: '...',
+                                                              escape: false)
     else
       @page_description = t('welcome.index.welcome_lead')
     end

--- a/app/models/exporters/solr/collection_exporter.rb
+++ b/app/models/exporters/solr/collection_exporter.rb
@@ -10,9 +10,16 @@ class Exporters::Solr::CollectionExporter < Exporters::Solr::BaseExporter
 
   index :community_id, type: :path, role: :pathing
 
-  index :description, role: [:search]
   index :restricted, type: :boolean, role: :exact_match
   index :creators, role: :exact_match
+
+  # Description may contain markdown which isn't particularly useful in a search context.  Let's strip that out.
+  custom_index :description, role: [:search],
+                             as: lambda { |collection|
+                                   if collection.community_id.present?
+                                     Jupiter::StripMarkdown.render(Community.find(collection.community_id).description)
+                                   end
+                                 }
 
   # TODO: refactor this next line and move the title into Fedora, if we're still on Fedora at that point.
   #

--- a/app/models/exporters/solr/community_exporter.rb
+++ b/app/models/exporters/solr/community_exporter.rb
@@ -8,8 +8,13 @@ class Exporters::Solr::CommunityExporter < Exporters::Solr::BaseExporter
   index :fedora3_uuid, role: :exact_match
   index :depositor, role: [:search]
 
-  index :description, role: [:search]
   index :creators, role: :exact_match
+
+  # Description may contain markdown which isn't particularly useful in a search context. Let's strip this out.
+  custom_index :description, role: [:search],
+                             as: lambda { |community|
+                                   Jupiter::StripMarkdown.render(community.description)
+                                 }
 
   default_sort index: :title, direction: :asc
 

--- a/app/models/exporters/solr/item_exporter.rb
+++ b/app/models/exporters/solr/item_exporter.rb
@@ -35,7 +35,6 @@ class Exporters::Solr::ItemExporter < Exporters::Solr::BaseExporter
   index :temporal_subjects, role: :search
   index :spatial_subjects, role: :search
 
-  index :description, type: :text, role: :search
   index :publisher, role: [:search, :facet]
 
   index :languages, role: [:search, :facet]
@@ -61,6 +60,12 @@ class Exporters::Solr::ItemExporter < Exporters::Solr::BaseExporter
 
   # Combine all the subjects for faceting
   custom_index :all_subjects, role: :facet, as: ->(item) { item.all_subjects }
+
+  # Description may contain markdown which isn't particularly useful in a search context.
+  custom_index :description, type: :text, role: [:search],
+                             as: lambda { |item|
+                                   Jupiter::StripMarkdown.render(item.description)
+                                 }
 
   default_sort index: :title, direction: :asc
 

--- a/app/models/exporters/solr/thesis_exporter.rb
+++ b/app/models/exporters/solr/thesis_exporter.rb
@@ -27,7 +27,6 @@ class Exporters::Solr::ThesisExporter < Exporters::Solr::BaseExporter
   index :subject, role: :search
 
   # Dublin Core attributes
-  index :abstract, type: :text, role: :search
   # NOTE: language is single-valued for Thesis, but languages is multi-valued for Item
   # See below for faceting
   index :language, role: :search
@@ -72,6 +71,11 @@ class Exporters::Solr::ThesisExporter < Exporters::Solr::BaseExporter
   custom_index :doi_without_label, role: :exact_match,
                                    as: ->(thesis) { thesis.doi.gsub('doi:', '') if thesis.doi.present? }
 
+  # Abstract may contain markdown which isn't particularly useful in a search context. Let's strip it out.
+  custom_index :abstract, type: :text, role: [:search],
+                          as: lambda { |thesis|
+                                Jupiter::StripMarkdown.render(thesis.abstract)
+                              }
   default_sort index: :title, direction: :asc
 
   fulltext_searchable :abstract

--- a/app/views/admin/communities/_community.html.erb
+++ b/app/views/admin/communities/_community.html.erb
@@ -5,7 +5,7 @@
       <%= render partial: 'thumbnail', locals: { object: community } %>
       <div class="media-body ml-3">
         <h4 class="mt-0"><%= community.title %></h4>
-        <p class="text-muted"><%= community.description %></p>
+        <p class="text-muted"><%= markdown(community.description) %></p>
       </div>
     <% end %>
 

--- a/app/views/application/_item.html.erb
+++ b/app/views/application/_item.html.erb
@@ -48,7 +48,7 @@
 
     <% if item.description.present? %>
       <p>
-        <%= render(highlights) || jupiter_truncate(item.description) %>
+        <%= render(highlights) || markdown(jupiter_truncate(item.description)) %>
       </p>
     <% end %>
   </div>

--- a/app/views/application/_thesis.html.erb
+++ b/app/views/application/_thesis.html.erb
@@ -49,7 +49,7 @@
 
     <% if thesis.abstract.present? %>
       <p>
-        <%= render(highlights) || jupiter_truncate(thesis.abstract) %>
+        <%= render(highlights) || markdown(jupiter_truncate(thesis.abstract)) %>
       </p>
     <% end %>
   </div>

--- a/app/views/collections/show.html.erb
+++ b/app/views/collections/show.html.erb
@@ -29,7 +29,7 @@
 
   <% if @collection.description.present? %>
     <div class="p-3">
-      <p><%= @collection.description %></p>
+      <p><%= markdown(@collection.description) %></p>
     </div>
   <% end %>
 

--- a/app/views/communities/_community.html.erb
+++ b/app/views/communities/_community.html.erb
@@ -6,7 +6,7 @@
     <%= render partial: 'thumbnail', locals: { object: community } %>
     <div class="media-body ml-3">
       <h3 class="mt-0"><%= community.title %></h3>
-      <p class="text-muted"><%= community.description %></p>
+      <p class="text-muted"><%= markdown(community.description) %></p>
     </div>
   <% end %>
 

--- a/app/views/communities/show.html.erb
+++ b/app/views/communities/show.html.erb
@@ -1,5 +1,5 @@
 <% page_title(@community.title) %>
-<% page_description(@community.description) %>
+<% markdown(page_description(@community.description)) %>
 
 <div class="container mt-3">
   <%= render partial: 'show_breadcrumbs' %>
@@ -31,7 +31,7 @@
   <div class="media p-3">
     <%= render partial: 'thumbnail', locals: { object: @community } %>
     <div class="media-body ml-3">
-      <p><%= @community.description %></p>
+      <p><%= markdown(@community.description) %></p>
     </div>
   </div>
 

--- a/app/views/items/_item.html.erb
+++ b/app/views/items/_item.html.erb
@@ -23,7 +23,7 @@
 
   <% if @item.description.present? %>
     <li class="list-unstyled list-group-item-action">
-      <p title="<%= t('.description') %>"><%= @item.description %></p>
+      <p title="<%= t('.description') %>"><%= markdown(@item.description) %></p>
     </li>
   <% end %>
 

--- a/app/views/items/_thesis.html.erb
+++ b/app/views/items/_thesis.html.erb
@@ -14,7 +14,7 @@
 
   <% if @item.abstract.present? %>
     <li class="list-unstyled list-group-item-action">
-      <p title="<%= t('.abstract') %>"><%= @item.abstract %></p>
+      <p title="<%= t('.abstract') %>"><%= markdown(@item.abstract) %></p>
     </li>
   <% end %>
 

--- a/app/views/items/draft/review_and_deposit_item.html.erb
+++ b/app/views/items/draft/review_and_deposit_item.html.erb
@@ -120,7 +120,7 @@
                 <%= t('items.draft.describe_item.description') %>
               </h6>
               <p class="card-text">
-                <%= @draft.description %>
+                <%= markdown(@draft.description) %>
               </p>
             <% end %>
             <h6 class="card-subtitle mb-1 text-muted">

--- a/app/views/profile/_user_items.html.erb
+++ b/app/views/profile/_user_items.html.erb
@@ -12,7 +12,7 @@
               <p class="text-muted"><%= draft_item.date_created.year %></p>
               <p class="text-muted"><%= draft_item.creators.join(', ') %></p>
               <% if draft_item.description.present? %>
-                <p class="text-muted"><%= jupiter_truncate draft_item.description %></p>
+                <p class="text-muted"><%= jupiter_truncate markdown(draft_item.description) %></p>
               <% end %>
             </div>
           </div>
@@ -61,7 +61,7 @@
                 <% end %>
               </p>
               <p class="text-muted"><%= draft_thesis.creator %></p>
-              <p class="text-muted"><%= jupiter_truncate draft_thesis.description %></p>
+              <p class="text-muted"><%= jupiter_truncate markdown(draft_thesis.description) %></p>
             </div>
           </div>
 

--- a/config/initializers/markdown.rb
+++ b/config/initializers/markdown.rb
@@ -1,0 +1,24 @@
+require 'redcarpet'
+require 'redcarpet/render_strip'
+
+module Jupiter
+  options = {
+    filter_html: true,
+    no_images: true,
+    no_styles: true,
+    hard_wrap: true,
+    link_attributes: { rel: 'noopener noreferrer', target: '_blank' }
+  }
+
+  extensions = {
+    lax_spacing: true,
+    fenced_code_blocks: true,
+    tables: true,
+    autolink: true
+  }
+
+  StripMarkdown = Redcarpet::Markdown.new(Redcarpet::Render::StripDown)
+
+  renderer = Redcarpet::Render::HTML.new(options)
+  RenderMarkdown = Redcarpet::Markdown.new(renderer, extensions)
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -116,6 +116,8 @@ if Rails.env.development? || Rails.env.uat?
       # Add an occasional verbose description
       description = if i % 10 == 5
                       Faker::Lorem.sentence(word_count: 100, supplemental: false, random_words_to_add: 0).chop
+                    elsif i % 7 == 0
+                      Faker::Markdown.sandwich
                     else
                       Faker::Lorem.sentence(word_count: 20, supplemental: false, random_words_to_add: 0).chop
                     end

--- a/test/helpers/markdown_helper_test.rb
+++ b/test/helpers/markdown_helper_test.rb
@@ -1,0 +1,158 @@
+require 'test_helper'
+
+class MarkdownHelperTest < ActionView::TestCase
+
+  include Webpacker::Helper
+
+  # we are testing by requirement in #1322
+  # - bold/strong text highlighting
+  # - italics
+  # - line breaks
+  # - paragraphs
+  # - links
+  # but some others too that came from Faker::Markdown.sandwich
+  # - headers
+  # - code
+  # - ordered and unordered lists
+  # - tables
+  RAW_MARKDOWN = <<~MARKDOWN.freeze
+    ##### Et
+    **Itaque _est_** ~~incidunt~~. Magnam *repellendus* id. Eos qui **voluptatem**.
+
+    Here's a line for us to start with.
+
+    This line is separated from the one above by two newlines, so it will be a *separate paragraph*.
+
+    This line is also a separate paragraph, but...
+    This line is only separated by a single newline, so it's a separate line in the *same paragraph*.
+
+    [I'm an inline-style link with title](https://www.google.com "Google's Homepage")
+
+    URLs and URLs in angle brackets will automatically get turned into links.
+    http://www.example.com or <http://www.example.com> and sometimes
+    example.com (but not on Github, for example).
+
+    ```ruby
+    Mollitia.
+    ```
+
+    sed | autem | illo
+    ---- | ---- | ----
+    magnam | voluptatibus | sint
+    totam | pariatur | nulla
+
+    1. Dolorum.
+      1. Reiciendis.
+    1. Iusto.
+    1. Saepe.
+
+    * Dolore.
+      * Eos.
+    * Eos.
+    * Facere.
+    * Qui.
+    * Qui.
+  MARKDOWN
+
+  test 'should render markdown as html' do
+    rendered_html = <<~RENDERED
+            <h5>Et</h5>
+      #{'            '}
+            <p><strong>Itaque <em>est</em></strong> <del>incidunt</del>. Magnam <em>repellendus</em> id. Eos qui <strong>voluptatem</strong>.</p>
+      #{'      '}
+            <p>Here&#39;s a line for us to start with.</p>
+      #{'      '}
+            <p>This line is separated from the one above by two newlines, so it will be a <em>separate paragraph</em>.</p>
+      #{'            '}
+            <p>This line is also a separate paragraph, but...<br>
+            This line is only separated by a single newline, so it&#39;s a separate line in the <em>same paragraph</em>.</p>
+      #{'            '}
+            <p><a href=\"https://www.google.com\" title=\"Google&#39;s Homepage\" rel=\"noopener noreferrer\" target=\"_blank\">I&#39;m an inline-style link with title</a></p>
+      #{'            '}
+            <p>URLs and URLs in angle brackets will automatically get turned into links. <br>
+            <a href=\"http://www.example.com\" rel=\"noopener noreferrer\" target=\"_blank\">http://www.example.com</a> or <a href=\"http://www.example.com\" rel=\"noopener noreferrer\" target=\"_blank\">http://www.example.com</a> and sometimes <br>
+            example.com (but not on Github, for example).</p>
+      #{'            '}
+            <pre><code class=\"ruby\">Mollitia.
+            </code></pre>
+      #{'      '}
+            <table><thead>
+            <tr>
+            <th>sed</th>
+            <th>autem</th>
+            <th>illo</th>
+            </tr>
+            </thead><tbody>
+            <tr>
+            <td>magnam</td>
+            <td>voluptatibus</td>
+            <td>sint</td>
+            </tr>
+            <tr>
+            <td>totam</td>
+            <td>pariatur</td>
+            <td>nulla</td>
+            </tr>
+            </tbody></table>
+      #{'      '}
+            <ol>
+            <li>Dolorum.
+      #{'      '}
+            <ol>
+            <li>Reiciendis.</li>
+            </ol></li>
+            <li>Iusto.</li>
+            <li>Saepe. </li>
+            </ol>
+      #{'      '}
+            <ul>
+            <li>Dolore.
+      #{'            '}
+            <ul>
+            <li>Eos.</li>
+            </ul></li>
+            <li>Eos.</li>
+            <li>Facere.</li>
+            <li>Qui.</li>
+            <li>Qui. </li>
+            </ul>
+    RENDERED
+
+    assert_equal rendered_html, markdown(RAW_MARKDOWN)
+  end
+
+  test 'should strip markdown from text' do
+    stripped_text = <<~STRIPPED
+            Et
+            Itaque est ~~incidunt~~. Magnam repellendus id. Eos qui voluptatem.
+            Here's a line for us to start with.
+            This line is separated from the one above by two newlines, so it will be a separate paragraph.
+            This line is also a separate paragraph, but...
+            This line is only separated by a single newline, so it's a separate line in the same paragraph.
+            I'm an inline-style link with title (https://www.google.com)
+            URLs and URLs in angle brackets will automatically get turned into links.
+            http://www.example.com or http://www.example.com and sometimes
+            example.com (but not on Github, for example).
+            ruby
+            Mollitia.
+      #{'      '}
+            sed | autem | illo
+            ---- | ---- | ----
+            magnam | voluptatibus | sint
+            totam | pariatur | nulla
+            Dolorum.
+            Reiciendis.
+            Iusto.
+            Saepe.
+            Dolore.
+            Eos.
+            Eos.
+            Facere.
+            Qui.
+            Qui.
+    STRIPPED
+
+    assert_equal stripped_text, strip_markdown(RAW_MARKDOWN)
+  end
+
+end


### PR DESCRIPTION
## Context

Many "description" or "abstract" fields (at the Item level as well as Communities and Collections) contain HTML tags. Because these are text fields, HTML is not rendered in the UI and text looks garbled and it's way less readable than ideal.

Markdown should work really well for this since that's already used in many of the tools staff working in repositories are familiar with.

Related to #1322

## What's New

- Added the redcarpet gem because it basically does what we want with markdown.  
- add `markdown` and `strip_markdown` helpers
- updated views to use the new `markdown` helper on description and abstract fields
- updated SolrExporters to use the new `strip_markdown` helper to remove content being indexed
