### PR TITLE
Add missing volume label to Digitization::Book

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Further discussion of the context can be found at [#2119](https://github.com/ual
 - Namespaces for the Controlled Vocabularies [#2118](https://github.com/ualbertalib/jupiter/issues/2118)
 - Labels for active facet badges [#1261](https://github.com/ualbertalib/jupiter/issues/1261)
 - book metadata for folk fest digitization [#2010](https://github.com/ualbertalib/jupiter/issues/2010)
+- Volume and Issue label attribute to Digitization::Book
 
 ### Removed
 – Remove entirely unnecessary config file. [PR#2044](https://github.com/ualbertalib/jupiter/pull/2044)

--- a/config/terms.yml
+++ b/config/terms.yml
@@ -65,6 +65,12 @@
   terms:
     extent: P60550
 
+# RDF::RDFS.label is version 1.0 while we want 1.1
+- vocabulary: rdfs
+  schema: 'https://www.w3.org/TR/rdf-schema/#'
+  terms:
+    ch_label: ch_label
+
 - vocabulary: swrc
   schema: 'http://ontoware.org/swrc/ontology#'
   terms:
@@ -76,7 +82,7 @@
   schema: 'http://projecthydra.org/ns/fits/'
   terms:
     palceholder: palceholder
-    
+
 - vocabulary: odf
   schema: 'http://projecthydra.org/ns/odf/'
   terms:

--- a/db/migrate/20210422200517_add_volume_label_to_digitization_book.rb
+++ b/db/migrate/20210422200517_add_volume_label_to_digitization_book.rb
@@ -1,0 +1,6 @@
+class AddVolumeLabelToDigitizationBook < ActiveRecord::Migration[6.0]
+  def change
+    add_column :digitization_books, :volume_label, :string
+    add_rdf_column_annotation :digitization_books, :volume_label, has_predicate: ::TERMS[:rdfs].ch_label
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_22_161911) do
+ActiveRecord::Schema.define(version: 2021_04_22_200517) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -109,6 +109,7 @@ ActiveRecord::Schema.define(version: 2021_04_22_161911) do
     t.string "geographic_subjects", array: true
     t.string "rights"
     t.string "topical_subjects", array: true
+    t.string "volume_label"
     t.index ["peel_id", "run", "part_number"], name: "unique_peel_book", unique: true
   end
 


### PR DESCRIPTION
## Context

Noticed this in the wireframe and circled back to the triples and discovered that I missed it the first time around.

Related to #2080 

![image](https://user-images.githubusercontent.com/1220762/115779553-5d7e6e00-a375-11eb-8c16-262093649dbb.png)
![image](https://user-images.githubusercontent.com/1220762/115779652-7b4bd300-a375-11eb-89c8-9c6f98248947.png)

## What's New

Added an attribute that represents the Volume & Issue label (i.e. 'vol 2')