### PR TITLE
Edit History of Deleted Collection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,18 +12,18 @@ and releases in Jupiter project adheres to [Semantic Versioning](http://semver.o
 - Updated Architecture diagrams [PR#2135](https://github.com/ualbertalib/jupiter/pull/2135)
 
 ### Removed
-– Remove entirely unnecessary config file. [PR#2044](https://github.com/ualbertalib/jupiter/pull/2044)
-– Completely disable logging of warnings around the "excel spreadsheet" issue [PR#2049](https://github.com/ualbertalib/jupiter/pull/2049)
+- Remove entirely unnecessary config file. [PR#2044](https://github.com/ualbertalib/jupiter/pull/2044)
+- Completely disable logging of warnings around the "excel spreadsheet" issue [PR#2049](https://github.com/ualbertalib/jupiter/pull/2049)
 
 ### Changed
 - Added DOI reset feature for admins [#1739](https://github.com/ualbertalib/jupiter/issues/1739)
-– Turn off reporting things like "this excel spreadsheet isn't thumbnailable" as warnings to Rollbar [PR#2046](https://github.com/ualbertalib/jupiter/pull/2046)
+- Turn off reporting things like "this excel spreadsheet isn't thumbnailable" as warnings to Rollbar [PR#2046](https://github.com/ualbertalib/jupiter/pull/2046)
 - migration to fix concatenated subjects (part 2) [#1449](https://github.com/ualbertalib/jupiter/issues/1449)
 - Catch and log embargo expiry job save errors [#1989](https://github.com/ualbertalib/jupiter/issues/1989)
 - Don't send failures to SessionController in development environment [PR#2121](https://github.com/ualbertalib/jupiter/pull/2121) 
-– Rails upgraded to 6.0.3.6 to resolve certain issues with community dependencies
+- Rails upgraded to 6.0.3.6 to resolve certain issues with community dependencies
 - Fixture names have been modified to ensure their uniqueness [PR#2302](https://github.com/ualbertalib/jupiter/pull/2302) 
-– Rails upgraded to 6.0.3.7 to resolve security issues
+- Rails upgraded to 6.0.3.7 to resolve security issues
 - Added Collection and Community to reindex rake task [#2444](https://github.com/ualbertalib/jupiter/issues/2444)
 
 ### Fixed
@@ -35,14 +35,19 @@ and releases in Jupiter project adheres to [Semantic Versioning](http://semver.o
 - bump rubocop and fix more cop violations [PR#2132](https://github.com/ualbertalib/jupiter/pull/2132)
 - Various fixes from lighthouse suggestions [PR#2254](https://github.com/ualbertalib/jupiter/pull/2254)
 - Danger token in Github Actions [#2282](https://github.com/ualbertalib/jupiter/issues/2282)
+- Fix issue where we improperly 404'd when a deleted Collection is being displayed in the edit history [#2504](https://github.com/ualbertalib/jupiter/issues/2504)
+
+## [2.0.3] - 2021-05-05
+
+- Rails critical CVE fixes
 
 ## [2.0.2] - 2020-12-17
 
-– Fix issue where we improperly 500'd when a file download URL referenced a non-existent fileset UUID, instead of 404ing
+- Fix issue where we improperly 500'd when a file download URL referenced a non-existent fileset UUID, instead of 404ing
 - Make reindex rake task actually reindex all of the objects into Solr, instead of acting as a no-op
-– Fix a mis-named error rescue that resulted in a crash when the sort field wasn't known for a model
+- Fix a mis-named error rescue that resulted in a crash when the sort field wasn't known for a model
 - Fix nil start or end faceting dates error [PR#2041](https://github.com/ualbertalib/jupiter/pull/2041)
-– Try to better handle the logo deletion circular constraint (next step: dropping it entirely)
+- Try to better handle the logo deletion circular constraint (next step: dropping it entirely)
 
 ## [2.0.1] - 2020-12-14
 

--- a/app/decorators/humanized_change_set.rb
+++ b/app/decorators/humanized_change_set.rb
@@ -15,8 +15,12 @@ class HumanizedChangeSet
 
   def user_info
     if @whodunnit.present?
-      user = User.find(@whodunnit)
-      user_info = "#{user.name} - #{user.email}"
+      user = User.find_by(id: @whodunnit)
+      user_info = if user.present?
+                    "#{user.name} - #{user.email}"
+                  else
+                    @whodunnit
+                  end
     else
       user_info = 'Unknown'
     end

--- a/app/decorators/humanized_change_set.rb
+++ b/app/decorators/humanized_change_set.rb
@@ -175,8 +175,8 @@ class HumanizedChangeSet
 
       change_item.map do |path|
         community_id, collection_id = path.split('/')
-        community_title = Community.find(community_id).title
-        collection_title = Collection.find(collection_id).title
+        community_title = Community.find_by(id: community_id)&.title || community_id.to_s
+        collection_title = Collection.find_by(id: collection_id)&.title || collection_id.to_s
         "#{community_title}/#{collection_title}"
       end
     end

--- a/app/views/items/_edit_history.html.erb
+++ b/app/views/items/_edit_history.html.erb
@@ -30,8 +30,10 @@
           <dd><%= changeset.user_info %></dd>
         </dl>
         <% changeset.html_diffs.each do |html_diff| %>
-          <dt><%= html_diff[:attribute] %></dt>
-          <dd><%= html_diff[:html] %></dd>
+          <dl>
+            <dt><%= html_diff[:attribute] %></dt>
+            <dd><%= html_diff[:html] %></dd>
+          </dl>
         <% end %>
       </li>
     <% end %>

--- a/app/views/items/_edit_history.html.erb
+++ b/app/views/items/_edit_history.html.erb
@@ -19,9 +19,12 @@
   </div>
 
   <div class="collapse" id='edit-history-hidden'>
+    <div id='edit-history-explainer' class="bg-light p-3 border border-primary rounded list-group my-3  ">
+      <%= t(:edit_history_explainer_html) %>
+    </div>
     <% @item.history.reverse_each do |changeset| %>
       <li class="list-unstyled list-group-item-action">
-        <h3><%= changeset.date %></h3>
+        <h2 class='h3'><%= changeset.date %></h3>
         <dl>
           <dt><%= t(:edited_by) %></dt>
           <dd><%= changeset.user_info %></dd>

--- a/app/views/items/_edit_history.html.erb
+++ b/app/views/items/_edit_history.html.erb
@@ -20,7 +20,17 @@
 
   <div class="collapse" id='edit-history-hidden'>
     <div id='edit-history-explainer' class="bg-light p-3 border border-primary rounded list-group my-3  ">
-      <%= t(:edit_history_explainer_html) %>
+      <h2 class='h4'><%= t(:edit_history_explainer_title) %></h2>
+      <ul>
+        <li>
+          <p><%= t(:edit_history_explainer_styles_title) %></p>
+          <p><%= t(:edit_history_explainer_styles_content_html) %></p>
+        </li>
+        <li>
+          <p><%= t(:edit_history_explainer_deleted_title) %></p>
+          <p><%= t(:edit_history_explainer_deleted_content) %></p>
+        </li>
+      </ul>
     </div>
     <% @item.history.reverse_each do |changeset| %>
       <li class="list-unstyled list-group-item-action">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -44,6 +44,18 @@ en:
   edit: 'Edit'
   edited_by: 'Edited by'
   edit_history: 'Edit history ...'
+  edit_history_explainer_html: |
+    <h2 class='h4'>Note about how changes are shown</h2>
+    <ul>
+      <li>
+        <p>We use these styles for each change: </p>
+        <p>Unchanged<del class="differ">Old</del><ins class="differ">New</ins></p>
+      </li>
+      <li>
+        <p>When part of the history has been deleted we will show only the id:</p>
+        <p>e.g. 00000000-0000-0000-0000-000000000000</p>
+      </li>
+    </ul>
   filter_by: 'Filter by'
   home: 'Home'
   hide_edit_history: 'Hide edit history ...'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -44,18 +44,11 @@ en:
   edit: 'Edit'
   edited_by: 'Edited by'
   edit_history: 'Edit history ...'
-  edit_history_explainer_html: |
-    <h2 class='h4'>Note about how changes are shown</h2>
-    <ul>
-      <li>
-        <p>We use these styles for each change: </p>
-        <p>Unchanged<del class="differ">Old</del><ins class="differ">New</ins></p>
-      </li>
-      <li>
-        <p>When part of the history has been deleted we will show only the id:</p>
-        <p>e.g. 00000000-0000-0000-0000-000000000000</p>
-      </li>
-    </ul>
+  edit_history_explainer_title: 'Note about how changes are shown'
+  edit_history_explainer_styles_title: 'We use these styles for each change:'
+  edit_history_explainer_styles_content_html: 'Unchanged<del class="differ">Old</del><ins class="differ">New</ins>'
+  edit_history_explainer_deleted_title: 'When part of the history has been deleted we will show only the id:'
+  edit_history_explainer_deleted_content: 'e.g. 00000000-0000-0000-0000-000000000000'
   filter_by: 'Filter by'
   home: 'Home'
   hide_edit_history: 'Hide edit history ...'

--- a/lib/jupiter/version.rb
+++ b/lib/jupiter/version.rb
@@ -1,3 +1,3 @@
 module Jupiter
-  VERSION = '2.0.2'.freeze
+  VERSION = '2.0.3'.freeze
 end


### PR DESCRIPTION
## Context

Items in the [Successful Grants](https://era.library.ualberta.ca/communities/8f446adf-bae4-49f5-84b7-6195718ca844/collections/18826f1d-a1f7-4466-9f0e-8ae88350b984?page=2) collection are all returning 404 errors for logged in admin users.

Recently clean up and consolidation work has been ongoing for some of our collections.  The collection that these items in particular formerly belonged to had been deleted so it throws a `ActiveRecord::RecordNotFound` when we try to find it in our edit history
```
irb(main):002:0> item = Item.find('ed2e7a53-b522-47b8-a636-9ec757aa3352')
irb(main):003:0> item = item.decorate
irb(main):004:0> item.history
  PaperTrail::Version Load (2.3ms)  SELECT "versions".* FROM "versions" WHERE "versions"."item_id" = $1 AND "versions"."item_type" = $2 ORDER BY "versions"."created_at" ASC, "versions"."id" ASC  [["item_id", "ed2e7a53-b522-47b8-a636-9ec757aa3352"], ["item_type", "Item"]]
  Item Load (1.3ms)  SELECT "items".* FROM "items" WHERE "items"."id" = $1 LIMIT $2  [["id", "ed2e7a53-b522-47b8-a636-9ec757aa3352"], ["LIMIT", 1]]
  Community Load (1.2ms)  SELECT "communities".* FROM "communities" WHERE "communities"."id" = $1 LIMIT $2  [["id", "d1ddec9f-951a-48c2-8853-09bbc2d38422"], ["LIMIT", 1]]
  Collection Load (1.2ms)  SELECT "collections".* FROM "collections" WHERE "collections"."id" = $1 LIMIT $2  [["id", "872324e8-7614-4a5b-b09f-a89d57c4ed33"], ["LIMIT", 1]]
Traceback (most recent call last):
       14: from (irb):4
       13: from app/decorators/item_decorator.rb:6:in `history'
       12: from app/decorators/item_decorator.rb:6:in `map'
       11: from app/decorators/item_decorator.rb:7:in `block in history'
       10: from app/decorators/item_decorator.rb:7:in `new'
        9: from app/decorators/humanized_change_set.rb:13:in `initialize'
        8: from app/decorators/humanized_change_set.rb:35:in `generate_html_diffs'
        7: from app/decorators/humanized_change_set.rb:35:in `each_key'
        6: from app/decorators/humanized_change_set.rb:40:in `block in generate_html_diffs'
        5: from app/decorators/humanized_change_set.rb:173:in `member_of_paths'
        4: from app/decorators/humanized_change_set.rb:173:in `map'
        3: from app/decorators/humanized_change_set.rb:176:in `block in member_of_paths'
        2: from app/decorators/humanized_change_set.rb:176:in `map'
        1: from app/decorators/humanized_change_set.rb:179:in `block (2 levels) in member_of_paths'
ActiveRecord::RecordNotFound (Couldn't find Collection with 'id'=872324e8-7614-4a5b-b09f-a89d57c4ed33)
```

We came to the conclusion that using the id as a sensible default will work.  There were lots of questions about the formatting cues which indicates that more design work is likely needed here.  Adding an explainer to orient our users.
![image](https://user-images.githubusercontent.com/1220762/133518105-9ba1331f-47c4-49f5-8764-d1ec1033f00b.png)


Related to #2504

## What's New
- fix the lookup of Community, Collection and User to display the id captured by paper trail as a sensible default if the object has been deleted.
- add an explanatory note at the top of the edit history to orient users to this rarely used feature