### PR TITLE
Preserve the `doi:` namespace 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ New entries in this file should aim to provide a meaningful amount of informatio
 
 ## [Unreleased]
 
-- The EZID Compatibility API is sunsetting at the end of this year, per https://blog.datacite.org/sunsetting-of-the-ez-api/.  [datacite-client](https://github.com/pgwillia/datacite-client) is a ruby gem that wraps the [Datacite API](https://support.datacite.org/reference/introduction) for our use.  The main changes are the format of metadata attributes, and the event mechanism for publishing/hiding the metadata from the public. Requires `datacite_api` feature flag and new secrets for our datacite credentials. [#2268](https://github.com/ualbertalib/jupiter/issues/2268)
+- The EZID Compatibility API is sunsetting at the end of this year, per https://blog.datacite.org/sunsetting-of-the-ez-api/.  [datacite-client](https://github.com/pgwillia/datacite-client) is a ruby gem that wraps the [Datacite API](https://support.datacite.org/reference/introduction) for our use.  The main changes are the DOI's no longer have the `doi:` prefix, the format of metadata attributes, and the event mechanism for publishing/hiding the metadata from the public. Requires `datacite_api` feature flag and new secrets for our datacite credentials. [#2268](https://github.com/ualbertalib/jupiter/issues/2268)
 
 ### Chores
 - bump sidekiq-unique-jobs from 7.0.12 to 7.1.8 and fix a long missed deprecation

--- a/app/services/doi_service.rb
+++ b/app/services/doi_service.rb
@@ -29,7 +29,7 @@ class DOIService
 
     response, id = if Flipper.enabled?(:datacite_api)
                      response = Datacite::Client.mint(datacite_attributes)
-                     [response, response.doi]
+                     [response, "doi:#{response.doi}"]
                    else
                      response = Ezid::Identifier.mint(Ezid::Client.config.default_shoulder, ezid_metadata)
                      [response, response.id]
@@ -65,7 +65,7 @@ class DOIService
                    event = Datacite::Event::PUBLISH
                  end
 
-                 Datacite::Client.modify(@item.doi, datacite_attributes, event: event, reason: reason)
+                 Datacite::Client.modify(@item.doi.delete_prefix('doi:'), datacite_attributes, event: event, reason: reason)
                else
                  Ezid::Identifier.modify(@item.doi, ezid_metadata)
                end
@@ -95,7 +95,7 @@ class DOIService
 
   def self.remove(doi)
     if Flipper.enabled?(:datacite_api)
-      Datacite::Client.modify(doi, { reason: 'unavailable | withdrawn', event: Datacite::Event::HIDE })
+      Datacite::Client.modify(doi.delete_prefix('doi:'), { reason: 'unavailable | withdrawn', event: Datacite::Event::HIDE })
     else
       Ezid::Identifier.modify(doi, status: "#{Ezid::Status::UNAVAILABLE} | withdrawn", export: 'no')
     end

--- a/app/services/doi_service.rb
+++ b/app/services/doi_service.rb
@@ -65,7 +65,8 @@ class DOIService
                    event = Datacite::Event::PUBLISH
                  end
 
-                 Datacite::Client.modify(@item.doi.delete_prefix('doi:'), datacite_attributes, event: event, reason: reason)
+                 Datacite::Client.modify(@item.doi.delete_prefix('doi:'), datacite_attributes, event: event,
+                                                                                               reason: reason)
                else
                  Ezid::Identifier.modify(@item.doi, ezid_metadata)
                end
@@ -95,7 +96,8 @@ class DOIService
 
   def self.remove(doi)
     if Flipper.enabled?(:datacite_api)
