### PR TITLE
Add `Digitization::Book` ingest artifacts to model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ Further discussion of the context can be found at [#2119](https://github.com/ual
 
 - Many "description" or "abstract" fields (at the Item level as well as Communities and Collections) contain HTML tags. Because these are text fields, HTML is not rendered in the UI and text looks garbled and it's way less readable than ideal. Markdown should work really well for this since that's already used in many of the tools staff working in repositories are familiar with. Added `redcarpet` gem which renders markdown in our decorators and strips markdown in our Solr exporters [#1322](https://github.com/ualbertalib/jupiter/issues/1322)
 
+- Add Digitization::Book ingest artifacts to model [#2011](https://github.com/ualbertalib/jupiter/issues/2011)
+
 
 ### Added
 - Added oaisys tests [#1888](https://github.com/ualbertalib/jupiter/issues/1888)

--- a/app/models/digitization/book.rb
+++ b/app/models/digitization/book.rb
@@ -1,6 +1,7 @@
 class Digitization::Book < JupiterCore::Depositable
 
   has_one_attached :historical_archive
+  has_one_attached :pdf, dependent: false
 
   belongs_to :owner, class_name: 'User'
 

--- a/app/models/digitization/book.rb
+++ b/app/models/digitization/book.rb
@@ -2,6 +2,8 @@ class Digitization::Book < JupiterCore::Depositable
 
   has_one_attached :historical_archive
   has_one_attached :pdf, dependent: false
+  has_one :fulltext, dependent: :destroy, class_name: 'Digitization::Fulltext', inverse_of: :book,
+                     foreign_key: :digitization_book_id
 
   belongs_to :owner, class_name: 'User'
 

--- a/app/models/digitization/book.rb
+++ b/app/models/digitization/book.rb
@@ -1,5 +1,7 @@
 class Digitization::Book < JupiterCore::Depositable
 
+  has_one_attached :historical_archive
+
   belongs_to :owner, class_name: 'User'
 
   validates :peel_id, uniqueness: { scope: [:run, :part_number] }, presence: true, if: :part_number?

--- a/app/models/digitization/fulltext.rb
+++ b/app/models/digitization/fulltext.rb
@@ -1,0 +1,8 @@
+class Digitization::Fulltext < ApplicationRecord
+
+  belongs_to :book, class_name: 'Digitization::Book', foreign_key: :digitization_book_id, primary_key: :id,
+                    inverse_of: :fulltext
+
+  validates :text, presence: true
+
+end

--- a/db/migrate/20210526215307_create_digitization_fulltexts.rb
+++ b/db/migrate/20210526215307_create_digitization_fulltexts.rb
@@ -1,0 +1,10 @@
+class CreateDigitizationFulltexts < ActiveRecord::Migration[6.0]
+  def change
+    create_table :digitization_fulltexts, id: :uuid do |t|
+      t.references :digitization_book, type: :uuid, null: false, index: true, foreign_key: true
+      t.text :text, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_05_004436) do
+ActiveRecord::Schema.define(version: 2021_05_26_215307) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -116,6 +116,14 @@ ActiveRecord::Schema.define(version: 2021_05_05_004436) do
     t.bigint "owner_id", null: false
     t.index ["owner_id"], name: "index_digitization_books_on_owner_id"
     t.index ["peel_id", "run", "part_number"], name: "unique_peel_book", unique: true
+  end
+
+  create_table "digitization_fulltexts", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "digitization_book_id", null: false
+    t.text "text", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["digitization_book_id"], name: "index_digitization_fulltexts_on_digitization_book_id"
   end
 
   create_table "digitization_images", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -425,6 +433,7 @@ ActiveRecord::Schema.define(version: 2021_05_05_004436) do
   add_foreign_key "collections", "users", column: "owner_id"
   add_foreign_key "communities", "users", column: "owner_id"
   add_foreign_key "digitization_books", "users", column: "owner_id"
+  add_foreign_key "digitization_fulltexts", "digitization_books"
   add_foreign_key "digitization_images", "users", column: "owner_id"
   add_foreign_key "digitization_maps", "users", column: "owner_id"
   add_foreign_key "digitization_newspapers", "users", column: "owner_id"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -708,7 +708,7 @@ if Rails.env.development? || Rails.env.uat?
   end
 
   11.times do |_i|
-    Digitization::Book.create(peel_id: rand(1..3400), part_number: rand(1..100),
+    Digitization::Book.new(peel_id: rand(1..3400), part_number: rand(1..100),
                               owner_id: admin.id,
                               dates_issued: [rand(1900..2020).to_s],
                               date_ingested: '2016-12-08T06:00:00.000Z',

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -709,6 +709,7 @@ if Rails.env.development? || Rails.env.uat?
 
   11.times do |_i|
     Digitization::Book.create(peel_id: rand(1..3400), part_number: rand(1..100),
+                              owner_id: admin.id,
                               dates_issued: [rand(1900..2020).to_s],
                               date_ingested: '2016-12-08T06:00:00.000Z',
                               title: "#{Faker::Company.name} #{Faker::WorldCup.city} Music Festival",
@@ -723,7 +724,11 @@ if Rails.env.development? || Rails.env.uat?
                               temporal_subjects: ['1981'],
                               geographic_subjects: [ControlledVocabulary.digitization.location.from_value('Edmonton (Alta.)')],
                               topical_subjects: [ControlledVocabulary.digitization.subject.from_value('Folk music festivals')],
-                              rights: ControlledVocabulary.digitization.rights.from_value('In Copyright')) # Folk Fest
+                              rights: ControlledVocabulary.digitization.rights.from_value('In Copyright')
+    ).tap do |book|
+      book.create_fulltext(text: Faker::Lorem.sentence(word_count: 250, supplemental: false, random_words_to_add: 0))
+      book.save!
+    end # Folk Fest
   end
 
   Digitization::Book.create(peel_id: '4062') # monograph

--- a/test/fixtures/digitization/fulltexts.yml
+++ b/test/fixtures/digitization/fulltexts.yml
@@ -1,0 +1,23 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  book: :folk_fest
+  text: Quia aliquam non nostrum ab ad distinctio consequuntur sunt dignissimos eum quia quia
+    nobis et impedit ex deserunt facilis quidem sint quaerat id sit alias dolores consectetur ut
+    officiis autem repudiandae ut reiciendis sed qui quia quisquam eos libero voluptatem mollitia
+    temporibus optio est et aperiam nesciunt nostrum dignissimos sapiente quos non consequatur magni
+    reprehenderit minus vero unde laborum tempora nihil provident qui ducimus excepturi minus et
+    deleniti delectus itaque rerum vel error beatae praesentium nisi accusantium ut vel explicabo
+    omnis minima cupiditate illo assumenda est sit aut necessitatibus est molestiae sed quisquam
+    commodi sunt iusto voluptatem adipisci error molestias est voluptatem veniam deleniti
+    reprehenderit dolor saepe voluptate autem culpa aut corrupti voluptas sit beatae sequi quasi aut
+    qui quibusdam omnis dolore accusantium nam fugiat harum possimus cumque numquam modi qui ut
+    cupiditate voluptas dolorum voluptas non eum ducimus repellendus quidem esse dolorem
+    voluptatibus magni molestias ea sunt non veniam inventore placeat neque ea harum sed aut iste
+    quod dolore id incidunt commodi fugit accusamus corporis voluptatem quia enim et molestiae
+    blanditiis iure possimus illum et enim saepe consequatur cumque minima necessitatibus voluptas
+    hic et omnis consectetur dolor et ullam facere iusto suscipit quod non laudantium asperiores eos
+    at occaecati odit voluptates rerum aut ipsam cum animi amet voluptates pariatur qui et et
+    numquam ipsum voluptatem in aperiam iste ut qui tenetur doloremque delectus magnam quam et natus
+    sint enim sed exercitationem veritatis et est nulla fugit eaque labore voluptas placeat velit et
+    dolores ratione dicta debitis aliquid aliquam quia.

--- a/test/models/digitization/book_test.rb
+++ b/test/models/digitization/book_test.rb
@@ -54,7 +54,7 @@ class Digitization::BookTest < ActiveSupport::TestCase
     assert_includes @document.errors[:resource_type], 'is not recognized'
   end
 
-  test 'unknown genresss are not valid' do
+  test 'unknown genres are not valid' do
     @document.assign_attributes(genres: ['some_fake_genres'])
     assert_not @document.valid?
     assert_includes @document.errors[:genres], 'is not recognized'
@@ -78,6 +78,28 @@ class Digitization::BookTest < ActiveSupport::TestCase
     assert_equal('does not conform to the Extended Date/Time Format standard',
                  @document.errors[:temporal_subjects].first)
     assert_equal('does not conform to the Extended Date/Time Format standard', @document.errors[:dates_issued].first)
+  end
+
+  test 'retrieve fulltext' do
+    assert_equal(
+      'Quia aliquam non nostrum ab ad distinctio consequuntur sunt dignissimos eum quia quia nobis et impedit ex '\
+      'deserunt facilis quidem sint quaerat id sit alias dolores consectetur ut officiis autem repudiandae ut '\
+      'reiciendis sed qui quia quisquam eos libero voluptatem mollitia temporibus optio est et aperiam nesciunt '\
+      'nostrum dignissimos sapiente quos non consequatur magni reprehenderit minus vero unde laborum tempora nihil '\
+      'provident qui ducimus excepturi minus et deleniti delectus itaque rerum vel error beatae praesentium nisi '\
+      'accusantium ut vel explicabo omnis minima cupiditate illo assumenda est sit aut necessitatibus est molestiae '\
+      'sed quisquam commodi sunt iusto voluptatem adipisci error molestias est voluptatem veniam deleniti '\
+      'reprehenderit dolor saepe voluptate autem culpa aut corrupti voluptas sit beatae sequi quasi aut qui quibusdam '\
+      'omnis dolore accusantium nam fugiat harum possimus cumque numquam modi qui ut cupiditate voluptas dolorum '\
+      'voluptas non eum ducimus repellendus quidem esse dolorem voluptatibus magni molestias ea sunt non veniam '\
+      'inventore placeat neque ea harum sed aut iste quod dolore id incidunt commodi fugit accusamus corporis '\
+      'voluptatem quia enim et molestiae blanditiis iure possimus illum et enim saepe consequatur cumque minima '\
+      'necessitatibus voluptas hic et omnis consectetur dolor et ullam facere iusto suscipit quod non laudantium '\
+      'asperiores eos at occaecati odit voluptates rerum aut ipsam cum animi amet voluptates pariatur qui et et '\
+      'numquam ipsum voluptatem in aperiam iste ut qui tenetur doloremque delectus magnam quam et natus sint enim sed '\
+      'exercitationem veritatis et est nulla fugit eaque labore voluptas placeat velit et dolores ratione dicta '\
+      'debitis aliquid aliquam quia.', @document.fulltext.text
+    )
   end
 
 end

--- a/test/models/digitization/fulltext_test.rb
+++ b/test/models/digitization/fulltext_test.rb
@@ -1,0 +1,19 @@
+require 'test_helper'
+
+class Digitization::FulltextTest < ActiveSupport::TestCase
+
+  setup do
+    @fulltext = digitization_fulltexts(:one)
+  end
+
+  test 'valid fulltext' do
+    assert @fulltext.valid?
+  end
+
+  test 'should have text' do
+    @fulltext.assign_attributes(text: nil)
+    assert_not @fulltext.valid?
+    assert_equal("can't be blank", @fulltext.errors[:text].first)
+  end
+
+end


### PR DESCRIPTION
## Context

The first set of digitization content will be the Folk Fest Programs. This set was chosen because it is small (there are 36) and well described.  This adds attributes to store the artifacts that we'll need 
- in how we'll want to deal with Preservation/AIPs, and previous archival efforts. The historical archive will never be loaded or made available for UI purposes and we'll have no reason to ever want to load it, so the attachment's only purpose is, in the future, somebody can find the old copy of the data.
- fulltext in an easy to process format. We want this in a join table so that it doesn't penalize us when we frequently request the object but close enough that we can re-index as required.

Related to #2011

## What's New

- Add `has_one_attached :historical_archive` to Book Model which takes the full archive for all directories relating to that object and archive it in case it's needed. Will not appear in the UI
- `fulltext` will be extracted from the ALTO xml. Should be easy to access in a join table but not the main object table so that results stay efficient.
- Attach one high quality PDF