### PR TITLE
bump CHANGELOG and VERSION for 3.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ New entries in this file should aim to provide a meaningful amount of informatio
 
 ## [Unreleased]
 
+## [3.0.0] - 2021-10-25
+
 - Refactored Controlled Vocabulary support to allow for new, raw vocabs without i18n translations. The motivation here is that we have a bunch of URIs we want to machine-map to human readable values, and it doesn't make sense to introduce intermediate symbols we'd have to cobble together somehow, plus that would involve polluting the i18n file with hundreds of new entries.
 
 API Examples:

--- a/lib/jupiter/version.rb
+++ b/lib/jupiter/version.rb
@@ -1,3 +1,3 @@
 module Jupiter
-  VERSION = '2.1.0'.freeze
+  VERSION = '3.0.0'.freeze
 end


### PR DESCRIPTION
## Context

Prepare for 3.0.0 release. In particular the ControlledVocabulary API change and subdomains makes this backwards incompatible, hence the major version assigned.

Related to https://github.com/ualbertalib/jupiter/issues/2524

## What's New
Updated `CHANGELOG` and `version.rb` version with new tag.
