### PR TITLE
Change subdomain for digitalcollections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ Further discussion of the context can be found at [#2119](https://github.com/ual
 - Add batch ingest controller and views for CRUDing batch ingests [#1986](https://github.com/ualbertalib/jupiter/issues/1986)
 - Add batch ingest form with google file picker and spreadsheet validation [#1986](https://github.com/ualbertalib/jupiter/issues/1986)
 - Add batch ingestion job for batch ingesting items into ERA [#1986](https://github.com/ualbertalib/jupiter/issues/1986)
+- Add 'digitalcollections' subdomain for future front door
 
 ### Removed
 - Remove entirely unnecessary config file. [PR#2044](https://github.com/ualbertalib/jupiter/pull/2044)

--- a/README.md
+++ b/README.md
@@ -68,11 +68,11 @@ Jupiter runs under subdomains. So you will need to configure your local environm
 
 ```
 127.0.0.1       era.demo.com
-127.0.0.1       digitization.demo.com
+127.0.0.1       digitalcollections.demo.com
 ```
-Once this is done, you can navigate to `era.demo.com:3000` or `digitization.demo.com:3000` to access your development environment.
+Once this is done, you can navigate to `era.demo.com:3000` or `digitalcollections.demo.com:3000` to access your development environment.
 
-Some alternatives is you may also use the `localhost` top level domain (e.g: you can just navigate to `era.ualberta.localhost:3000` or `digitization.ualberta.localhost:3000` to access your development environment without configuring `/etc/hosts` ). Another alternative is you can use services like `lvh.me` (e.g: navigate to `era.lvh.me:3000` or `digitization.lvh.me:3000` to access your development environment).
+Some alternatives is you may also use the `localhost` top level domain (e.g: you can just navigate to `era.ualberta.localhost:3000` or `digitalcollections.ualberta.localhost:3000` to access your development environment without configuring `/etc/hosts` ). Another alternative is you can use services like `lvh.me` (e.g: navigate to `era.lvh.me:3000` or `digitalcollections.lvh.me:3000` to access your development environment).
 
 # UAT Environment
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -69,5 +69,5 @@ Rails.application.configure do
   config.action_controller.action_on_unpermitted_parameters = :raise
 
   config.hosts << 'era.lvh.me'
-  config.hosts << 'digitization.lvh.me'
+  config.hosts << 'digitalcollections.lvh.me'
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -164,7 +164,7 @@ Rails.application.routes.draw do
       end
     end
   end
-  constraints(subdomain: 'digitization') do
+  constraints(subdomain: 'digitalcollections') do
     ## Peel URL redirects
     get '/bibliography/:peel_id(/*page)', to: 'digitization/redirect#peel_book'
     get '/bibliography/:peel_id.:part_number(/*page)', to: 'digitization/redirect#peel_book'

--- a/test/controllers/digitization/redirect_controller_test.rb
+++ b/test/controllers/digitization/redirect_controller_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 class Digitization::RedirectControllerTest < ActionDispatch::IntegrationTest
 
   setup do
-    host! URI('http://digitization.ualberta.localhost').host
+    host! URI('http://digitalcollections.ualberta.localhost').host
   end
 
   test 'should not find the requested book' do

--- a/test/system/digitization/book_show_test.rb
+++ b/test/system/digitization/book_show_test.rb
@@ -3,7 +3,7 @@ require 'application_system_test_case'
 class Digitization::BookShowTest < ApplicationSystemTestCase
 
   setup do
-    host! 'http://digitization.ualberta.localhost'
+    host! 'http://digitalcollections.ualberta.localhost'
   end
   test 'Books are working correctly' do
     visit digitization_book_url(digitization_books(:folk_fest))


### PR DESCRIPTION
## Context

I had erroneously conflated the namespace that we created for the difference between ERA models and Digitization models was also the subdomain for the digitalcollections url.  This decision was made in October 2020 and the ip address was allocated for digitalcollections.library.ualberta.ca in December 2020.

## What's New

Changed the subdomain and references from `digitization` to `digitalcollections`