### PR TITLE
Fixes: Docker demo Redis bad URI error #2610

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ New entries in this file should aim to provide a meaningful amount of informatio
 
 ### Chores
 - bump sidekiq-unique-jobs from 7.0.12 to 7.1.8 and fix a long missed deprecation
+- Fixes: Docker demo Redis bad URI error [#2610](https://github.com/ualbertalib/jupiter/issues/2610)
 
 ## [2.2.0] - 2021-10-21
 

--- a/docker-compose.demo.yml
+++ b/docker-compose.demo.yml
@@ -34,7 +34,7 @@ services:
       - DB_PASSWORD=mysecretpassword
       - SOLR_URL=http://solr:8983/solr/development
       - SOLR_TEST_URL=http://solr:8983/solr/test
-      - REDIS_URL='redis://redis/1'
+      - REDIS_URL=redis://redis/1
     ports:
       - "3000:3000"
     links:


### PR DESCRIPTION
## Context

Docker demo fails to start web container due to error: Redis bad URI: #2610 

## What's New

Update the docker-compose file for the demo
