### PR TITLE
Corrected missing pluralization in Digitization::Book attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ Further discussion of the context can be found at [#2119](https://github.com/ual
 - bump rdf-n3 and fix isomorphic_with? regression [PR#2070](https://github.com/ualbertalib/jupiter/pull/2070)
 - bump rubocop and fix more cop violations [PR#2132](https://github.com/ualbertalib/jupiter/pull/2132)
 - Fix error when parsing n3 files which include objects with elements as values.
+- Corrected missing pluralization in Digitization::Book attributes
 
 ## [2.0.2] - 2020-12-17
 - Enable Skylight in the Staging environment and remove it from the UAT environment (where it was unused, and the performance of the Docker environment is less likely to be similar to Production)

--- a/app/models/digitization/book.rb
+++ b/app/models/digitization/book.rb
@@ -3,17 +3,17 @@ class Digitization::Book < ApplicationRecord
   validates :peel_id, uniqueness: { scope: [:run, :part_number] }, presence: true, if: :part_number?
   validates :part_number, presence: true, if: :run?
 
-  validates :temporal_subject, presence: true, unless: :geographic_subject? || :topical_subject?
-  validates :geographic_subject, presence: true, unless: :temporal_subject? || :topical_subject?
-  validates :topical_subject, presence: true, unless: :temporal_subject? || :geographic_subject?
+  validates :temporal_subjects, presence: true, unless: :geographic_subjects? || :topical_subjects?
+  validates :geographic_subjects, presence: true, unless: :temporal_subjects? || :topical_subjects?
+  validates :topical_subjects, presence: true, unless: :temporal_subjects? || :geographic_subjects?
 
   validates :title, presence: true
   validates :resource_type, presence: true, uri: { namespace: :digitization, in_vocabulary: :resource_type }
-  validates :genre, presence: true, uri: { namespace: :digitization, in_vocabulary: :genre }
-  validates :language, presence: true, uri: { namespace: :digitization, in_vocabulary: :language }
+  validates :genres, presence: true, uri: { namespace: :digitization, in_vocabulary: :genre }
+  validates :languages, presence: true, uri: { namespace: :digitization, in_vocabulary: :language }
   validates :rights, presence: true, uri: { namespace: :digitization, in_vocabulary: :rights }
 
-  validates :date_issued, edtf: true
-  validates :temporal_subject, edtf: true
+  validates :dates_issued, edtf: true
+  validates :temporal_subjects, edtf: true
 
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -164,9 +164,9 @@ en:
             attributes:
               resource_type:
                 not_recognized: 'is not recognized'
-              genre:
+              genres:
                 not_recognized: 'is not recognized'
-              language:
+              languages:
                 not_recognized: 'is not recognized'
               rights:
                 not_recognized: 'is not recognized'

--- a/db/migrate/20210422161911_rename_columns_in_digitization_book.rb
+++ b/db/migrate/20210422161911_rename_columns_in_digitization_book.rb
@@ -12,5 +12,24 @@ class RenameColumnsInDigitizationBook < ActiveRecord::Migration[6.0]
       t.rename :geographic_subject, :geographic_subjects
       t.rename :topical_subject, :topical_subjects
     end
+
+    remove_rdf_table_annotations :digitization_books
+
+    add_rdf_table_annotations for_table: :digitization_books do |t|
+      t.dates_issued has_predicate: ::RDF::Vocab::DC.issued
+      t.temporal_subjects has_predicate: ::RDF::Vocab::SCHEMA.temporalCoverage
+      t.title has_predicate: ::RDF::Vocab::DC.title
+      t.alternative_title has_predicate: ::RDF::Vocab::DC.alternative
+      t.resource_type has_predicate: ::RDF::Vocab::DC.type
+      t.genres has_predicate: ::RDF::Vocab::EDM.hasType
+      t.languages has_predicate: ::RDF::Vocab::DC.language
+      t.publishers has_predicate: ::RDF::Vocab::MARCRelators.pbl
+      t.places_of_publication has_predicate: ::RDF::Vocab::MARCRelators.pup
+      t.extent has_predicate: ::TERMS[:rdau].extent
+      t.notes has_predicate: ::RDF::Vocab::SKOS.note
+      t.geographic_subjects has_predicate: ::RDF::Vocab::DC11.coverage
+      t.rights has_predicate: ::RDF::Vocab::DC11.rights
+      t.topical_subjects has_predicate: ::RDF::Vocab::DC11.subject
+    end
   end
 end

--- a/db/migrate/20210422161911_rename_columns_in_digitization_book.rb
+++ b/db/migrate/20210422161911_rename_columns_in_digitization_book.rb
@@ -1,0 +1,16 @@
+class RenameColumnsInDigitizationBook < ActiveRecord::Migration[6.0]
+  def change
+    change_table :digitization_books do |t|
+      t.rename :alt_title, :alternative_titles
+      t.rename :language, :languages
+      t.rename :date_issued, :dates_issued
+      t.rename :temporal_subject, :temporal_subjects
+      t.rename :genre, :genres
+      t.rename :publisher, :publishers
+      t.rename :place_of_publication, :places_of_publication
+      t.rename :note, :notes
+      t.rename :geographic_subject, :geographic_subjects
+      t.rename :topical_subject, :topical_subjects
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_04_210653) do
+ActiveRecord::Schema.define(version: 2021_04_22_161911) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -95,20 +95,20 @@ ActiveRecord::Schema.define(version: 2020_12_04_210653) do
     t.integer "part_number"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.string "date_issued", array: true
-    t.string "temporal_subject", array: true
+    t.string "dates_issued", array: true
+    t.string "temporal_subjects", array: true
     t.string "title", null: false
-    t.text "alt_title", array: true
+    t.text "alternative_titles", array: true
     t.string "resource_type", null: false
-    t.string "genre", null: false, array: true
-    t.string "language", null: false, array: true
-    t.string "publisher", array: true
-    t.string "place_of_publication", array: true
+    t.string "genres", null: false, array: true
+    t.string "languages", null: false, array: true
+    t.string "publishers", array: true
+    t.string "places_of_publication", array: true
     t.string "extent"
-    t.text "note", array: true
-    t.string "geographic_subject", array: true
+    t.text "notes", array: true
+    t.string "geographic_subjects", array: true
     t.string "rights"
-    t.string "topical_subject", array: true
+    t.string "topical_subjects", array: true
     t.index ["peel_id", "run", "part_number"], name: "unique_peel_book", unique: true
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -699,19 +699,19 @@ if Rails.env.development? || Rails.env.uat?
 
   11.times do |_i|
     Digitization::Book.create(peel_id: rand(1..3400), part_number: rand(1..100),
-                              date_issued: [rand(1900..2020).to_s],
+                              dates_issued: [rand(1900..2020).to_s],
                               title: "#{Faker::Company.name} #{Faker::WorldCup.city} Music Festival",
-                              alt_title: [Faker::Hipster.sentence.to_s],
+                              alternative_titles: [Faker::Hipster.sentence.to_s],
                               resource_type: ControlledVocabulary.digitization.resource_type.from_value('Text'),
-                              genre: [ControlledVocabulary.digitization.genre.from_value('Programs (Publications)')],
-                              language: [ControlledVocabulary.digitization.language.from_value('English')],
-                              publisher: [ControlledVocabulary.digitization.subject.from_value('Edmonton Folk Music Festival')],
-                              place_of_publication: [ControlledVocabulary.digitization.location.from_value('Edmonton (Alta.)')],
+                              genres: [ControlledVocabulary.digitization.genre.from_value('Programs (Publications)')],
+                              languages: [ControlledVocabulary.digitization.language.from_value('English')],
+                              publishers: [ControlledVocabulary.digitization.subject.from_value('Edmonton Folk Music Festival')],
+                              places_of_publication: [ControlledVocabulary.digitization.location.from_value('Edmonton (Alta.)')],
                               extent: 'v. : ill. ; 22-27 cm.',
-                              note: ['Souvenir program of the festival, including biographical notes on and portraits and discographies of the performers, articles, etc.', Faker::Hipster.sentence.to_s],
-                              temporal_subject: ['1981'],
-                              geographic_subject: [ControlledVocabulary.digitization.location.from_value('Edmonton (Alta.)')],
-                              topical_subject: [ControlledVocabulary.digitization.subject.from_value('Folk music festivals')],
+                              notes: ['Souvenir program of the festival, including biographical notes on and portraits and discographies of the performers, articles, etc.', Faker::Hipster.sentence.to_s],
+                              temporal_subjects: ['1981'],
+                              geographic_subjects: [ControlledVocabulary.digitization.location.from_value('Edmonton (Alta.)')],
+                              topical_subjects: [ControlledVocabulary.digitization.subject.from_value('Folk music festivals')],
                               rights: ControlledVocabulary.digitization.rights.from_value('In Copyright')) # Folk Fest
   end
 

--- a/test/fixtures/digitization/books.yml
+++ b/test/fixtures/digitization/books.yml
@@ -1,54 +1,54 @@
 # Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
-# TODO: resource_type, genre, language and a subject are required. These are placeholders.
+# TODO: resource_type, genres, languages and a subject are required. These are placeholders.
 peel_monograph:
   peel_id: 4062
   title: 'Report on a rural survey of the agricultural, educational, social, and religious life'
   resource_type: <%= ControlledVocabulary.digitization.resource_type.from_value("Text") %>
-  genre: <%= [ControlledVocabulary.digitization.genre.from_value("Programs (Publications)")] %>
-  language: <%= [ControlledVocabulary.digitization.language.from_value("English")] %>
-  temporal_subject: ['1914']
+  genres: <%= [ControlledVocabulary.digitization.genre.from_value("Programs (Publications)")] %>
+  languages: <%= [ControlledVocabulary.digitization.language.from_value("English")] %>
+  temporal_subjects: ['1914']
 
-# TODO: resource_type, genre, language, and a subject are required. These are placeholders.
+# TODO: resource_type, genres, languages, and a subject are required. These are placeholders.
 henderson:
   peel_id: 3178
   run: 1
   part_number: 1
   title: "Henderson's Moose Jaw city directory for 1908"
   resource_type: <%= ControlledVocabulary.digitization.resource_type.from_value("Text") %>
-  genre: <%= [ControlledVocabulary.digitization.genre.from_value("Programs (Publications)")] %>
-  language: <%= [ControlledVocabulary.digitization.language.from_value("English")] %>
-  temporal_subject: ['1908']
+  genres: <%= [ControlledVocabulary.digitization.genre.from_value("Programs (Publications)")] %>
+  languages: <%= [ControlledVocabulary.digitization.language.from_value("English")] %>
+  temporal_subjects: ['1908']
   rights: <%= ControlledVocabulary.digitization.rights.from_value("In Copyright") %>
 
 folk_fest:
   peel_id: 10572
   part_number: 1
   title: 'Edmonton Folk Music Festival'
-  alt_title: ['Annual Edmonton Folk Music Festival', 'Edmonton Folk Music Festival program book', 'Edmonton Folkfest', 'Edmonton Folk Fest', 'Edmonton Folk Festival']
-  date_issued: ['1980']
-  temporal_subject: ['1980']
+  alternative_titles: ['Annual Edmonton Folk Music Festival', 'Edmonton Folk Music Festival program book', 'Edmonton Folkfest', 'Edmonton Folk Fest', 'Edmonton Folk Festival']
+  dates_issued: ['1980']
+  temporal_subjects: ['1980']
   resource_type: <%= ControlledVocabulary.digitization.resource_type.from_value("Text") %>
-  genre: <%= [ControlledVocabulary.digitization.genre.from_value("Programs (Publications)")] %>
-  language: <%= [ControlledVocabulary.digitization.language.from_value("English")] %>
-  publisher: <%= [ControlledVocabulary.digitization.subject.from_value("Edmonton Folk Music Festival")] %>
-  place_of_publication: <%= [ControlledVocabulary.digitization.location.from_value("Edmonton (Alta.)")] %>
+  genres: <%= [ControlledVocabulary.digitization.genre.from_value("Programs (Publications)")] %>
+  languages: <%= [ControlledVocabulary.digitization.language.from_value("English")] %>
+  publishers: <%= [ControlledVocabulary.digitization.subject.from_value("Edmonton Folk Music Festival")] %>
+  places_of_publication: <%= [ControlledVocabulary.digitization.location.from_value("Edmonton (Alta.)")] %>
   extent: 'v. : ill. ; 22-27 cm.'
-  note: ['Statement of responsibility: [Holger Petersen, editor ; contributors, Silvio Dobri ... [et al.].',
-  'Souvenir program of the festival, including biographical notes on and portraits and discographies of the performers, articles, etc.',
+  notes: ['Statement of responsibility: [Holger Petersen, editor ; contributors, Silvio Dobri ... [et al.].',
+  'Souvenir program of the festival, including biographical notess on and portraits and discographies of the performers, articles, etc.',
   'Thank you to Randy Reichardt and to the Edmonton Folk Music Festival for their generous contributions of print volumes of this title for digitization.'
   ]
-  geographic_subject: <%= [ControlledVocabulary.digitization.subject.from_value("Edmonton (Alta.)")] %>
+  geographic_subjects: <%= [ControlledVocabulary.digitization.subject.from_value("Edmonton (Alta.)")] %>
   rights: <%= ControlledVocabulary.digitization.rights.from_value("In Copyright") %>
-  topical_subject: <%= [ControlledVocabulary.digitization.subject.from_value("Edmonton Folk Music Festival"), ControlledVocabulary.digitization.subject.from_value("Folk music festivals")] %>
+  topical_subjects: <%= [ControlledVocabulary.digitization.subject.from_value("Edmonton Folk Music Festival"), ControlledVocabulary.digitization.subject.from_value("Folk music festivals")] %>
 
-# TODO: resource_type, genre, language, and a subject are required. These are placeholders.
+# TODO: resource_type, genres, languages, and a subject are required. These are placeholders.
 government_document:
   peel_id: 10571
   part_number: 2
   title: 'The patrician'
   resource_type: <%= ControlledVocabulary.digitization.resource_type.from_value("Text") %>
-  genre: <%= [ControlledVocabulary.digitization.genre.from_value("Programs (Publications)")] %>
-  language: <%= [ControlledVocabulary.digitization.language.from_value("English")] %>
-  temporal_subject: ['1914']
+  genres: <%= [ControlledVocabulary.digitization.genre.from_value("Programs (Publications)")] %>
+  languages: <%= [ControlledVocabulary.digitization.language.from_value("English")] %>
+  temporal_subjects: ['1914']
 

--- a/test/models/digitization/book_test.rb
+++ b/test/models/digitization/book_test.rb
@@ -35,11 +35,11 @@ class Digitization::BookTest < ActiveSupport::TestCase
   end
 
   test 'should have at least one type of subject' do
-    @document.assign_attributes(temporal_subject: nil, geographic_subject: nil, topical_subject: nil)
+    @document.assign_attributes(temporal_subjects: nil, geographic_subjects: nil, topical_subjects: nil)
     assert_not @document.valid?
-    assert_equal("can't be blank", @document.errors[:temporal_subject].first)
-    assert_equal("can't be blank", @document.errors[:geographic_subject].first)
-    assert_equal("can't be blank", @document.errors[:topical_subject].first)
+    assert_equal("can't be blank", @document.errors[:temporal_subjects].first)
+    assert_equal("can't be blank", @document.errors[:geographic_subjects].first)
+    assert_equal("can't be blank", @document.errors[:topical_subjects].first)
   end
 
   test 'should have a title' do
@@ -54,16 +54,16 @@ class Digitization::BookTest < ActiveSupport::TestCase
     assert_includes @document.errors[:resource_type], 'is not recognized'
   end
 
-  test 'unknown genres are not valid' do
-    @document.assign_attributes(genre: ['some_fake_genre'])
+  test 'unknown genresss are not valid' do
+    @document.assign_attributes(genres: ['some_fake_genres'])
     assert_not @document.valid?
-    assert_includes @document.errors[:genre], 'is not recognized'
+    assert_includes @document.errors[:genres], 'is not recognized'
   end
 
   test 'unknown languages are not valid' do
-    @document.assign_attributes(language: ['some_fake_language'])
+    @document.assign_attributes(languages: ['some_fake_language'])
     assert_not @document.valid?
-    assert_includes @document.errors[:language], 'is not recognized'
+    assert_includes @document.errors[:languages], 'is not recognized'
   end
 
   test 'unknown rights are not valid' do
@@ -73,11 +73,11 @@ class Digitization::BookTest < ActiveSupport::TestCase
   end
 
   test 'dates must conform to EDTF format' do
-    @document.assign_attributes(date_issued: ['INVALID DATE'], temporal_subject: ['INVALID DATE'])
+    @document.assign_attributes(dates_issued: ['INVALID DATE'], temporal_subjects: ['INVALID DATE'])
     assert_not @document.valid?
     assert_equal('does not conform to the Extended Date/Time Format standard',
-                 @document.errors[:temporal_subject].first)
-    assert_equal('does not conform to the Extended Date/Time Format standard', @document.errors[:date_issued].first)
+                 @document.errors[:temporal_subjects].first)
+    assert_equal('does not conform to the Extended Date/Time Format standard', @document.errors[:dates_issued].first)
   end
 
 end


### PR DESCRIPTION
## Context

When I was creating the show views for the Digitization::Book model I found that I was reasoning about arrays but referring to them in the singular.  This meant there wasn't an appropriate name for the singular values from the array.  This PR intends to correct the poor choices I made when originally naming these values.

https://github.com/ualbertalib/jupiter/blob/0bfbb0d9334465630dcdd1cf318b2435db1ba66f/db/schema.rb#L92-L113

Related to #2080 

## What's New
Renamed the attributes in the Digitization::Book model and corrected their use elsewhere in the code as well.

