### PR TITLE
Make `Digitization` objects `Depositable` 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ Further discussion of the context can be found at [#2119](https://github.com/ual
 - Moved `visibility` vocabulary into a `jupiter_core` namespace
 - Move `doi_url` to `Doiable` class
 - Make `Digitization::Book` `Depositable`
+- Make `Digitization::Newspaper` `Depositable`
 
 ### Fixed
 - bump rubocop and fix cop violations [PR#2072](https://github.com/ualbertalib/jupiter/pull/2072)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ Further discussion of the context can be found at [#2119](https://github.com/ual
 - Move `doi_url` to `Doiable` class
 - Make `Digitization::Book` `Depositable`
 - Make `Digitization::Newspaper` `Depositable`
+- Make `Digitization::Image` `Depositable`
 
 ### Fixed
 - bump rubocop and fix cop violations [PR#2072](https://github.com/ualbertalib/jupiter/pull/2072)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ Further discussion of the context can be found at [#2119](https://github.com/ual
 - Make `Digitization::Book` `Depositable`
 - Make `Digitization::Newspaper` `Depositable`
 - Make `Digitization::Image` `Depositable`
+- Make `Digitization::Map` `Depositable`
 
 ### Fixed
 - bump rubocop and fix cop violations [PR#2072](https://github.com/ualbertalib/jupiter/pull/2072)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ Further discussion of the context can be found at [#2119](https://github.com/ual
 – Rails upgraded to 6.0.3.6 to resolve certain issues with community dependencies
 - Moved `visibility` vocabulary into a `jupiter_core` namespace
 - Move `doi_url` to `Doiable` class
+- Make `Digitization::Book` `Depositable`
 
 ### Fixed
 - bump rubocop and fix cop violations [PR#2072](https://github.com/ualbertalib/jupiter/pull/2072)

--- a/app/models/digitization/book.rb
+++ b/app/models/digitization/book.rb
@@ -1,4 +1,6 @@
-class Digitization::Book < ApplicationRecord
+class Digitization::Book < JupiterCore::Depositable
+
+  belongs_to :owner, class_name: 'User'
 
   validates :peel_id, uniqueness: { scope: [:run, :part_number] }, presence: true, if: :part_number?
   validates :part_number, presence: true, if: :run?

--- a/app/models/digitization/image.rb
+++ b/app/models/digitization/image.rb
@@ -1,4 +1,6 @@
-class Digitization::Image < ApplicationRecord
+class Digitization::Image < JupiterCore::Depositable
+
+  belongs_to :owner, class_name: 'User'
 
   validates :peel_image_id, uniqueness: true
 

--- a/app/models/digitization/map.rb
+++ b/app/models/digitization/map.rb
@@ -1,4 +1,6 @@
-class Digitization::Map < ApplicationRecord
+class Digitization::Map < JupiterCore::Depositable
+
+  belongs_to :owner, class_name: 'User'
 
   validates :peel_map_id, uniqueness: true
 

--- a/app/models/digitization/newspaper.rb
+++ b/app/models/digitization/newspaper.rb
@@ -1,4 +1,6 @@
-class Digitization::Newspaper < ApplicationRecord
+class Digitization::Newspaper < JupiterCore::Depositable
+
+  belongs_to :owner, class_name: 'User'
 
   validates :publication_code, uniqueness: { scope: [:year, :month, :day] }
   validates :year, :month, :day, presence: true, if: :publication_code?

--- a/db/migrate/20210427173040_add_depositable_columns_to_digitization_book.rb
+++ b/db/migrate/20210427173040_add_depositable_columns_to_digitization_book.rb
@@ -1,0 +1,15 @@
+class AddDepositableColumnsToDigitizationBook < ActiveRecord::Migration[6.0]
+  def change
+    change_table :digitization_books do |t|
+      t.datetime :date_ingested, null: false
+      t.datetime :record_created_at
+      t.string :visibility
+      t.references :owner, null: false, index: true, foreign_key: {to_table: :users, column: :id}
+    end
+
+    add_rdf_table_annotations for_table: :digitization_books do |t|
+      t.date_ingested has_predicate: RDF::Vocab::EBUCore.dateIngested
+      t.record_created_at has_predicate: ::TERMS[:ual].record_created_in_jupiter
+    end
+  end
+end

--- a/db/migrate/20210427201321_add_depositable_columns_to_digitization_newspaper.rb
+++ b/db/migrate/20210427201321_add_depositable_columns_to_digitization_newspaper.rb
@@ -1,0 +1,16 @@
+class AddDepositableColumnsToDigitizationNewspaper < ActiveRecord::Migration[6.0]
+  def change
+    change_table :digitization_newspapers do |t|
+      t.datetime :date_ingested, null: false
+      t.datetime :record_created_at
+      t.string :visibility
+      t.references :owner, null: false, index: true, foreign_key: {to_table: :users, column: :id}
+      t.string :title, null: false
+    end
+
+    add_rdf_table_annotations for_table: :digitization_newspapers do |t|
+      t.date_ingested has_predicate: RDF::Vocab::EBUCore.dateIngested
+      t.record_created_at has_predicate: ::TERMS[:ual].record_created_in_jupiter
+    end
+  end
+end

--- a/db/migrate/20210427212402_add_depositable_columns_to_digitization_image.rb
+++ b/db/migrate/20210427212402_add_depositable_columns_to_digitization_image.rb
@@ -1,0 +1,16 @@
+class AddDepositableColumnsToDigitizationImage < ActiveRecord::Migration[6.0]
+  def change
+    change_table :digitization_images do |t|
+      t.datetime :date_ingested, null: false
+      t.datetime :record_created_at
+      t.string :visibility
+      t.references :owner, null: false, index: true, foreign_key: {to_table: :users, column: :id}
+      t.string :title, null: false
+    end
+
+    add_rdf_table_annotations for_table: :digitization_images do |t|
+      t.date_ingested has_predicate: RDF::Vocab::EBUCore.dateIngested
+      t.record_created_at has_predicate: ::TERMS[:ual].record_created_in_jupiter
+    end
+  end
+end

--- a/db/migrate/20210427214238_add_depositable_columns_to_digitization_map.rb
+++ b/db/migrate/20210427214238_add_depositable_columns_to_digitization_map.rb
@@ -1,0 +1,16 @@
+class AddDepositableColumnsToDigitizationMap < ActiveRecord::Migration[6.0]
+  def change
+    change_table :digitization_maps do |t|
+      t.datetime :date_ingested, null: false
+      t.datetime :record_created_at
+      t.string :visibility
+      t.references :owner, null: false, index: true, foreign_key: {to_table: :users, column: :id}
+      t.string :title, null: false
+    end
+
+    add_rdf_table_annotations for_table: :digitization_maps do |t|
+      t.date_ingested has_predicate: RDF::Vocab::EBUCore.dateIngested
+      t.record_created_at has_predicate: ::TERMS[:ual].record_created_in_jupiter
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_27_201321) do
+ActiveRecord::Schema.define(version: 2021_04_27_212402) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -122,6 +122,12 @@ ActiveRecord::Schema.define(version: 2021_04_27_201321) do
     t.string "peel_image_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.datetime "date_ingested", null: false
+    t.datetime "record_created_at"
+    t.string "visibility"
+    t.bigint "owner_id", null: false
+    t.string "title", null: false
+    t.index ["owner_id"], name: "index_digitization_images_on_owner_id"
     t.index ["peel_image_id"], name: "unique_peel_image", unique: true
   end
 
@@ -413,6 +419,7 @@ ActiveRecord::Schema.define(version: 2021_04_27_201321) do
   add_foreign_key "collections", "users", column: "owner_id"
   add_foreign_key "communities", "users", column: "owner_id"
   add_foreign_key "digitization_books", "users", column: "owner_id"
+  add_foreign_key "digitization_images", "users", column: "owner_id"
   add_foreign_key "digitization_newspapers", "users", column: "owner_id"
   add_foreign_key "draft_items", "users"
   add_foreign_key "draft_theses", "institutions"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_22_200517) do
+ActiveRecord::Schema.define(version: 2021_04_27_173040) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -110,6 +110,11 @@ ActiveRecord::Schema.define(version: 2021_04_22_200517) do
     t.string "rights"
     t.string "topical_subjects", array: true
     t.string "volume_label"
+    t.datetime "date_ingested", null: false
+    t.datetime "record_created_at"
+    t.string "visibility"
+    t.bigint "owner_id", null: false
+    t.index ["owner_id"], name: "index_digitization_books_on_owner_id"
     t.index ["peel_id", "run", "part_number"], name: "unique_peel_book", unique: true
   end
 
@@ -401,6 +406,7 @@ ActiveRecord::Schema.define(version: 2021_04_22_200517) do
   add_foreign_key "announcements", "users"
   add_foreign_key "collections", "users", column: "owner_id"
   add_foreign_key "communities", "users", column: "owner_id"
+  add_foreign_key "digitization_books", "users", column: "owner_id"
   add_foreign_key "draft_items", "users"
   add_foreign_key "draft_theses", "institutions"
   add_foreign_key "draft_theses", "languages"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_27_173040) do
+ActiveRecord::Schema.define(version: 2021_04_27_201321) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -139,6 +139,12 @@ ActiveRecord::Schema.define(version: 2021_04_27_173040) do
     t.string "day"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.datetime "date_ingested", null: false
+    t.datetime "record_created_at"
+    t.string "visibility"
+    t.bigint "owner_id", null: false
+    t.string "title", null: false
+    t.index ["owner_id"], name: "index_digitization_newspapers_on_owner_id"
     t.index ["publication_code", "year", "month", "day"], name: "unique_peel_newspaper", unique: true
   end
 
@@ -407,6 +413,7 @@ ActiveRecord::Schema.define(version: 2021_04_27_173040) do
   add_foreign_key "collections", "users", column: "owner_id"
   add_foreign_key "communities", "users", column: "owner_id"
   add_foreign_key "digitization_books", "users", column: "owner_id"
+  add_foreign_key "digitization_newspapers", "users", column: "owner_id"
   add_foreign_key "draft_items", "users"
   add_foreign_key "draft_theses", "institutions"
   add_foreign_key "draft_theses", "languages"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_27_212402) do
+ActiveRecord::Schema.define(version: 2021_04_27_214238) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -135,6 +135,12 @@ ActiveRecord::Schema.define(version: 2021_04_27_212402) do
     t.string "peel_map_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.datetime "date_ingested", null: false
+    t.datetime "record_created_at"
+    t.string "visibility"
+    t.bigint "owner_id", null: false
+    t.string "title", null: false
+    t.index ["owner_id"], name: "index_digitization_maps_on_owner_id"
     t.index ["peel_map_id"], name: "unique_peel_map", unique: true
   end
 
@@ -420,6 +426,7 @@ ActiveRecord::Schema.define(version: 2021_04_27_212402) do
   add_foreign_key "communities", "users", column: "owner_id"
   add_foreign_key "digitization_books", "users", column: "owner_id"
   add_foreign_key "digitization_images", "users", column: "owner_id"
+  add_foreign_key "digitization_maps", "users", column: "owner_id"
   add_foreign_key "digitization_newspapers", "users", column: "owner_id"
   add_foreign_key "draft_items", "users"
   add_foreign_key "draft_theses", "institutions"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -710,6 +710,7 @@ if Rails.env.development? || Rails.env.uat?
   11.times do |_i|
     Digitization::Book.create(peel_id: rand(1..3400), part_number: rand(1..100),
                               dates_issued: [rand(1900..2020).to_s],
+                              date_ingested: '2016-12-08T06:00:00.000Z',
                               title: "#{Faker::Company.name} #{Faker::WorldCup.city} Music Festival",
                               alternative_titles: [Faker::Hipster.sentence.to_s],
                               resource_type: ControlledVocabulary.digitization.resource_type.from_value('Text'),

--- a/test/fixtures/digitization/books.yml
+++ b/test/fixtures/digitization/books.yml
@@ -8,6 +8,9 @@ peel_monograph:
   genres: <%= [ControlledVocabulary.digitization.genre.from_value("Programs (Publications)")] %>
   languages: <%= [ControlledVocabulary.digitization.language.from_value("English")] %>
   temporal_subjects: ['1914']
+  date_ingested: '2000-01-01T00:00:00.007Z'
+  record_created_at: '2000-01-01T00:00:00.007Z'
+  owner: admin
 
 # TODO: resource_type, genres, languages, and a subject are required. These are placeholders.
 henderson:
@@ -20,6 +23,9 @@ henderson:
   languages: <%= [ControlledVocabulary.digitization.language.from_value("English")] %>
   temporal_subjects: ['1908']
   rights: <%= ControlledVocabulary.digitization.rights.from_value("In Copyright") %>
+  date_ingested: '2000-01-01T00:00:00.007Z'
+  record_created_at: '2000-01-01T00:00:00.007Z'
+  owner: admin
 
 folk_fest:
   peel_id: 10572
@@ -41,6 +47,9 @@ folk_fest:
   geographic_subjects: <%= [ControlledVocabulary.digitization.subject.from_value("Edmonton (Alta.)")] %>
   rights: <%= ControlledVocabulary.digitization.rights.from_value("In Copyright") %>
   topical_subjects: <%= [ControlledVocabulary.digitization.subject.from_value("Edmonton Folk Music Festival"), ControlledVocabulary.digitization.subject.from_value("Folk music festivals")] %>
+  date_ingested: '2000-01-01T00:00:00.007Z'
+  record_created_at: '2000-01-01T00:00:00.007Z'
+  owner: admin
 
 # TODO: resource_type, genres, languages, and a subject are required. These are placeholders.
 government_document:
@@ -51,4 +60,7 @@ government_document:
   genres: <%= [ControlledVocabulary.digitization.genre.from_value("Programs (Publications)")] %>
   languages: <%= [ControlledVocabulary.digitization.language.from_value("English")] %>
   temporal_subjects: ['1914']
+  date_ingested: '2000-01-01T00:00:00.007Z'
+  record_created_at: '2000-01-01T00:00:00.007Z'
+  owner: admin
 

--- a/test/fixtures/digitization/images.yml
+++ b/test/fixtures/digitization/images.yml
@@ -1,7 +1,15 @@
 # Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
 magee:
+  title: 'Man standing on large rock'
   peel_image_id: 'MGNGBG0001'
+  date_ingested: '2000-01-01T00:00:00.007Z'
+  record_created_at: '2000-01-01T00:00:00.007Z'
+  owner: admin
 
 postcard:
+  title: '24 snapshots of Dauphin as seen by the rubbernecks'
   peel_image_id: 'PC015716'
+  date_ingested: '2000-01-01T00:00:00.007Z'
+  record_created_at: '2000-01-01T00:00:00.007Z'
+  owner: admin

--- a/test/fixtures/digitization/maps.yml
+++ b/test/fixtures/digitization/maps.yml
@@ -1,4 +1,8 @@
 # Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
 map:
+  title: 'Map shewing the townships surveyed in the Province of Manitoba and North-West Territory in the Dominion of Canada'
   peel_map_id: 'M000230'
+  date_ingested: '2000-01-01T00:00:00.007Z'
+  record_created_at: '2000-01-01T00:00:00.007Z'
+  owner: admin

--- a/test/fixtures/digitization/newspapers.yml
+++ b/test/fixtures/digitization/newspapers.yml
@@ -2,6 +2,10 @@
 
 la_survivance:
   publication_code: 'LSV'
+  title: 'La Survivance March 29, 1967'
   year: '1967'
   month: '03'
   day: '29'
+  date_ingested: '2000-01-01T00:00:00.007Z'
+  record_created_at: '2000-01-01T00:00:00.007Z'
+  owner: admin


### PR DESCRIPTION
## Context
This is key to Jupiter working as planned.  Digitization objects being `Depositable` will mean that they are searchable, accessible, preservable, auditable etc.

Related to #2080

## What's New
Added `date_ingested`, `record_created_at`, `visibility` attributes and `owner` foreign key to `Book`, `Newspaper`, `Image`, and `Map`. Also updated fixtures with the required values.