### PR TITLE
Fix test deprecation and driver path failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ New entries in this file should aim to provide a meaningful amount of informatio
 
 ### Chores
 - bump sidekiq-unique-jobs from 7.0.12 to 7.1.8 and fix a long missed deprecation
+- fixed deprecation warning on tests [#2604](https://github.com/ualbertalib/jupiter/issues/2604)
 
 ## [2.2.0] - 2021-10-21
 

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -6,7 +6,7 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   Capybara.default_max_wait_time = 5
 
   setup do
-    host! Jupiter::TEST_URL
+    Capybara.app_host = Jupiter::TEST_URL
   end
 
   # If you `snap install chromium` on Ubuntu, you might have tests that hang after a minute

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -12,7 +12,7 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   # If you `snap install chromium` on Ubuntu, you might have tests that hang after a minute
   # https://github.com/titusfortner/webdrivers/issues/217
   if ENV['CHROMIUM_CHROMEDRIVER_PATH']
-    Selenium::WebDriver::Chrome::Service.driver_path = ENV['CHROMIUM_CHROMEDRIVER_PATH']
+    Selenium::WebDriver::Chrome::Service.driver_path = proc { ENV['CHROMIUM_CHROMEDRIVER_PATH'] }
   end
   if ENV['CAPYBARA_NO_HEADLESS']
     driven_by :selenium, using: :chrome, screen_size: [1400, 1400]

--- a/test/system/digitization/book_show_test.rb
+++ b/test/system/digitization/book_show_test.rb
@@ -3,7 +3,7 @@ require 'application_system_test_case'
 class Digitization::BookShowTest < ApplicationSystemTestCase
 
   setup do
-    host! 'http://digitalcollections.ualberta.localhost'
+    Capybara.app_host = 'http://digitalcollections.ualberta.localhost'
   end
   test 'Books are working correctly' do
     visit digitization_book_url(digitization_books(:folk_fest))


### PR DESCRIPTION
## Context

A recent upgrade to our application created many deprecation warnings in our application.  It also changed the behaviour of `driver_path`

Closes #2604

## What's New

- fix `host!` deprecation
- make `driver_path` a `Proc` so that it can be called