### PR TITLE
Update codeowners :cry:

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,2 @@
 # https://help.github.com/articles/about-codeowners/
-* @ConnorSheremeta @lagoan @mbarnett @murny @pgwillia
-
-# Make sure you bug @mbarnett when touching files in these directories
-app/models/jupiter_core/ @mbarnett
-app/models/exporters/ @mbarnett
+* @ConnorSheremeta @lagoan @murny @pgwillia


### PR DESCRIPTION
## Context

Removes @mbarnett so we can still change code.

Related to #2396

## What's New

Cherry-picked from master.  The only other changes from last time @murny merged were nokogiri and puma bumps.  Independently these are already in integration branch.