### PR TITLE
Drop logo_id foreign key on item/thesis 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ Further discussion of the context can be found at [#2119](https://github.com/ual
 ### Removed
 – Remove entirely unnecessary config file. [PR#2044](https://github.com/ualbertalib/jupiter/pull/2044)
 – Completely disable logging of warnings around the "excel spreadsheet" issue [PR#2049](https://github.com/ualbertalib/jupiter/pull/2049)
+- Remove logo_id foreign key on item/thesis which was causing issues with deletions
 
 ### Changed
 - Added DOI reset feature for admins [#1739](https://github.com/ualbertalib/jupiter/issues/1739)

--- a/app/controllers/admin/items_controller.rb
+++ b/app/controllers/admin/items_controller.rb
@@ -15,20 +15,6 @@ class Admin::ItemsController < Admin::AdminController
     end
 
     begin
-      # rubocop:disable Rails/SkipsModelValidations
-      # HACK: bit of a silly hack (write a nil directly to the column) to get around this hack where destroying
-      # the item tries to destroy the attachments, which then errors out because the attachment id is
-      # still referenced by the item that's about to be destroyed.
-      #
-      # TODO: investigate further why this happens (seems inconsistent with the settings for
-      # the constraint:
-      #  +add_foreign_key "items", "active_storage_attachments", column: "logo_id", on_delete: :nullify+
-      # which should allow this to work?) and consider dropping the constraint
-      # entirely if this is unreliable on PostgreSQL
-
-      @item.update_columns(logo_id: nil)
-
-      # rubocop:enable Rails/SkipsModelValidations
       @item.destroy!
       flash[:notice] = t('.deleted')
     rescue StandardError => e

--- a/db/migrate/20210505004436_remove_logo_id_foreign_keys.rb
+++ b/db/migrate/20210505004436_remove_logo_id_foreign_keys.rb
@@ -1,0 +1,6 @@
+class RemoveLogoIdForeignKeys < ActiveRecord::Migration[6.0]
+  def change
+    remove_foreign_key "items", "active_storage_attachments", column: "logo_id"
+    remove_foreign_key "theses", "active_storage_attachments", column: "logo_id"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_27_214238) do
+ActiveRecord::Schema.define(version: 2021_05_05_004436) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -432,8 +432,6 @@ ActiveRecord::Schema.define(version: 2021_04_27_214238) do
   add_foreign_key "draft_theses", "institutions"
   add_foreign_key "draft_theses", "languages"
   add_foreign_key "draft_theses", "users"
-  add_foreign_key "items", "active_storage_attachments", column: "logo_id", on_delete: :nullify
   add_foreign_key "items", "users", column: "owner_id"
-  add_foreign_key "theses", "active_storage_attachments", column: "logo_id", on_delete: :nullify
   add_foreign_key "theses", "users", column: "owner_id"
 end


### PR DESCRIPTION
This foreign key isn't working how it's suppose to be when deleting an Item (or during a roll back on a failed a transaction).

You will receive an error like the following (this was during a roll back of a failed item ingest wrapped in a transaction): 
```
Caused by PG::ForeignKeyViolation: ERROR:  insert or update on table "items" violates foreign key constraint "fk_rails_a9238d43b0"
DETAIL:  Key (logo_id)=(71) is not present in table "active_storage_attachments".
```

Seems like something odd is happening with ActiveStorage associations? When the attachment gets deleted it should null out the logo_id column for Item model via the `on_delete: :nullify` but for whatever reason this isn't happening.


Definitely requires a deeper investigation, but for now, let's just remove this foreign_key. 
