### PR TITLE
Move `doi_url` to Doiable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ Further discussion of the context can be found at [#2119](https://github.com/ual
 - Catch and log embargo expiry job save errors [#1989](https://github.com/ualbertalib/jupiter/issues/1989)
 - Don't send failures to SessionController in development environment [PR#2121](https://github.com/ualbertalib/jupiter/pull/2121)
 – Rails upgraded to 6.0.3.6 to resolve certain issues with community dependencies
+- Move `doi_url` to Doiable class
 
 ### Fixed
 - bump rubocop and fix cop violations [PR#2072](https://github.com/ualbertalib/jupiter/pull/2072)

--- a/app/models/jupiter_core/depositable.rb
+++ b/app/models/jupiter_core/depositable.rb
@@ -76,10 +76,6 @@ class JupiterCore::Depositable < ApplicationRecord
     visibility == JupiterCore::VISIBILITY_AUTHENTICATED
   end
 
-  def doi_url
-    "https://doi.org/#{doi.delete_prefix('doi:')}"
-  end
-
   def each_community_collection
     member_of_paths.each do |path|
       community_id, collection_id = path.split('/')

--- a/app/models/jupiter_core/doiable.rb
+++ b/app/models/jupiter_core/doiable.rb
@@ -38,6 +38,10 @@ class JupiterCore::Doiable < JupiterCore::Depositable
     end
   end
 
+  def doi_url
+    "https://doi.org/#{doi.delete_prefix('doi:')}"
+  end
+
   def handle_doi_states
     # this should be disabled during migration runs and enabled for production
     return unless Rails.application.secrets.doi_minting_enabled


### PR DESCRIPTION
## Context

I want to make Digitization::Book Depositable but we won't be minting DOIs for those items.  Makes more sense for this method to live in the other class.

Related to #2080 

## What's New

Move `doi_url` to `Doiable` class.