### PR TITLE
Lock ezid-client < 1.9

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,7 +51,7 @@ gem 'addressable', '~> 2.7.0' # Replacement for the standard URI implementation
 gem 'differ' # Used to diff two strings
 gem 'draper'
 gem 'edtf', '~> 3.0', '>= 3.0.6' # parsing Extended Date/Time Format
-gem 'ezid-client', '~> 1.8.0'
+gem 'ezid-client', '< 1.9.0'
 gem 'flipper', '~> 0.20.4' # Feature flags for Ruby
 gem 'flipper-active_record', '~> 0.20.4' # Store feature flags in ActiveRecord
 gem 'flipper-ui', '~> 0.20.4' # UI for feature flags

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -542,7 +542,7 @@ DEPENDENCIES
   draper
   edtf (~> 3.0, >= 3.0.6)
   erb_lint (>= 0.0.35)
-  ezid-client (~> 1.8.0)
+  ezid-client (< 1.9.0)
   faker
   flipper (~> 0.20.4)
   flipper-active_record (~> 0.20.4)


### PR DESCRIPTION
## Context

ezid-client 1.9 changed the way requests execute:

https://github.com/duke-libraries/ezid-client/blob/24cc925c7d9a34e3baad636693859e83df7e0081/lib/ezid/requests/request.rb#L49-L64

```ruby
   # Executes the request and returns the response
    # @return [Ezid::Response] the response
    def execute
      retries = 0
      begin
        response_class.new(get_response_for_request)
      rescue Net::HTTPServerException, UnexpectedResponseError => e
        if retries < 2
          sleep 15
          retries += 1
          retry
        else
          raise
        end
      end
    end
```

I can't see any good reason for confusing request and retry logic inside the library in this way. Either you were making requests synchronously, in which case now your web requests lock up for 30 seconds unexpectedly because of a library's minor version bump any time a third party API goes down (which presumably you were handling more gracefully before?), or you were backgrounding the DOI requests (like we do) and now your Jobs, which already have sane, well-thought-out exponential retry and backoff logic when they fail, start locking up for 30 seconds before going into Sidekiq's retry queue for no good reason when you were already handling this in a better way at the work queue level. Neither is an improvement over the status quo in 1.8, which is going to have knock-on effects on other jobs in the queue.

Additionally, the Datacite Ezid Compatibility API is shutting down in December, so I anticipate that we won't be using this gem for much longer anyways; there's no reason to make our DOI requests strictly worse in the meantime.

## What's New

Lock ezid-client to versions < 1.9, when this behaviour was introduced.