### PR TITLE
Update CI to test 2.6 & 2.7 now that 2.5 is no longer in Prod

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -7,7 +7,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby: [2.5, 2.7]
+        ruby: [2.6, 2.7]
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
## Context

Just like it says on the tin. 2.5 is EOL and no longer used on the Production servers, which have been upgraded to Ruby 2.6.6. The tests should likewise be upgraded to test current Prod and the next version of Ruby.

## What's New

Replace Ruby 2.5 with 2.6 in the test version matrix.