### PR TITLE
Revise uat deploy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ New entries in this file should aim to provide a meaningful amount of informatio
 
 ### Chores
 - bump sidekiq-unique-jobs from 7.0.12 to 7.1.8 and fix a long missed deprecation
+- revise uat deploy configuration and watchtower script [#1985](https://github.com/ualbertalib/jupiter/issues/1985)
 
 ## [2.2.0] - 2021-10-21
 

--- a/bin/predeploy
+++ b/bin/predeploy
@@ -16,7 +16,7 @@ readonly install_directory="/home/deploy/jupiter"
 mkdir -p "${install_directory}"
 curl -o "${install_directory}/deploy" "https://raw.githubusercontent.com/ualbertalib/jupiter/${branch_name}/bin/deploy"
 curl -o "${install_directory}/docker-compose.yml" "https://raw.githubusercontent.com/ualbertalib/jupiter/${branch_name}/docker-compose.production.yml"
-curl -o "${install_directory}/watchtower-post-update"  "https://raw.githubusercontent.com/ualbertalib/jupiter/${branch_name}/bin/watchtower-post-update"
+curl -o "${install_directory}/watchtower-post-update.sh"  "https://raw.githubusercontent.com/ualbertalib/jupiter/${branch_name}/bin/watchtower-post-update.sh"
 
 mkdir -p "${install_directory}/config"
 curl -o "${install_directory}/config/nginx.conf" "https://raw.githubusercontent.com/ualbertalib/jupiter/${branch_name}/config/nginx.conf"

--- a/bin/watchtower-post-update.sh
+++ b/bin/watchtower-post-update.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
-rake db:migrate
-rake assets:precompile
+bundle exec rake db:migrate
+bundle exec rake assets:precompile

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -17,6 +17,8 @@ services:
     restart: always
     image: postgres:12-alpine
     env_file: .env_deployment
+    volumes:
+      - postgres:/var/lib/postgresql/data
 
   solr:
     restart: always


### PR DESCRIPTION
## Context
After a day or so, I would return to era.uat.library.ualberta.ca and find 500 errors.  I'd run `rails db:migrate` and it would start from the first migration.  I would search and it would report a number of items but not render any.  It seemed like the database wasn't persisting through restarts or watchtower updates.

Related to #1985

## What's New
- db wasn't persisting
- watchtower script not found because it was the wrong target