### PR TITLE
Use read-only token for Danger

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Run Danger
         env:
-          DANGER_GITHUB_API_TOKEN: ${{ secrets.DANGER_GITHUB_API_TOKEN }}
+          DANGER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: bundle exec danger
 
       - name: Lint with RuboCop

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@ Further discussion of the context can be found at [#2119](https://github.com/ual
 - Corrected missing pluralization in Digitization::Book attributes
 - Bump flipper-ui, flipper-active_record and flipper and remove redundant configuration
 - Various fixes from lighthouse suggestions [PR#2254](https://github.com/ualbertalib/jupiter/pull/2254)
+- Danger token in Github Actions [#2282](https://github.com/ualbertalib/jupiter/issues/2282)
 
 ## [2.0.2] - 2020-12-17
 - Enable Skylight in the Staging environment and remove it from the UAT environment (where it was unused, and the performance of the Docker environment is less likely to be similar to Production)


### PR DESCRIPTION
## Context

> Starting March 1st, 2021 workflow runs that are triggered by Dependabot from push, pull_request, pull_request_review, or pull_request_review_comment events will be treated as if they were opened from a repository fork. This means they will receive a read-only GITHUB_TOKEN and will not have access to any secrets available in the repository.

Note that this DOES NOT allow developers the possibility to propose change sets from a fork of the repository. This hasn't been possible since the [policy change in Travis](https://github.com/ualbertalib/jupiter/pull/1600#issuecomment-615385889).

Related to #2082 

## What's New

Changed Danger github action to use the read-only [GITHUB_TOKEN](https://docs.github.com/en/actions/reference/authentication-in-a-workflow) and the GithubActions bot.