### PR TITLE
Use read-only token for Danger

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -35,10 +35,10 @@ jobs:
           bundle config path vendor/bundle
           bundle config set without 'production development'
           bundle install --jobs 4 --retry 3
-      
+
       - name: Run Danger
         env:
-          DANGER_GITHUB_API_TOKEN: ${{ secrets.DANGER_GITHUB_API_TOKEN }}
+          DANGER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: bundle exec danger
 
       - name: Lint with RuboCop

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ Further discussion of the context can be found at [#2119](https://github.com/ual
 - bump rubocop and fix more cop violations [PR#2132](https://github.com/ualbertalib/jupiter/pull/2132)
 - Fix error when parsing n3 files which include objects with elements as values.
 - Corrected missing pluralization in Digitization::Book attributes
+- Danger token in Github Actions [#2282](https://github.com/ualbertalib/jupiter/issues/2282)
 
 ## [2.0.2] - 2020-12-17
 - Enable Skylight in the Staging environment and remove it from the UAT environment (where it was unused, and the performance of the Docker environment is less likely to be similar to Production)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,7 +70,7 @@ Further discussion of the context can be found at [#2119](https://github.com/ual
 - bump rubocop and fix more cop violations [PR#2132](https://github.com/ualbertalib/jupiter/pull/2132)
 - Fix error when parsing n3 files which include objects with elements as values.
 - Corrected missing pluralization in Digitization::Book attributes
-- Danger token in Github Actions [#2282](https://github.com/ualbertalib/jupiter/issues/2282)
+- Danger
 
 ## [2.0.2] - 2020-12-17
 - Enable Skylight in the Staging environment and remove it from the UAT environment (where it was unused, and the performance of the Docker environment is less likely to be similar to Production)


### PR DESCRIPTION
## Context

> Starting March 1st, 2021 workflow runs that are triggered by Dependabot from push, pull_request, pull_request_review, or pull_request_review_comment events will be treated as if they were opened from a repository fork. This means they will receive a read-only GITHUB_TOKEN and will not have access to any secrets available in the repository.

Note that this DOES NOT allow developers the possibility to propose change sets from a fork of the repository. This hasn't been possible since the [policy change in Travis](https://github.com/ualbertalib/jupiter/pull/1600#issuecomment-615385889).

Related to #2082 

## What's New

Changed Danger github action to use the read-only GITHUB_TOKEN