### PR TITLE
Postgres is now on v12 in production, lets update our code/CI to reflect this

### DIFF
--- a/docker-compose.demo.yml
+++ b/docker-compose.demo.yml
@@ -3,11 +3,11 @@
 # To use, you must pass in the `-f` flag to docker-compose
 # For example: docker-compose -f docker-compose.demo.yml up -d
 
-version: '3.4'
+version: "3.4"
 
 services:
   postgres:
-    image: postgres:11-alpine
+    image: postgres:12-alpine
     environment:
       - POSTGRES_PASSWORD=mysecretpassword
     volumes:

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -1,4 +1,4 @@
-version: '3.3'
+version: "3.3"
 
 volumes:
   postgres:
@@ -15,7 +15,7 @@ volumes:
 services:
   postgres:
     restart: always
-    image: postgres:9.6-alpine
+    image: postgres:12-alpine
     env_file: .env_deployment
 
   solr:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ version: '3.4'
 
 services:
   postgres:
-    image: postgres:11-alpine
+    image: postgres:12-alpine
     environment:
       - POSTGRES_PASSWORD=mysecretpassword
     volumes:


### PR DESCRIPTION
Matt said production is now using version 12 of postgres, so let's update this for our CI and local docker stuff.