### PR TITLE
Add batch ingestion job for creating items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ Further discussion of the context can be found at [#2119](https://github.com/ual
 - Brakeman linting to Github Actions workflow
 - Add batch ingest controller and views for CRUDing batch ingests [#1986](https://github.com/ualbertalib/jupiter/issues/1986)
 - Add batch ingest form with google file picker and spreadsheet validation [#1986](https://github.com/ualbertalib/jupiter/issues/1986)
+- Add batch ingestion job for batch ingesting items into ERA [#1986](https://github.com/ualbertalib/jupiter/issues/1986)
 
 ### Removed
 – Remove entirely unnecessary config file. [PR#2044](https://github.com/ualbertalib/jupiter/pull/2044)

--- a/app/controllers/admin/batch_ingests_controller.rb
+++ b/app/controllers/admin/batch_ingests_controller.rb
@@ -31,8 +31,7 @@ class Admin::BatchIngestsController < Admin::AdminController
     @batch_ingest.assign_attributes(permitted_attributes(BatchIngest))
 
     if @batch_ingest.save
-      # TODO: queue a background job for the actual batch ingestion
-      # BatchIngestionJob.perform_later(@batch_ingest.id)
+      BatchIngestionJob.perform_later(@batch_ingest.id)
 
       redirect_to [:admin, @batch_ingest], notice: t('.created')
     elsif access_token

--- a/app/jobs/batch_ingestion_job.rb
+++ b/app/jobs/batch_ingestion_job.rb
@@ -22,7 +22,6 @@ class BatchIngestionJob < ApplicationJob
       issued_at: batch_ingest.issued_at
     )
 
-    # TODO: verify this error
     raise GoogleAPIError if google_credentials.nil?
 
     spreadsheet = google_credentials.download_spreadsheet(batch_ingest.google_spreadsheet_id)

--- a/app/jobs/batch_ingestion_job.rb
+++ b/app/jobs/batch_ingestion_job.rb
@@ -68,13 +68,13 @@ class BatchIngestionJob < ApplicationJob
       end
 
       if item_data['languages'].present?
-        unlocked_obj.languages = item_data['languages'].split('|').map do |language|
+        unlocked_obj.languages = item_data['languages'].split('|').map(&:strip).map do |language|
           ControlledVocabulary.era.language.send(language.to_sym) if language.present?
         end
       end
 
-      unlocked_obj.creators = item_data['creators'].split('|') if item_data['creators'].present?
-      unlocked_obj.subject = item_data['subjects'].split('|') if item_data['subjects'].present?
+      unlocked_obj.creators = item_data['creators'].split('|').map(&:strip) if item_data['creators'].present?
+      unlocked_obj.subject = item_data['subjects'].split('|').map(&:strip) if item_data['subjects'].present?
       unlocked_obj.created = item_data['date_created'].to_s
       unlocked_obj.description = item_data['description']
 
@@ -102,10 +102,14 @@ class BatchIngestionJob < ApplicationJob
       end
 
       # Additional fields
-      unlocked_obj.contributors = item_data['contributors'].split('|') if item_data['contributors'].present?
-      unlocked_obj.spatial_subjects = item_data['places'].split('|') if item_data['places'].present?
-      unlocked_obj.temporal_subjects = item_data['time_periods'].split('|') if item_data['time_periods'].present?
-      unlocked_obj.is_version_of = item_data['citations'].split('|') if item_data['citations'].present?
+      if item_data['contributors'].present?
+        unlocked_obj.contributors = item_data['contributors'].split('|').map(&:strip)
+      end
+      unlocked_obj.spatial_subjects = item_data['places'].split('|').map(&:strip) if item_data['places'].present?
+      if item_data['time_periods'].present?
+        unlocked_obj.temporal_subjects = item_data['time_periods'].split('|').map(&:strip)
+      end
+      unlocked_obj.is_version_of = item_data['citations'].split('|').map(&:strip) if item_data['citations'].present?
       unlocked_obj.source = item_data['source']
       unlocked_obj.related_link = item_data['related_item']
 

--- a/app/jobs/batch_ingestion_job.rb
+++ b/app/jobs/batch_ingestion_job.rb
@@ -1,0 +1,126 @@
+class BatchIngestionJob < ApplicationJob
+
+  class GoogleAPIError < StandardError; end
+
+  queue_as :default
+
+  rescue_from(StandardError) do |exception|
+    batch_ingest = BatchIngest.find(arguments.first)
+    batch_ingest.update(error_message: exception.message, status: :failed)
+    raise exception
+  end
+
+  def perform(id)
+    batch_ingest = BatchIngest.find(id)
+
+    batch_ingest.processing!
+
+    google_credentials = GoogleDriveClientService.new(
+      access_token: batch_ingest.access_token,
+      refresh_token: batch_ingest.refresh_token,
+      expires_in: batch_ingest.expires_in,
+      issued_at: batch_ingest.issued_at
+    )
+
+    # TODO: verify this error
+    raise GoogleAPIError if google_credentials.nil?
+
+    spreadsheet = google_credentials.download_spreadsheet(batch_ingest.google_spreadsheet_id)
+
+    ActiveRecord::Base.transaction do
+      spreadsheet.each do |row|
+        item_file = batch_ingest.batch_ingest_files.find { |file| file.google_file_name == row['file_name'] }
+
+        next if item_file.blank?
+
+        item = item_ingest(batch_ingest, row)
+        file_ingest(item, item_file, google_credentials)
+      end
+    end
+
+    batch_ingest.completed!
+  end
+
+  private
+
+  def item_ingest(batch_ingest, item_data)
+    item = batch_ingest.items.new
+    item.tap do |unlocked_obj|
+      unlocked_obj.owner_id = item_data['owner_id']
+      unlocked_obj.title = item_data['title']
+      unlocked_obj.alternative_title = item_data['alternate_title']
+
+      if item_data['type'].present?
+        unlocked_obj.item_type = ControlledVocabulary.era.item_type.send(item_data['type'].to_sym)
+      end
+
+      # If item type is an article, we need to add an array of statuses to the publication status field...
+      if item_data['type'] == 'article' && ['draft', 'published'].include?(item_data['publication_status'])
+        unlocked_obj.publication_status = if item_data['publication_status'] == 'draft'
+                                            [
+                                              ControlledVocabulary.era.publication_status.draft,
+                                              ControlledVocabulary.era.publication_status.submitted
+                                            ]
+                                          else
+                                            [
+                                              ControlledVocabulary.era.publication_status.published
+                                            ]
+                                          end
+      end
+
+      if item_data['languages'].present?
+        unlocked_obj.languages = item_data['languages'].split('|').map do |language|
+          ControlledVocabulary.era.language.send(language.to_sym) if language.present?
+        end
+      end
+
+      unlocked_obj.creators = item_data['creators'].split('|') if item_data['creators'].present?
+      unlocked_obj.subject = item_data['subjects'].split('|') if item_data['subjects'].present?
+      unlocked_obj.created = item_data['date_created'].to_s
+      unlocked_obj.description = item_data['description']
+
+      # Handle visibility and embargo logic
+      if item_data['visibility'].present?
+        unlocked_obj.visibility = ControlledVocabulary.jupiter_core.visibility.send(item_data['visibility'].to_sym)
+      end
+
+      if item_data['visibility_after_embargo'].present?
+        unlocked_obj.visibility_after_embargo =
+          ControlledVocabulary.jupiter_core.visibility.send(item_data['visibility_after_embargo'].to_sym)
+      end
+
+      unlocked_obj.embargo_end_date = item_data['embargo_end_date'].to_date if item_data['embargo_end_date'].present?
+
+      # Handle license vs rights
+      if item_data['license'].present?
+        unlocked_obj.license =
+          ControlledVocabulary.era.license.send(item_data['license'].to_sym) ||
+          ControlledVocabulary.era.old_license.send(item_data['license'].to_sym)
+      end
+      unlocked_obj.rights = item_data['license_text']
+
+      # Additional fields
+      unlocked_obj.contributors = item_data['contributors'].split('|') if item_data['contributors'].present?
+      unlocked_obj.spatial_subjects = item_data['places'].split('|') if item_data['places'].present?
+      unlocked_obj.temporal_subjects = item_data['time_periods'].split('|') if item_data['time_periods'].present?
+      unlocked_obj.is_version_of = item_data['citations'].split('|') if item_data['citations'].present?
+      unlocked_obj.source = item_data['source']
+      unlocked_obj.related_link = item_data['related_item']
+
+      # We only support single communities/collections pairs for time being,
+      # could accomodate multiple pairs without much work here
+      unlocked_obj.add_to_path(item_data['community_id'], item_data['collection_id'])
+
+      unlocked_obj.save!
+    end
+
+    item
+  end
+
+  def file_ingest(item, item_file, google_credentials)
+    file = google_credentials.download_file(item_file.google_file_id, item_file.google_file_name)
+    item.add_and_ingest_files([file])
+    item.set_thumbnail(item.files.first) if item.files.first.present?
+  end
+
+end

--- a/app/jobs/batch_ingestion_job.rb
+++ b/app/jobs/batch_ingestion_job.rb
@@ -92,11 +92,14 @@ class BatchIngestionJob < ApplicationJob
 
       # Handle license vs rights
       if item_data['license'].present?
-        unlocked_obj.license =
-          ControlledVocabulary.era.license.send(item_data['license'].to_sym) ||
-          ControlledVocabulary.era.old_license.send(item_data['license'].to_sym)
+        if item_data['license'] == 'license_text'
+          unlocked_obj.rights = item_data['license_text']
+        else
+          unlocked_obj.license =
+            ControlledVocabulary.era.license.send(item_data['license'].to_sym) ||
+            ControlledVocabulary.era.old_license.send(item_data['license'].to_sym)
+        end
       end
-      unlocked_obj.rights = item_data['license_text']
 
       # Additional fields
       unlocked_obj.contributors = item_data['contributors'].split('|') if item_data['contributors'].present?

--- a/app/validators/batch_ingest_spreadsheet_validator.rb
+++ b/app/validators/batch_ingest_spreadsheet_validator.rb
@@ -30,6 +30,17 @@ class BatchIngestSpreadsheetValidator < ActiveModel::EachValidator
         end
       end
 
+      # Check if "type" is article, then it must have a "publication_status"
+      if row['type'] == 'article' && row['publication_status'].blank?
+        record.errors.add(attribute, :publication_status_required_for_articles, row_number: row_number)
+      end
+
+      # check if "status" is embargo, then it must have "embargo_end_date" and "visibility_after_embargo"
+      if row['visibility'] == 'embargo' &&
+         (row['embargo_end_date'].blank? || row['visibility_after_embargo'].blank?)
+        record.errors.add(attribute, :embargo_missing_required_data, row_number: row_number)
+      end
+
       # Check if given owner/community/collection ids actually exists?
       unless Community.exists?(row['community_id'])
         record.errors.add(attribute, :column_not_found, column: 'community_id', row_number: row_number)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -184,6 +184,8 @@ en:
           attributes:
             google_spreadsheet_id:
                 missing_required_column: "%{column} is required and was not found for row %{row_number} of spreadsheet"
+                publication_status_required_for_articles: 'Publication status is required for articles and was not found for row %{row_number} of spreadsheet'
+                embargo_missing_required_data: 'Embargo end date and visibility after embargo is required for embargo items. Missing data was not found for row %{row_number} of spreadsheet'
                 column_not_found: "%{column} does not exist in ERA for row %{row_number} of spreadsheet"
                 no_matching_files: "file_name for row %{row_number} of spreadsheet has no matching files below"
                 spreadsheet_could_not_be_read: "Spreadsheet could not be read. Please follow the template spreadsheet as an example"

--- a/test/controllers/admin/batch_ingests_controller_test.rb
+++ b/test/controllers/admin/batch_ingests_controller_test.rb
@@ -33,8 +33,7 @@ class Admin::BatchIngestsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should create batch_ingest' do
-    # TODO: Add checks for job being queued up on creation
-    # assert_no_enqueued_jobs only: BatchIngestionJob
+    assert_no_enqueued_jobs only: BatchIngestionJob
 
     VCR.use_cassette('google_fetch_access_token', record: :none) do
       get new_admin_google_session_url, params: {
@@ -65,10 +64,10 @@ class Admin::BatchIngestsControllerTest < ActionDispatch::IntegrationTest
         end
       end
     end
-    # assert_enqueued_jobs 1, only: BatchIngestionJob
+    assert_enqueued_jobs 1, only: BatchIngestionJob
     assert_redirected_to admin_batch_ingest_url(BatchIngest.last)
 
-    # clear_enqueued_jobs
+    clear_enqueued_jobs
   end
 
   test 'should show batch_ingest' do

--- a/test/jobs/batch_ingestion_job_test.rb
+++ b/test/jobs/batch_ingestion_job_test.rb
@@ -1,0 +1,70 @@
+require 'test_helper'
+
+class BatchIngestionJobTest < ActiveJob::TestCase
+
+  # Files in batch don't match spreadsheet?!
+  test 'batch ingestion with inconsistent files' do
+    batch_ingest = batch_ingests(:batch_ingest_with_one_file)
+
+    assert_no_difference('Item.count') do
+      VCR.use_cassette('google_fetch_spreadsheet',
+                       record: :none,
+                       erb: {
+                         collection_id: collections(:collection_fantasy).id,
+                         community_id: communities(:community_books).id,
+                         owner_id: users(:user_admin).id
+                       }) do
+        BatchIngestionJob.perform_now(batch_ingest.id)
+      end
+
+      batch_ingest.reload
+      assert(batch_ingest.completed?)
+    end
+  end
+
+  # Test exception handling
+  test 'batch ingestion job captures exceptions and updates batch ingest model' do
+    batch_ingest = batch_ingests(:batch_ingest_with_one_file)
+
+    def batch_ingest.processing!
+      raise StandardError, 'Testing! Error has happened!'
+    end
+
+    BatchIngest.stub :find, batch_ingest do
+      assert_raises StandardError do
+        assert_no_difference('Item.count') do
+          BatchIngestionJob.perform_now(batch_ingest.id)
+        end
+      end
+
+      batch_ingest.reload
+      assert(batch_ingest.failed?)
+      assert_equal('Testing! Error has happened!', batch_ingest.error_message)
+    end
+  end
+
+  test 'successful batch ingestion' do
+    batch_ingest = batch_ingests(:batch_ingest_with_two_files)
+
+    assert_difference('Item.count', +2) do
+      VCR.use_cassette('google_fetch_spreadsheet',
+                       record: :none,
+                       erb: {
+                         collection_id: collections(:collection_fantasy).id,
+                         community_id: communities(:community_books).id,
+                         owner_id: users(:user_admin).id
+                       }) do
+        VCR.use_cassette('google_fetch_file',
+                         record: :none,
+                         allow_playback_repeats: true) do
+          BatchIngestionJob.perform_now(batch_ingest.id)
+        end
+      end
+
+      batch_ingest.reload
+      assert(batch_ingest.completed?)
+      assert_equal(2, batch_ingest.items.count)
+    end
+  end
+
+end


### PR DESCRIPTION
This PR will add the batch ingestion job work, which will get queued up and ran after a successful batch ingest creation.
The job will use the newly created batch ingest's spreadsheet and files to create an Item record from each row of the spreadsheet thus allowing us to batch ingest a bunch of items into ERA.

After creating a batch ingest:

![image](https://user-images.githubusercontent.com/1930474/130012843-0ce30ac2-e4af-459a-b08b-86810b2901e4.png)

Job is being processed:
![image](https://user-images.githubusercontent.com/1930474/130012862-d742a838-d1e8-42ec-a5ce-087d8d73b3b3.png)

Successful job ingestion with newly ingested Item records being shown:
![image](https://user-images.githubusercontent.com/1930474/130012915-ece6dc81-e42a-4454-bb10-94e99a911404.png)
