### PR TITLE
Fix some test debt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,7 @@ Further discussion of the context can be found at [#2119](https://github.com/ual
 - Bump rubocop to 1.18.2 and fix cop violations [PR#2415](https://github.com/ualbertalib/jupiter/pull/2415)
 - Bump rubocop-minitest to 0.14.0 and note really smelly tests [PR#2416](https://github.com/ualbertalib/jupiter/pull/2416)
 - Fixed a flaky test where the page hasn't finished loading [#2129](https://github.com/ualbertalib/jupiter/issues/2129)
+- Refactored one of our smelliest tests to use fixtures and reduce number of assertions per test [#2419](https://github.com/ualbertalib/jupiter/issues/2419)
 
 ## [2.0.2] - 2020-12-17
 - Enable Skylight in the Staging environment and remove it from the UAT environment (where it was unused, and the performance of the Docker environment is less likely to be similar to Production)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,7 @@ Further discussion of the context can be found at [#2119](https://github.com/ual
 - Bump rubocop to 1.15.0 and Style/TrivialAccessors default changed [PR#2343](https://github.com/ualbertalib/jupiter/pull/2343)
 - Bump rubocop to 1.18.2 and fix cop violations [PR#2415](https://github.com/ualbertalib/jupiter/pull/2415)
 - Bump rubocop-minitest to 0.14.0 and note really smelly tests [PR#2416](https://github.com/ualbertalib/jupiter/pull/2416)
+- Fixed a flaky test where the page hasn't finished loading [#2129](https://github.com/ualbertalib/jupiter/issues/2129)
 
 ## [2.0.2] - 2020-12-17
 - Enable Skylight in the Staging environment and remove it from the UAT environment (where it was unused, and the performance of the Docker environment is less likely to be similar to Production)

--- a/test/fixtures/communities.yml
+++ b/test/fixtures/communities.yml
@@ -2,22 +2,26 @@ community_books:
   title: 'Books'
   owner: user_admin
   record_created_at: <%= Time.zone.now - 1.hour %>
+  created_at: <%= Time.zone.now - 1.hour %>
   date_ingested: <%= Time.zone.now - 1.hour %>
 
 community_thesis:
   title: 'Thesis'
   owner: user_admin
-  record_created_at: <%= Time.zone.now - 1.hour %>
-  date_ingested: <%= Time.zone.now - 1.hour %>
+  record_created_at: <%= Time.zone.now - 2.hour %>
+  created_at: <%= Time.zone.now - 2.hour %>
+  date_ingested: <%= Time.zone.now - 2.hour %>
 
 community_fancy:
   title: 'Fancy Community'
   owner: user_admin
-  record_created_at: <%= Time.zone.now - 1.hour %>
-  date_ingested: <%= Time.zone.now - 1.hour %>
+  record_created_at: <%= Time.zone.now - 3.hour %>
+  created_at: <%= Time.zone.now - 3.hour %>
+  date_ingested: <%= Time.zone.now - 3.hour %>
 
 community_with_no_collections:
     title: 'Community with no collections'
     owner: user_admin
-    record_created_at: <%= Time.zone.now - 1.hour %>
-    date_ingested: <%= Time.zone.now - 1.hour %>
+    record_created_at: <%= Time.zone.now - 4.hour %>
+    created_at: <%= Time.zone.now - 4.hour %>
+    date_ingested: <%= Time.zone.now - 4.hour %>

--- a/test/system/admin_users_index_test.rb
+++ b/test/system/admin_users_index_test.rb
@@ -18,10 +18,12 @@ class AdminUsersIndexTest < ApplicationSystemTestCase
 
     click_link 'Email' # email ascending
 
+    assert_selector '.fa-sort-down'
     assert_selector 'tbody tr:first-child th[scope="row"]', text: admin.email
 
     click_link 'Email' # email descending
 
+    assert_selector '.fa-sort-up' # the rest of this test is flaky without ensuring the page has finished updating
     assert_selector 'tbody tr:last-child th[scope="row"]', text: admin.email
 
     logout_user
@@ -53,6 +55,7 @@ class AdminUsersIndexTest < ApplicationSystemTestCase
 
     # Autocomplete 'Administrator'
     fill_in I18n.t('search_label'), with: admin.name
+    assert_selector 'div', text: 'Displaying 1 of 1 matching users'
     assert_selector 'tbody tr', count: 1
     assert_selector 'tbody tr:first-child th[scope="row"]', text: admin.email
 

--- a/test/system/communities_pagination_and_sort_test.rb
+++ b/test/system/communities_pagination_and_sort_test.rb
@@ -3,114 +3,77 @@ require 'application_system_test_case'
 class CommunitiesPaginationAndSortTest < ApplicationSystemTestCase
 
   setup do
-    # for some runs/seeds (like SEED=1099), stale Communities are left over from other tests.
-    # We need to assume the communities created here are the only ones!
-    Community.delete_all
-
-    admin = users(:user_admin)
-    (0..10).each do |i|
-      Community.new(title: format("#{random_title(i)} Community %02i", i), owner_id: admin.id).save!
+    @default_per_page = 10
+    Kaminari.configure do |c|
+      @default_per_page = c.default_per_page
+      c.default_per_page = 3
     end
   end
 
-  # rubocop:disable Minitest/MultipleAssertions
-  # TODO: our tests are quite smelly.  This one needs work!
-  # TODO: Slow test
-  test 'anybody should be able to sort and paginate communities' do
-    # for some runs/seeds (like SEED=1099), stale Communities are left over from other tests. We can't assume the
-    # communities created here are the only ones! This test needs to be re-written
-    # For sorting, creation order is 'Fancy Community 00', 'Nice Community 01', 'Fancy Community 02', etc. ...
-    #
-    # Try SEED=8921
+  teardown do
+    Kaminari.configure { |c| c.default_per_page = @default_per_page }
+  end
 
+  test 'anybody should be able to paginate communities' do
     visit communities_path
 
-    assert_selector 'div', text: '1 - 10 of 11'
-    # Default sort is by title. First 6 say 'Fancy', last 4 say 'Nice'
-    assert_selector 'li:first-child a', text: 'Fancy Community 00'
-    assert_selector 'li:nth-child(2) a', text: 'Fancy Community 02'
-    assert_selector 'li:nth-child(9) a', text: 'Nice Community 05'
-    assert_selector 'li:last-child a', text: 'Nice Community 07'
+    assert_selector 'div', text: '1 - 3 of 4'
+    assert_selector 'li:first-child a', text: 'Books'
+    assert_selector 'li:nth-child(2) a', text: 'Community with no collections'
+    assert_selector 'li:last-child a', text: 'Fancy Community'
 
     # The last one should be on next page
-    refute_selector 'a', text: 'Nice Community 09'
+    refute_selector 'a', text: 'Thesis'
     click_link 'Next'
     assert_equal URI.parse(current_url).request_uri, communities_path(page: '2')
-    assert_selector 'div', text: '11 - 11 of 11'
-    assert_selector 'li:first-child a', text: 'Nice Community 09'
+    assert_selector 'div', text: '4 - 4 of 4'
+    assert_selector 'li:first-child a', text: 'Thesis'
+  end
 
-    # Sort links
+  test 'anybody should be able to sort by title descending and ascending' do
+    visit communities_path
+
     click_button 'Sort by'
-    assert_selector 'a', text: 'Title (A-Z)'
-    assert_selector 'a', text: 'Title (Z-A)'
-    assert_selector 'a', text: 'Date (newest first)'
-    assert_selector 'a', text: 'Date (oldest first)'
 
     # Reverse sort
     click_link 'Title (Z-A)'
     assert_equal URI.parse(current_url).request_uri, communities_path(sort: 'title', direction: 'desc')
-    assert_selector 'div', text: '1 - 10 of 11'
     assert_selector 'button', text: 'Title (Z-A)'
-    assert_selector 'li:first-child a', text: 'Nice Community 09'
-    assert_selector 'li:nth-child(2) a', text: 'Nice Community 07'
-    assert_selector 'li:nth-child(9) a', text: 'Fancy Community 04'
-    assert_selector 'li:last-child a', text: 'Fancy Community 02'
-    # The first 'Fancy' community should be on next page
-    refute_selector 'a', text: 'Fancy Community 00'
-    click_link 'Next'
-    assert_equal URI.parse(current_url).request_uri, communities_path(sort: 'title', direction: 'desc', page: '2')
-    assert_selector 'div', text: '11 - 11 of 11'
-    assert_selector 'li:first-child a', text: 'Fancy Community 00'
+    assert_selector 'li:first-child a', text: 'Thesis'
+    assert_selector 'li:nth-child(2) a', text: 'Fancy Community'
+    assert_selector 'li:last-child a', text: 'Community with no collections'
 
     # Sort the other way again
     click_button 'Title (Z-A)'
     click_link 'Title (A-Z)'
     assert_equal URI.parse(current_url).request_uri, communities_path(sort: 'title', direction: 'asc')
     assert_selector 'button', text: 'Title (A-Z)'
-    assert_selector 'div', text: '1 - 10 of 11'
-    # Default sort is by title. First 6 say 'Fancy', last 4 say 'Nice'
-    assert_selector 'li:first-child a', text: 'Fancy Community 00'
-    assert_selector 'li:nth-child(2) a', text: 'Fancy Community 02'
-    assert_selector 'li:nth-child(9) a', text: 'Nice Community 05'
-    assert_selector 'li:last-child a', text: 'Nice Community 07'
+    assert_selector 'li:first-child a', text: 'Books'
+    assert_selector 'li:nth-child(2) a', text: 'Community with no collections'
+    assert_selector 'li:last-child a', text: 'Fancy Community'
+  end
+
+  test 'anybody should be able to sort by date descending and ascending' do
+    visit communities_path
+
+    click_button 'Sort by'
 
     # Sort with newest first
-    click_button 'Title (A-Z)'
     click_link 'Date (newest first)'
     assert_equal URI.parse(current_url).request_uri, communities_path(sort: 'record_created_at', direction: 'desc')
     assert_selector 'button', text: 'Date (newest first)'
-    assert_selector 'div', text: '1 - 10 of 11'
-    assert_selector 'li:first-child a', text: 'Fancy Community 10'
-    assert_selector 'li:nth-child(2) a', text: 'Nice Community 09'
-    assert_selector 'li:nth-child(9) a', text: 'Fancy Community 02'
-    assert_selector 'li:last-child a', text: 'Nice Community 01'
-    # The first 'Fancy' community should be on next page
-    refute_selector 'a', text: 'Fancy Community 00'
-    click_link 'Next'
-    assert_equal URI.parse(current_url).request_uri, communities_path(sort: 'record_created_at',
-                                                                      direction: 'desc', page: '2')
-    assert_selector 'div', text: '11 - 11 of 11'
-    assert_selector 'li:first-child a', text: 'Fancy Community 00'
+    assert_selector 'li:first-child a', text: 'Books'
+    assert_selector 'li:nth-child(2) a', text: 'Thesis'
+    assert_selector 'li:last-child a', text: 'Fancy Community'
 
     # Sort with oldest first
     click_button 'Date (newest first)'
     click_link 'Date (oldest first)'
     assert_equal URI.parse(current_url).request_uri, communities_path(sort: 'record_created_at', direction: 'asc')
     assert_selector 'button', text: 'Date (oldest first)'
-    assert_selector 'div', text: '1 - 10 of 11'
-    assert_selector 'li:first-child a', text: 'Fancy Community 00'
-    assert_selector 'li:nth-child(2) a', text: 'Nice Community 01'
-    assert_selector 'li:nth-child(9) a', text: 'Fancy Community 08'
-    assert_selector 'li:last-child a', text: 'Nice Community 09'
-    # The Last 'Fancy' community should be on next page
-    refute_selector 'a', text: 'Fancy Community 10'
-
-    click_link 'Next'
-    assert_equal URI.parse(current_url).request_uri, communities_path(sort: 'record_created_at',
-                                                                      direction: 'asc', page: '2')
-    assert_selector 'div', text: '11 - 11 of 11'
-    assert_selector 'li:first-child a', text: 'Fancy Community 10'
+    assert_selector 'li:first-child a', text: 'Community with no collections'
+    assert_selector 'li:nth-child(2) a', text: 'Fancy Community'
+    assert_selector 'li:last-child a', text: 'Thesis'
   end
-  # rubocop:enable Minitest/MultipleAssertions
 
 end


### PR DESCRIPTION
## Context

I've notice that the admin users index test will fail intermittently in our dependabot PRs.  Since it is a broken window I made time to fix it.  #2129

While I was investigating that the test to excercise sorting and pagination of communities failed.  I also took some time to address this test as well. #2419

Before:
![image](https://user-images.githubusercontent.com/1220762/128537364-3a98067c-6fb7-4876-9c7a-676a22407a7c.png)
After:
![image](https://user-images.githubusercontent.com/1220762/128537109-d1ef543a-2da0-45f9-9ed0-b8c9eef5af6b.png)

## What's New

- Fixed test that exercises sorting

The selector will partially match the page before it's been updated and give a negative result.  First checking for something that has changed on the page will ensure that the following assertions will have a chance to succeed.

- Refactored one of our smelliest tests

Prefer using fixtures to creating new objects.

This test had many assertions  which is contrary to the imperative to test only one thing at a time.
