### PR TITLE
#1986: Add new batch ingest models that will hold batch ingestion information

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ Further discussion of the context can be found at [#2119](https://github.com/ual
 - Labels for active facet badges [#1261](https://github.com/ualbertalib/jupiter/issues/1261)
 - book metadata for folk fest digitization [#2010](https://github.com/ualbertalib/jupiter/issues/2010)
 - Volume and Issue label attribute to Digitization::Book
+- Add new models (BatchIngest and BatchIngestFile) for improved batch ingest work [#1986](https://github.com/ualbertalib/jupiter/issues/1986)
 
 ### Removed
 – Remove entirely unnecessary config file. [PR#2044](https://github.com/ualbertalib/jupiter/pull/2044)

--- a/app/models/batch_ingest.rb
+++ b/app/models/batch_ingest.rb
@@ -1,0 +1,18 @@
+class BatchIngest < ApplicationRecord
+
+  enum status: { created: 0, processing: 1, completed: 2, failed: 3 }
+
+  belongs_to :user
+
+  has_many :items, dependent: :nullify
+  has_many :batch_ingest_files, dependent: :destroy
+
+  accepts_nested_attributes_for :batch_ingest_files
+
+  validates :access_token, presence: true
+  validates :google_spreadsheet_id, presence: true
+  validates :google_spreadsheet_name, presence: true
+  validates :batch_ingest_files, presence: true
+  validates :title, presence: true, uniqueness: { case_sensitive: false }
+
+end

--- a/app/models/batch_ingest_file.rb
+++ b/app/models/batch_ingest_file.rb
@@ -1,0 +1,8 @@
+class BatchIngestFile < ApplicationRecord
+
+  belongs_to :batch_ingest
+
+  validates :google_file_id, presence: true
+  validates :google_file_name, presence: true
+
+end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -4,6 +4,7 @@ class Item < JupiterCore::Doiable
 
   has_solr_exporter Exporters::Solr::ItemExporter
 
+  belongs_to :batch_ingest, optional: true
   belongs_to :owner, class_name: 'User'
 
   has_many_attached :files, dependent: false

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,10 +1,12 @@
 class User < ApplicationRecord
 
   has_secure_password :api_key, validations: false
-  has_many :identities, dependent: :destroy
+
   has_many :announcements, dependent: :destroy
+  has_many :batch_ingests, dependent: :destroy
   has_many :draft_items, dependent: :destroy
   has_many :draft_theses, dependent: :destroy
+  has_many :identities, dependent: :destroy
 
   has_many :items, foreign_key: :owner_id, inverse_of: :owner, dependent: :restrict_with_error
   has_many :theses, foreign_key: :owner_id, inverse_of: :owner, dependent: :restrict_with_error

--- a/db/migrate/20210523154753_create_batch_ingests.rb
+++ b/db/migrate/20210523154753_create_batch_ingests.rb
@@ -1,0 +1,24 @@
+class CreateBatchIngests < ActiveRecord::Migration[6.0]
+  def change
+    create_table :batch_ingests do |t|
+      t.string :title, null: false
+      t.integer :status, default: 0, null: false
+
+      t.string :access_token, null: false
+      t.string :refresh_token
+      t.string :expires_in
+      t.string :issued_at
+
+      t.string :error_message
+
+      t.string :google_spreadsheet_name, null: false
+      t.string :google_spreadsheet_id, null: false
+
+      t.references :user, foreign_key: true
+
+      t.timestamps
+    end
+
+    add_index :batch_ingests, :title, unique: true
+  end
+end

--- a/db/migrate/20210523164753_create_batch_ingest_files.rb
+++ b/db/migrate/20210523164753_create_batch_ingest_files.rb
@@ -1,0 +1,12 @@
+class CreateBatchIngestFiles < ActiveRecord::Migration[6.0]
+  def change
+    create_table :batch_ingest_files do |t|
+      t.string :google_file_name, null: false
+      t.string :google_file_id, null: false
+
+      t.references :batch_ingest, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20210601042208_add_batch_ingest_items.rb
+++ b/db/migrate/20210601042208_add_batch_ingest_items.rb
@@ -1,0 +1,5 @@
+class AddBatchIngestItems < ActiveRecord::Migration[6.0]
+  def change
+    add_reference :items, :batch_ingest, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_05_004436) do
+ActiveRecord::Schema.define(version: 2021_06_01_042208) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -53,6 +53,32 @@ ActiveRecord::Schema.define(version: 2021_05_05_004436) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "logo_id"
+  end
+
+  create_table "batch_ingest_files", force: :cascade do |t|
+    t.string "google_file_name", null: false
+    t.string "google_file_id", null: false
+    t.bigint "batch_ingest_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["batch_ingest_id"], name: "index_batch_ingest_files_on_batch_ingest_id"
+  end
+
+  create_table "batch_ingests", force: :cascade do |t|
+    t.string "title", null: false
+    t.integer "status", default: 0, null: false
+    t.string "access_token", null: false
+    t.string "refresh_token"
+    t.string "expires_in"
+    t.string "issued_at"
+    t.string "error_message"
+    t.string "google_spreadsheet_name", null: false
+    t.string "google_spreadsheet_id", null: false
+    t.bigint "user_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["title"], name: "index_batch_ingests_on_title", unique: true
+    t.index ["user_id"], name: "index_batch_ingests_on_user_id"
   end
 
   create_table "collections", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
@@ -316,6 +342,8 @@ ActiveRecord::Schema.define(version: 2021_05_05_004436) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.json "subject", array: true
+    t.bigint "batch_ingest_id"
+    t.index ["batch_ingest_id"], name: "index_items_on_batch_ingest_id"
     t.index ["logo_id"], name: "index_items_on_logo_id"
     t.index ["owner_id"], name: "index_items_on_owner_id"
   end
@@ -422,6 +450,8 @@ ActiveRecord::Schema.define(version: 2021_05_05_004436) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "announcements", "users"
+  add_foreign_key "batch_ingest_files", "batch_ingests"
+  add_foreign_key "batch_ingests", "users"
   add_foreign_key "collections", "users", column: "owner_id"
   add_foreign_key "communities", "users", column: "owner_id"
   add_foreign_key "digitization_books", "users", column: "owner_id"
@@ -432,6 +462,7 @@ ActiveRecord::Schema.define(version: 2021_05_05_004436) do
   add_foreign_key "draft_theses", "institutions"
   add_foreign_key "draft_theses", "languages"
   add_foreign_key "draft_theses", "users"
+  add_foreign_key "items", "batch_ingests"
   add_foreign_key "items", "users", column: "owner_id"
   add_foreign_key "theses", "users", column: "owner_id"
 end

--- a/test/fixtures/batch_ingest_files.yml
+++ b/test/fixtures/batch_ingest_files.yml
@@ -1,0 +1,14 @@
+batch_ingest_file_one:
+  google_file_id: "16fCERu9Wey9M-q89Vt7nUEUBsY0AdBJn"
+  google_file_name: "test.png"
+  batch_ingest: batch_ingest_with_one_file
+
+batch_ingest_file_two:
+  google_file_id: "19gX6kVrMFh6PT7UrrKKHx8sf7zWDTELx"
+  google_file_name: "conference.pdf"
+  batch_ingest: batch_ingest_with_two_files
+
+batch_ingest_file_three:
+  google_file_id: "1WAbJqbQzALwuZz2kVKyE3__680I8bsrC"
+  google_file_name: "conference_logo.png"
+  batch_ingest: batch_ingest_with_two_files

--- a/test/fixtures/batch_ingest_files.yml
+++ b/test/fixtures/batch_ingest_files.yml
@@ -1,14 +1,14 @@
 batch_ingest_file_one:
-  google_file_id: "16fCERu9Wey9M-q89Vt7nUEUBsY0AdBJn"
+  google_file_id: "RANDOMFILEID"
   google_file_name: "test.png"
   batch_ingest: batch_ingest_with_one_file
 
 batch_ingest_file_two:
-  google_file_id: "19gX6kVrMFh6PT7UrrKKHx8sf7zWDTELx"
+  google_file_id: "RANDOMFILEID"
   google_file_name: "conference.pdf"
   batch_ingest: batch_ingest_with_two_files
 
 batch_ingest_file_three:
-  google_file_id: "1WAbJqbQzALwuZz2kVKyE3__680I8bsrC"
+  google_file_id: "RANDOMFILEID"
   google_file_name: "conference_logo.png"
   batch_ingest: batch_ingest_with_two_files

--- a/test/fixtures/batch_ingests.yml
+++ b/test/fixtures/batch_ingests.yml
@@ -1,13 +1,13 @@
 batch_ingest_with_one_file:
   title: "Test Batch"
   user: user_admin
-  google_spreadsheet_id: "0ByqIunuzLALHUTI4eVhKXzdnLXM"
+  google_spreadsheet_id: "RANDOMSPREADSHEETID"
   google_spreadsheet_name: "Test Batch Ingest"
   access_token: "ACCESSTOKEN"
 
 batch_ingest_with_two_files:
   title: "Conference Batch"
   user: user_admin_two
-  google_spreadsheet_id: "1xnAsY0e8E9MKJ9yOkE3CHZC"
+  google_spreadsheet_id: "RANDOMSPREADSHEETID"
   google_spreadsheet_name: "Conference Batch Ingest"
   access_token: "ACCESSTOKEN"

--- a/test/fixtures/batch_ingests.yml
+++ b/test/fixtures/batch_ingests.yml
@@ -1,0 +1,13 @@
+batch_ingest_with_one_file:
+  title: "Test Batch"
+  user: user_admin
+  google_spreadsheet_id: "0ByqIunuzLALHUTI4eVhKXzdnLXM"
+  google_spreadsheet_name: "Test Batch Ingest"
+  access_token: "ACCESSTOKEN"
+
+batch_ingest_with_two_files:
+  title: "Conference Batch"
+  user: user_admin_two
+  google_spreadsheet_id: "1xnAsY0e8E9MKJ9yOkE3CHZC"
+  google_spreadsheet_name: "Conference Batch Ingest"
+  access_token: "ACCESSTOKEN"

--- a/test/models/batch_ingest_file_test.rb
+++ b/test/models/batch_ingest_file_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class BatchIngestFileTest < ActiveSupport::TestCase
 
-  def setup
+  setup do
     @batch_ingest_file = batch_ingest_files(:batch_ingest_file_one)
   end
 

--- a/test/models/batch_ingest_file_test.rb
+++ b/test/models/batch_ingest_file_test.rb
@@ -1,0 +1,31 @@
+require 'test_helper'
+
+class BatchIngestFileTest < ActiveSupport::TestCase
+
+  def setup
+    @batch_ingest_file = batch_ingest_files(:batch_ingest_file_one)
+  end
+
+  test 'valid batch ingest file' do
+    assert @batch_ingest_file.valid?
+  end
+
+  test 'invalid without google file id' do
+    @batch_ingest_file.google_file_id = nil
+    assert_not @batch_ingest_file.valid?
+    assert_equal("can't be blank", @batch_ingest_file.errors[:google_file_id].first)
+  end
+
+  test 'invalid without google file name' do
+    @batch_ingest_file.google_file_name = nil
+    assert_not @batch_ingest_file.valid?
+    assert_equal("can't be blank", @batch_ingest_file.errors[:google_file_name].first)
+  end
+
+  test 'invalid without batch ingest' do
+    @batch_ingest_file.batch_ingest = nil
+    assert_not @batch_ingest_file.valid?
+    assert_equal('must exist', @batch_ingest_file.errors[:batch_ingest].first)
+  end
+
+end

--- a/test/models/batch_ingest_test.rb
+++ b/test/models/batch_ingest_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class BatchIngestTest < ActiveSupport::TestCase
 
-  def setup
+  setup do
     @batch_ingest = batch_ingests(:batch_ingest_with_one_file)
   end
 

--- a/test/models/batch_ingest_test.rb
+++ b/test/models/batch_ingest_test.rb
@@ -1,0 +1,55 @@
+require 'test_helper'
+
+class BatchIngestTest < ActiveSupport::TestCase
+
+  def setup
+    @batch_ingest = batch_ingests(:batch_ingest_with_one_file)
+  end
+
+  test 'valid batch ingest' do
+    assert @batch_ingest.valid?
+  end
+
+  test 'invalid without access token' do
+    @batch_ingest.access_token = nil
+    assert_not @batch_ingest.valid?
+    assert_equal("can't be blank", @batch_ingest.errors[:access_token].first)
+  end
+
+  test 'invalid without files' do
+    @batch_ingest.batch_ingest_files = []
+    assert_not @batch_ingest.valid?
+    assert_equal("can't be blank", @batch_ingest.errors[:batch_ingest_files].first)
+  end
+
+  test 'invalid without google spreadsheet id' do
+    @batch_ingest.google_spreadsheet_id = nil
+    assert_not @batch_ingest.valid?
+    assert_equal("can't be blank", @batch_ingest.errors[:google_spreadsheet_id].first)
+  end
+
+  test 'invalid without google spreadsheet name' do
+    @batch_ingest.google_spreadsheet_name = nil
+    assert_not @batch_ingest.valid?
+    assert_equal("can't be blank", @batch_ingest.errors[:google_spreadsheet_name].first)
+  end
+
+  test 'invalid without title' do
+    @batch_ingest.title = nil
+    assert_not @batch_ingest.valid?
+    assert_equal("can't be blank", @batch_ingest.errors[:title].first)
+  end
+
+  test 'invalid if title taken already' do
+    @batch_ingest.title = 'Conference Batch'
+    assert_not @batch_ingest.valid?
+    assert_equal('has already been taken', @batch_ingest.errors[:title].first)
+  end
+
+  test 'invalid without user' do
+    @batch_ingest.user = nil
+    assert_not @batch_ingest.valid?
+    assert_equal('must exist', @batch_ingest.errors[:user].first)
+  end
+
+end


### PR DESCRIPTION
## Context

This is first of many PRs for the improved batch ingestion work. This PR provides the data layer and models that will hold all the information we need in order to successfully (or unsuccessfully) handle a batch ingest request.

Related to #1986

## What's New

Adds new BatchIngest and BatchIngestFile models (A BatchIngest has many BatchIngestFiles). Also adds associations for batch ingest to items/user models (BatchIngest has many items and BatchIngest belongs to a user).