### PR TITLE
Use read-only token for Danger

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -36,7 +36,7 @@ jobs:
       
       - name: Run Danger
         env:
-          DANGER_GITHUB_API_TOKEN: ${{ secrets.DANGER_GITHUB_API_TOKEN }}
+          DANGER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: bundle exec danger
 
       - name: Lint with RuboCop

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and releases in Jupiter project adheres to [Semantic Versioning](http://semver.o
 - bump rdf-n3 and fix isomorphic_with? regression [PR#2070](https://github.com/ualbertalib/jupiter/pull/2070)
 - bump rubocop and fix more cop violations [PR#2132](https://github.com/ualbertalib/jupiter/pull/2132)
 - Various fixes from lighthouse suggestions [PR#2254](https://github.com/ualbertalib/jupiter/pull/2254)
+- Danger token in Github Actions [#2282](https://github.com/ualbertalib/jupiter/issues/2282)
 
 ## [2.0.2] - 2020-12-17
 


### PR DESCRIPTION
## Context

This change has been proven to work on the `integration` branch.  Propose that we also apply to master.

> Starting March 1st, 2021 workflow runs that are triggered by Dependabot from push, pull_request, pull_request_review, or pull_request_review_comment events will be treated as if they were opened from a repository fork. This means they will receive a read-only GITHUB_TOKEN and will not have access to any secrets available in the repository.

Note that this DOES NOT allow developers the possibility to propose change sets from a fork of the repository. This hasn't been possible since the [policy change in Travis](https://github.com/ualbertalib/jupiter/pull/1600#issuecomment-615385889).

Related to #2082  #2282 #2352

## What's New

Changed Danger github action to use the read-only [GITHUB_TOKEN](https://docs.github.com/en/actions/reference/authentication-in-a-workflow) and the GithubActions bot.