### PR TITLE
`Digitization::Book` view completed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@ Further discussion of the context can be found at [#2119](https://github.com/ual
 - Make `Digitization::Map` `Depositable`
 - Fixture names have been modified to ensure their uniqueness [PR#2302](https://github.com/ualbertalib/jupiter/pull/2302)
 - Rails upgraded to 6.0.3.7 to resolve security issues
+- Refactored item download/view behaviour in routes and views to be reusable in digitization namespace and application wide
 
 ### Fixed
 - bump rubocop and fix cop violations [PR#2072](https://github.com/ualbertalib/jupiter/pull/2072)

--- a/app/decorators/thesis_decorator.rb
+++ b/app/decorators/thesis_decorator.rb
@@ -17,4 +17,10 @@ class ThesisDecorator < ApplicationDecorator
     strip_markdown(model.abstract)
   end
 
+  # We want to treat thesis the same as items in a lot of cases
+  # specifically when we're building links to download/view the items
+  def model_name
+    Item.model_name
+  end
+
 end

--- a/app/policies/digitization/book_policy.rb
+++ b/app/policies/digitization/book_policy.rb
@@ -4,4 +4,12 @@ class Digitization::BookPolicy < ApplicationPolicy
     true
   end
 
+  def thumbnail?
+    true
+  end
+
+  def download?
+    true
+  end
+
 end

--- a/app/views/application/_files_section_sidebar.html.erb
+++ b/app/views/application/_files_section_sidebar.html.erb
@@ -1,26 +1,26 @@
 <div class="mb-3">
   <div class="d-flex justify-content-center">
-    <%= render partial: 'feature_image', locals: { object: @item } %>
+    <%= render partial: 'feature_image', locals: { object: item } %>
   </div>
 
-  <% if policy(@item).download? %>
-    <% if @item.files.count == 1 %>
-      <% file = @item.files.first %>
+  <% if policy(item).download? %>
+    <% if item.files.count == 1 %>
+      <% file = item.files.first %>
       <% if file.present? && file.fileset_uuid.present? %>
         <div class="d-flex justify-content-center mt-3">
           <div class="p-1">
             <%= link_to(t('.view'),
-                        file_view_item_url(id: file.record.id,
-                                           file_set_id: file.fileset_uuid,
-                                           file_name: file.filename.to_s),
+                        send("file_view_#{item.model_name.singular}_url", id: file.record.id,
+                                                                          file_set_id: file.fileset_uuid,
+                                                                          file_name: file.filename.to_s),
                         class: 'btn btn-outline-primary',
                         rel: 'noopener noreferrer',
                         target: :_blank) %>
           </div>
           <div class="p-1">
             <%= link_to(t('.download'),
-                        file_download_item_url(id: file.record.id,
-                                               file_set_id: file.fileset_uuid),
+                        send("file_download_#{item.model_name.singular}_url", id: file.record.id,
+                                                                              file_set_id: file.fileset_uuid),
                         class: 'btn btn-outline-primary',
                         rel: 'nofollow',
                         download: file.filename) %>
@@ -32,24 +32,24 @@
         <div class="card-header"><%= t('.header') %></div>
         <div class="card-body p-2">
           <div class="list-group item-files">
-            <% @item.files.each do |file| %>
+            <% item.files.each do |file| %>
               <div class="list-group-item list-group-item-action d-flex flex-column">
                 <div class="item-filename text-center pb-3"><%= file.filename %></div>
                 <% if file.fileset_uuid.present? %>
                   <div class="d-flex justify-content-center">
                     <div class="p-1">
                       <%= link_to(t('.view'),
-                                  file_view_item_url(id: file.record.id,
-                                                     file_set_id: file.fileset_uuid,
-                                                     file_name: file.filename.to_s),
+                                  send("file_view_#{item.model_name.singular}_url", id: file.record.id,
+                                                                                    file_set_id: file.fileset_uuid,
+                                                                                    file_name: file.filename.to_s),
                                   class: 'btn btn-outline-primary',
                                   rel: 'noopener noreferrer',
                                   target: :_blank) %>
                     </div>
                     <div class="p-1">
                       <%= link_to(t('.download'),
-                                  file_download_item_url(id: file.record.id,
-                                                         file_set_id: file.fileset_uuid),
+                                  send("file_download_#{item.model_name.singular}_url", id: file.record.id,
+                                                                                        file_set_id: file.fileset_uuid),
                                   class: 'js-download btn btn-outline-primary',
                                   rel: 'nofollow',
                                   download: file.filename) %>
@@ -60,7 +60,7 @@
             <% end %>
           </div>
           <div class="pt-2">
-            <% unless @item.files.any? {|file| file.fileset_uuid.blank?} %>
+            <% unless item.files.any? {|file| file.fileset_uuid.blank?} %>
               <button type="button" class="js-download-all btn btn-outline-primary float-right">
                 <%= t('.download_all') %>
               </button>

--- a/app/views/digitization/books/show.html.erb
+++ b/app/views/digitization/books/show.html.erb
@@ -36,7 +36,7 @@
     <div class="col-md-4 mt-5">
       <%# FILES SIDEBAR %>
       <% if @digitization_book.files.present? %>
-        <%= render partial: 'files_section_sidebar' %>
+        <%= render partial: 'files_section_sidebar', locals: { item: @digitization_book } %>
       <% end %>
 
       <%# COMMUNITY/COLLECTION PATHS %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -38,7 +38,7 @@
     <div class="col-md-4 mt-5">
       <%# FILES SIDEBAR %>
       <% if @item.files.present? %>
-        <%= render partial: 'files_section_sidebar' %>
+        <%= render partial: 'files_section_sidebar', locals: { item: @item } %>
       <% end %>
 
       <%# COMMUNITY/COLLECTION PATHS %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -225,6 +225,8 @@ en:
       download: 'Download'
       download_all: 'Download All'
       header: 'Files'
+      ccid_restricted_item: Item Restricted to University of Alberta Users
+      login_with_ccid_to_view: Log In with CCID to View Item
 
   layouts:
     admin:
@@ -648,13 +650,6 @@ en:
       committee_members: 'Examining committee members and their departments'
     thumbnail:
       thumbnail: 'thumbnail'
-    files_section_sidebar:
-      view: 'View'
-      download: 'Download'
-      download_all: 'Download All'
-      header: 'Files'
-      ccid_restricted_item: Item Restricted to University of Alberta Users
-      login_with_ccid_to_view: Log In with CCID to View Item
     admin_sidebar:
       admin: 'Admin'
       reset_doi: 'Reset DOI'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -220,6 +220,11 @@ en:
       skip_to_results: 'Skip to Search Results'
     range_facet_result:
       to: 'to'
+    files_section_sidebar:
+      view: 'View'
+      download: 'Download'
+      download_all: 'Download All'
+      header: 'Files'
 
   layouts:
     admin:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,7 +10,14 @@ Rails.application.routes.draw do
 
     root to: 'welcome#index'
 
-    resources :items, only: [:show, :edit] do
+    concern :downloadable do
+      member do
+        get 'download/:file_set_id', to: DownloadsController.action(:download), format: false, as: 'file_download'
+        get 'view/:file_set_id/*file_name', to: DownloadsController.action(:view), format: false, as: 'file_view'
+      end
+    end
+
+    resources :items, only: [:show, :edit], concerns: :downloadable do
       collection do
         post :create_draft, controller: 'items/draft', action: :create
       end
@@ -22,11 +29,6 @@ Rails.application.routes.draw do
         member do
           patch :set_thumbnail
         end
-      end
-
-      member do
-        get 'download/:file_set_id', to: 'downloads#download', format: false, as: 'file_download'
-        get 'view/:file_set_id/*file_name', to: 'downloads#view', format: false, as: 'file_view'
       end
     end
 
@@ -177,7 +179,7 @@ Rails.application.routes.draw do
     get '/maps/:peel_map_id', to: 'digitization/redirect#peel_map', peel_map_id: /M[0-9]{6}/
 
     scope module: 'digitization', as: 'digitization', only: [:index, :show] do
-      resources :books, :newspapers, :images, :maps
+      resources :books, :newspapers, :images, :maps, concerns: :downloadable
     end
   end
 end


### PR DESCRIPTION
## Context

While working through the ingest tasks I wanted the visual feedback that everything was working as expected.  This led to ensuring that the download/view links worked on the page.  Initially they were directing into the era subdomain, which worked but might be confusing to our users.

Related to #2011

## What's New

![image (1)](https://user-images.githubusercontent.com/1220762/129272034-6823bc6c-1bd0-423e-a9a8-371e31c25fae.png)
