### PR TITLE
Remove rufus-scheduler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ Further discussion of the context can be found at [#2119](https://github.com/ual
 - Remove entirely unnecessary config file. [PR#2044](https://github.com/ualbertalib/jupiter/pull/2044)
 - Completely disable logging of warnings around the "excel spreadsheet" issue [PR#2049](https://github.com/ualbertalib/jupiter/pull/2049)
 - Remove logo_id foreign key on item/thesis which was causing issues with deletions
+- Removed `rufus-scheduler` -- it's an unused dependency [PR#2434](https://github.com/ualbertalib/jupiter/pull/2434)
 
 ### Changed
 - Added DOI reset feature for admins [#1739](https://github.com/ualbertalib/jupiter/issues/1739)

--- a/Gemfile
+++ b/Gemfile
@@ -42,7 +42,6 @@ gem 'sidekiq', '~> 5.2'
 gem 'sidekiq-unique-jobs', '~> 7.0'
 gem 'sinatra', '~> 2.1.0' # used by sidekiq/web
 # Sidekiq cron jobs
-gem 'rufus-scheduler', '3.7.0' # https://github.com/ondrejbartas/sidekiq-cron/issues/199
 gem 'sidekiq-cron'
 
 # Misc Utilities

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -467,8 +467,6 @@ GEM
       ffi (~> 1.12)
     ruby2_keywords (0.0.4)
     rubyzip (2.3.0)
-    rufus-scheduler (3.7.0)
-      fugit (~> 1.1, >= 1.1.6)
     sawyer (0.8.2)
       addressable (>= 2.3.5)
       faraday (> 0.8, < 2.0)
@@ -647,7 +645,6 @@ DEPENDENCIES
   rubocop-minitest
   rubocop-performance
   rubocop-rails
-  rufus-scheduler (= 3.7.0)
   sdoc
   selenium-webdriver
   shoulda-matchers (~> 5.0)


### PR DESCRIPTION
## Context

In version 1.0 of sidekiq-cron they changed to
> use fugit instead of rufus-scheduler - API of cron didn't change (rufus scheduler is using fugit)

https://github.com/ondrejbartas/sidekiq-cron/blob/6a0aeff6c900f3b7246734282f6869c61e1d5b4e/Changes.md#v-100

That means that this dependency is unused so there isn't a good reason to keep it around.

Closes #2434

## What's New

Removes `rufus-scheduler` gem from our dependencies.