### PR TITLE
Some Adjustments to the `Digitization::Book` Model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,7 @@ Further discussion of the context can be found at [#2119](https://github.com/ual
 - Bump rubocop-minitest to 0.14.0 and note really smelly tests [PR#2416](https://github.com/ualbertalib/jupiter/pull/2416)
 - Fixed a flaky test where the page hasn't finished loading [#2129](https://github.com/ualbertalib/jupiter/issues/2129)
 - Refactored one of our smelliest tests to use fixtures and reduce number of assertions per test [#2419](https://github.com/ualbertalib/jupiter/issues/2419)
+- Make Digitization::Book more like other items and other small fixes
 
 ## [2.0.2] - 2020-12-17
 - Enable Skylight in the Staging environment and remove it from the UAT environment (where it was unused, and the performance of the Docker environment is less likely to be similar to Production)

--- a/app/models/digitization/book.rb
+++ b/app/models/digitization/book.rb
@@ -3,7 +3,6 @@ class Digitization::Book < JupiterCore::Depositable
   acts_as_rdfable
 
   has_one_attached :historical_archive
-  has_many_attached :files, dependent: false
   has_one :fulltext, dependent: :destroy, class_name: 'Digitization::Fulltext', inverse_of: :book,
                      foreign_key: :digitization_book_id
 

--- a/app/models/digitization/book.rb
+++ b/app/models/digitization/book.rb
@@ -1,7 +1,9 @@
 class Digitization::Book < JupiterCore::Depositable
 
+  acts_as_rdfable
+
   has_one_attached :historical_archive
-  has_one_attached :pdf, dependent: false
+  has_many_attached :files, dependent: false
   has_one :fulltext, dependent: :destroy, class_name: 'Digitization::Fulltext', inverse_of: :book,
                      foreign_key: :digitization_book_id
 
@@ -30,7 +32,7 @@ class Digitization::Book < JupiterCore::Depositable
   validates :temporal_subjects, edtf: true
 
   def all_subjects
-    topical_subjects + temporal_subjects + geographic_subjects
+    topical_subjects + temporal_subjects.to_a + geographic_subjects.to_a
   end
 
   def all_contributors

--- a/config/controlled_vocabularies/digitization/genre.raw.yml
+++ b/config/controlled_vocabularies/digitization/genre.raw.yml
@@ -1,2 +1,2 @@
 genre:
-  'Programs (Publications)': https://id.loc.gov/authorities/genreForms/gf2014026156.html
+  'Programs (Publications)': http://id.loc.gov/authorities/genreForms/gf2014026156

--- a/db/migrate/20210422161911_rename_columns_in_digitization_book.rb
+++ b/db/migrate/20210422161911_rename_columns_in_digitization_book.rb
@@ -19,7 +19,7 @@ class RenameColumnsInDigitizationBook < ActiveRecord::Migration[6.0]
       t.dates_issued has_predicate: ::RDF::Vocab::DC.issued
       t.temporal_subjects has_predicate: ::RDF::Vocab::SCHEMA.temporalCoverage
       t.title has_predicate: ::RDF::Vocab::DC.title
-      t.alternative_title has_predicate: ::RDF::Vocab::DC.alternative
+      t.alternative_titles has_predicate: ::RDF::Vocab::DC.alternative
       t.resource_type has_predicate: ::RDF::Vocab::DC.type
       t.genres has_predicate: ::RDF::Vocab::EDM.hasType
       t.languages has_predicate: ::RDF::Vocab::DC.language
@@ -28,7 +28,7 @@ class RenameColumnsInDigitizationBook < ActiveRecord::Migration[6.0]
       t.extent has_predicate: ::TERMS[:rdau].extent
       t.notes has_predicate: ::RDF::Vocab::SKOS.note
       t.geographic_subjects has_predicate: ::RDF::Vocab::DC11.coverage
-      t.rights has_predicate: ::RDF::Vocab::DC11.rights
+      t.rights has_predicate: ::RDF::Vocab::EDM.rights
       t.topical_subjects has_predicate: ::RDF::Vocab::DC11.subject
     end
   end

--- a/db/migrate/20210422161911_rename_columns_in_digitization_book.rb
+++ b/db/migrate/20210422161911_rename_columns_in_digitization_book.rb
@@ -11,6 +11,7 @@ class RenameColumnsInDigitizationBook < ActiveRecord::Migration[6.0]
       t.rename :note, :notes
       t.rename :geographic_subject, :geographic_subjects
       t.rename :topical_subject, :topical_subjects
+      t.references :logo, foreign_key: {to_table: :active_storage_attachments, column: :id, on_delete: :nullify}
     end
 
     remove_rdf_table_annotations :digitization_books

--- a/db/migrate/20210422161911_rename_columns_in_digitization_book.rb
+++ b/db/migrate/20210422161911_rename_columns_in_digitization_book.rb
@@ -11,7 +11,6 @@ class RenameColumnsInDigitizationBook < ActiveRecord::Migration[6.0]
       t.rename :note, :notes
       t.rename :geographic_subject, :geographic_subjects
       t.rename :topical_subject, :topical_subjects
-      t.references :logo, foreign_key: {to_table: :active_storage_attachments, column: :id, on_delete: :nullify}
     end
 
     remove_rdf_table_annotations :digitization_books
@@ -20,7 +19,7 @@ class RenameColumnsInDigitizationBook < ActiveRecord::Migration[6.0]
       t.dates_issued has_predicate: ::RDF::Vocab::DC.issued
       t.temporal_subjects has_predicate: ::RDF::Vocab::SCHEMA.temporalCoverage
       t.title has_predicate: ::RDF::Vocab::DC.title
-      t.alternative_titles has_predicate: ::RDF::Vocab::DC.alternative
+      t.alternative_title has_predicate: ::RDF::Vocab::DC.alternative
       t.resource_type has_predicate: ::RDF::Vocab::DC.type
       t.genres has_predicate: ::RDF::Vocab::EDM.hasType
       t.languages has_predicate: ::RDF::Vocab::DC.language
@@ -29,7 +28,7 @@ class RenameColumnsInDigitizationBook < ActiveRecord::Migration[6.0]
       t.extent has_predicate: ::TERMS[:rdau].extent
       t.notes has_predicate: ::RDF::Vocab::SKOS.note
       t.geographic_subjects has_predicate: ::RDF::Vocab::DC11.coverage
-      t.rights has_predicate: ::RDF::Vocab::EDM.rights
+      t.rights has_predicate: ::RDF::Vocab::DC11.rights
       t.topical_subjects has_predicate: ::RDF::Vocab::DC11.subject
     end
   end

--- a/db/migrate/20210825195251_further_rename_columns_in_digitization_book.rb
+++ b/db/migrate/20210825195251_further_rename_columns_in_digitization_book.rb
@@ -1,0 +1,11 @@
+class FurtherRenameColumnsInDigitizationBook < ActiveRecord::Migration[6.0]
+  def change
+    add_reference :digitization_books, :logo, foreign_key: {to_table: :active_storage_attachments, column: :id, on_delete: :nullify}
+
+    delete_column_annotation :digitization_books, :alternative_title
+    add_rdf_column_annotation :digitization_books, :alternative_titles, has_predicate: ::RDF::Vocab::DC.alternative
+
+    delete_column_annotation :digitization_books, :rights
+    add_rdf_column_annotation :digitization_books, :rights, has_predicate: ::RDF::Vocab::EDM.rights
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_01_042208) do
+ActiveRecord::Schema.define(version: 2021_08_25_195251) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -135,12 +135,12 @@ ActiveRecord::Schema.define(version: 2021_06_01_042208) do
     t.string "geographic_subjects", array: true
     t.string "rights"
     t.string "topical_subjects", array: true
-    t.bigint "logo_id"
     t.string "volume_label"
     t.datetime "date_ingested", null: false
     t.datetime "record_created_at"
     t.string "visibility"
     t.bigint "owner_id", null: false
+    t.bigint "logo_id"
     t.index ["logo_id"], name: "index_digitization_books_on_logo_id"
     t.index ["owner_id"], name: "index_digitization_books_on_owner_id"
     t.index ["peel_id", "run", "part_number"], name: "unique_peel_book", unique: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -135,11 +135,13 @@ ActiveRecord::Schema.define(version: 2021_06_01_042208) do
     t.string "geographic_subjects", array: true
     t.string "rights"
     t.string "topical_subjects", array: true
+    t.bigint "logo_id"
     t.string "volume_label"
     t.datetime "date_ingested", null: false
     t.datetime "record_created_at"
     t.string "visibility"
     t.bigint "owner_id", null: false
+    t.index ["logo_id"], name: "index_digitization_books_on_logo_id"
     t.index ["owner_id"], name: "index_digitization_books_on_owner_id"
     t.index ["peel_id", "run", "part_number"], name: "unique_peel_book", unique: true
   end
@@ -462,6 +464,7 @@ ActiveRecord::Schema.define(version: 2021_06_01_042208) do
   add_foreign_key "batch_ingests", "users"
   add_foreign_key "collections", "users", column: "owner_id"
   add_foreign_key "communities", "users", column: "owner_id"
+  add_foreign_key "digitization_books", "active_storage_attachments", column: "logo_id", on_delete: :nullify
   add_foreign_key "digitization_books", "users", column: "owner_id"
   add_foreign_key "digitization_fulltexts", "digitization_books"
   add_foreign_key "digitization_images", "users", column: "owner_id"


### PR DESCRIPTION
## Context

Faced with real data about the folk fest items demonstrated that I had introduced some errors. 

Choosing to call the attachment `pdf` earlier was limiting.  For Items and Thesis these attachments have been called `files`.  By making this change now we can reuse the `DownloadController` and `files_section_sidebar` partial.

Related to #2011

## What's New

- fix URI and correct predicates
- Making Book act as rdfable will allow us to use the predicate relationships later.
- change `pdf` to `files`