-      Datacite::Client.modify(doi.delete_prefix('doi:'), { reason: 'unavailable | withdrawn', event: Datacite::Event::HIDE })
+      Datacite::Client.modify(doi.delete_prefix('doi:'),
+                              { reason: 'unavailable | withdrawn', event: Datacite::Event::HIDE })
     else
       Ezid::Identifier.modify(doi, status: "#{Ezid::Status::UNAVAILABLE} | withdrawn", export: 'no')
     end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -424,7 +424,7 @@ if Rails.env.development? || Rails.env.uat?
   base_radioactive_item_values = {
     # Set model id on each new Item so we can find it easily when testing
     owner_id: admin.id,
-    doi: '10.80243/99dh-v584',
+    doi: 'doi:10.80243/99dh-v584',
     visibility: JupiterCore::VISIBILITY_PUBLIC,
     creators: ['dc:creator1$ Doe, Jane', 'dc:creator2$ Doe, John'],
     contributors: ['dc:contributor1$ Perez, Juan', 'dc:contributor2$ Perez, Maria'],

--- a/test/fixtures/files/n3/items/2107bfb6-2670-4ffc-94a1-aeb4f8c1fd81-prev-embargoed.n3
+++ b/test/fixtures/files/n3/items/2107bfb6-2670-4ffc-94a1-aeb4f8c1fd81-prev-embargoed.n3
@@ -11,7 +11,7 @@
   pcdm:hasMember <<%= url %>/aip/v1/items/2107bfb6-2670-4ffc-94a1-aeb4f8c1fd81/filesets/<%= fileset_0_uuid %>>,
     <<%= url %>/aip/v1/items/2107bfb6-2670-4ffc-94a1-aeb4f8c1fd81/filesets/<%= fileset_1_uuid %>>;
   pcdm:memberOf <<%= url %>/aip/v1/collections/<%= collection_uuid %>>;
-  <http://prismstandard.org/namespaces/basic/3.0/doi> "10.80243/99dh-v584";
+  <http://prismstandard.org/namespaces/basic/3.0/doi> "doi:10.80243/99dh-v584";
   <http://projecthydra.org/ns/auth/acl#embargoHistory> ("acl:embargoHistory1$ An expired embargo was deactivated on 2000-01-01T00:00:00.000Z.  Its release date was 2000-01-01T00:00:00.000Z.  Visibility during embargo was restricted and intended visibility after embargo was open" "acl:embargoHistory2$ An expired embargo was deactivated on 2000-01-01T00:00:00.000Z.  Its release date was 2000-01-01T00:00:00.000Z.  Visibility during embargo was restricted and intended visibility after embargo was open");
   <http://projecthydra.org/ns/auth/acl#visibilityAfterEmbargo> "http://terms.library.ualberta.ca/public";
   dc11:contributor "dc:contributor2$ Perez, Maria",

--- a/test/fixtures/files/n3/items/3bb26070-0d25-4f0e-b44f-e9879da333ec-embargoed.n3
+++ b/test/fixtures/files/n3/items/3bb26070-0d25-4f0e-b44f-e9879da333ec-embargoed.n3
@@ -11,7 +11,7 @@
   pcdm:hasMember <<%= url %>/aip/v1/items/3bb26070-0d25-4f0e-b44f-e9879da333ec/filesets/<%= fileset_0_uuid %>>,
     <<%= url %>/aip/v1/items/3bb26070-0d25-4f0e-b44f-e9879da333ec/filesets/<%= fileset_1_uuid %>>;
   pcdm:memberOf <<%= url %>/aip/v1/collections/<%= collection_uuid %>>;
-  <http://prismstandard.org/namespaces/basic/3.0/doi> "10.80243/99dh-v584";
+  <http://prismstandard.org/namespaces/basic/3.0/doi> "doi:10.80243/99dh-v584";
   <http://projecthydra.org/ns/auth/acl#embargoHistory> ("acl:embargoHistory1$ Item currently embargoed");
   <http://projecthydra.org/ns/auth/acl#visibilityAfterEmbargo> "http://terms.library.ualberta.ca/public";
   dc11:contributor "dc:contributor2$ Perez, Maria",

--- a/test/fixtures/files/n3/items/93126aae-4b9d-4db2-98f1-4e04b40778cf-published-status.n3
+++ b/test/fixtures/files/n3/items/93126aae-4b9d-4db2-98f1-4e04b40778cf-published-status.n3
@@ -11,7 +11,7 @@
   pcdm:hasMember <<%= url %>/aip/v1/items/93126aae-4b9d-4db2-98f1-4e04b40778cf/filesets/<%= fileset_0_uuid %>>,
     <<%= url %>/aip/v1/items/93126aae-4b9d-4db2-98f1-4e04b40778cf/filesets/<%= fileset_1_uuid %>>;
   pcdm:memberOf <<%= url %>/aip/v1/collections/<%= collection_uuid %>>;
-  <http://prismstandard.org/namespaces/basic/3.0/doi> "10.80243/99dh-v584";
+  <http://prismstandard.org/namespaces/basic/3.0/doi> "doi:10.80243/99dh-v584";
   dc11:contributor "dc:contributor1$ Perez, Juan",
     "dc:contributor2$ Perez, Maria";
   dc11:creator "dc:creator1$ Doe, Jane",

--- a/test/fixtures/files/n3/items/c795337f-075f-429a-bb18-16b56d9b750f-rights.n3
+++ b/test/fixtures/files/n3/items/c795337f-075f-429a-bb18-16b56d9b750f-rights.n3
@@ -11,7 +11,7 @@
   pcdm:hasMember <<%= url %>/aip/v1/items/c795337f-075f-429a-bb18-16b56d9b750f/filesets/<%= fileset_0_uuid %>>,
     <<%= url %>/aip/v1/items/c795337f-075f-429a-bb18-16b56d9b750f/filesets/<%= fileset_1_uuid %>>;
   pcdm:memberOf <<%= url %>/aip/v1/collections/<%= collection_uuid %>>;
-  <http://prismstandard.org/namespaces/basic/3.0/doi> "10.80243/99dh-v584";
+  <http://prismstandard.org/namespaces/basic/3.0/doi> "doi:10.80243/99dh-v584";
   dc11:contributor "dc:contributor2$ Perez, Maria",
     "dc:contributor1$ Perez, Juan";
   dc11:creator "dc:creator2$ Doe, John",

--- a/test/fixtures/files/n3/items/e2ec88e3-3266-4e95-8575-8b04fac2a679-base.n3
+++ b/test/fixtures/files/n3/items/e2ec88e3-3266-4e95-8575-8b04fac2a679-base.n3
@@ -11,7 +11,7 @@
   pcdm:hasMember <<%= url %>/aip/v1/items/e2ec88e3-3266-4e95-8575-8b04fac2a679/filesets/<%= fileset_0_uuid %>>,
     <<%= url %>/aip/v1/items/e2ec88e3-3266-4e95-8575-8b04fac2a679/filesets/<%= fileset_1_uuid %>>;
   pcdm:memberOf <<%= url %>/aip/v1/collections/<%= collection_uuid %>>;
-  <http://prismstandard.org/namespaces/basic/3.0/doi> "10.80243/99dh-v584";
+  <http://prismstandard.org/namespaces/basic/3.0/doi> "doi:10.80243/99dh-v584";
   dc11:contributor "dc:contributor1$ Perez, Juan",
     "dc:contributor2$ Perez, Maria";
   dc11:creator "dc:creator1$ Doe, Jane",

--- a/test/fixtures/items.yml
+++ b/test/fixtures/items.yml
@@ -35,7 +35,7 @@ item_practical:
 item_admin:
   id: "e2ec88e3-3266-4e95-8575-8b04fac2a679"
   owner: user_admin
-  doi: "10.80243/99dh-v584"
+  doi: "doi:10.80243/99dh-v584"
   visibility: <%= JupiterCore::VISIBILITY_PUBLIC %>
   creators: ["dc:creator1$ Doe, Jane", "dc:creator2$ Doe, John"]
   contributors:

--- a/test/services/datacite_doi_service_test.rb
+++ b/test/services/datacite_doi_service_test.rb
@@ -31,7 +31,7 @@ class DataciteDoiServiceTest < ActiveSupport::TestCase
 
       datacite_identifer = DOIService.new(@item).create
       assert_not_nil datacite_identifer
-      assert_equal @item.doi, datacite_identifer.doi
+      assert_equal @item.doi.delete_prefix('doi:'), datacite_identifer.doi
       assert_equal 'University of Alberta Library', datacite_identifer.publisher
       assert_equal @item.title, datacite_identifer.titles.first[:title]
       assert_equal @item.description, datacite_identifer.descriptions.first[:description]
@@ -54,7 +54,7 @@ class DataciteDoiServiceTest < ActiveSupport::TestCase
 
       datacite_identifer = DOIService.new(@item).update
       assert_not_nil datacite_identifer
-      assert_equal @item.doi, datacite_identifer.doi
+      assert_equal @item.doi.delete_prefix('doi:'), datacite_identifer.doi
       assert_equal Datacite::State::FINDABLE, datacite_identifer.state
       assert_equal 'Different Title', datacite_identifer.titles.first[:title]
       assert_equal 'available', @item.aasm_state
@@ -72,7 +72,7 @@ class DataciteDoiServiceTest < ActiveSupport::TestCase
 
       datacite_identifer = DOIService.new(@item).update
       assert_not_nil datacite_identifer
-      assert_equal @item.doi, datacite_identifer.doi
+      assert_equal @item.doi.delete_prefix('doi:'), datacite_identifer.doi
       assert_equal Datacite::State::REGISTERED, datacite_identifer.state
       assert_equal 'unavailable| not publicly released', datacite_identifer.reason
       assert_equal 'not_available', @item.aasm_state
@@ -90,7 +90,7 @@ class DataciteDoiServiceTest < ActiveSupport::TestCase
 
       datacite_identifer = DOIService.remove(@item.doi)
       assert_not_nil datacite_identifer
-      assert_equal @item.doi, datacite_identifer.doi
+      assert_equal @item.doi.delete_prefix('doi:'), datacite_identifer.doi
       assert_equal Datacite::State::REGISTERED, datacite_identifer.state
       assert_equal 'unavailable | withdrawn', datacite_identifer.reason
     end

--- a/test/services/datacite_doi_service_test.rb
+++ b/test/services/datacite_doi_service_test.rb
@@ -4,8 +4,7 @@ class DataciteDoiServiceTest < ActiveSupport::TestCase
 
   include ActiveJob::TestHelper
 
-  # If you need to re-record the vcr cassettes uncomment this line so you get them in order
-  # ActiveSupport::TestCase.test_order = :sorted
+  # If you need to re-record the vcr cassettes use SEED=20 to record the tests in order
 
   setup do
     Flipper.enable(:datacite_api)
@@ -20,7 +19,7 @@ class DataciteDoiServiceTest < ActiveSupport::TestCase
     Flipper.disable(:datacite_api)
   end
 
-  test 'a. mint DOI' do
+  test 'mint DOI' do
     VCR.use_cassette('datacite_minting', erb: { id: @item.id }, record: :once) do
       assert_no_enqueued_jobs
       @item.update(doi: nil)
@@ -44,7 +43,7 @@ class DataciteDoiServiceTest < ActiveSupport::TestCase
     end
   end
 
-  test 'b. update DOI' do
+  test 'update DOI' do
     VCR.use_cassette('datacite_updating', erb: { id: @item.id }, record: :once) do
       assert_no_enqueued_jobs
       @item.update(title: 'Different Title', aasm_state: :available)
@@ -61,7 +60,7 @@ class DataciteDoiServiceTest < ActiveSupport::TestCase
     end
   end
 
-  test 'c. unavailable DOI' do
+  test 'unavailable DOI' do
     VCR.use_cassette('datacite_updating_unavailable', erb: { id: @item.id }, record: :once) do
       assert_no_enqueued_jobs
 
@@ -79,7 +78,7 @@ class DataciteDoiServiceTest < ActiveSupport::TestCase
     end
   end
 
-  test 'd. remove DOI' do
+  test 'remove DOI' do
     VCR.use_cassette('datacite_removal', erb: { id: @item.id }, record: :once, allow_unused_http_interactions: false) do
       assert_no_enqueued_jobs
 


### PR DESCRIPTION
## Context

All our existing doi's have a `doi:` prefix.  This is the output we use for identifiers in OAI.

Rather than make a change that has unknown repercussions we will continue the same DOI structure.

I investigated if the Datacite API recognized DOIs in the format `doi:<prefix>/<id>`.  It does not.

I investigated if the Datacite API recognized our existing DOIs in the `<prefix>/<id>` format and it does. We can be assured that this change will ensure continuity of the existing data.
Related to #2554 and #2268

## What's New

- Item and Thesis doi retains the `doi:` prefix and the DOIService will strip the prefix before making requests to Datacite.