### PR TITLE
Catch unsafe migrations in development

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -175,3 +175,8 @@ Naming/VariableNumber:
 Style/OpenStructUse:
   Exclude: 
     - config/initializers/controlled_vocabularies.rb
+
+# Migrations are YYYYMMDDHHMMSS rather than a numeric
+Style/NumericLiterals:
+  Exclude:
+    - config/initializers/strong_migrations.rb

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ New entries in this file should aim to provide a meaningful amount of informatio
 - fixed deprecation warning on tests [#2604](https://github.com/ualbertalib/jupiter/issues/2604)
 - revise uat deploy configuration and watchtower script [#1985](https://github.com/ualbertalib/jupiter/issues/1985)
 - fixes: Docker demo Redis bad URI error [#2610](https://github.com/ualbertalib/jupiter/issues/2610)
+- add `strong_migrations` to catch unsafe migrations in development [#2621](https://github.com/ualbertalib/jupiter/issues/2621)
 
 ## [2.2.0] - 2021-10-21
 

--- a/Gemfile
+++ b/Gemfile
@@ -101,6 +101,8 @@ group :development, :test do
   gem 'rubocop-minitest', require: false
   gem 'rubocop-performance', require: false
   gem 'rubocop-rails', require: false
+
+  gem 'strong_migrations', '~> 0.7.8'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -564,6 +564,8 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
+    strong_migrations (0.7.8)
+      activerecord (>= 5)
     sxp (1.1.0)
       rdf (~> 3.1)
     terminal-table (3.0.2)
@@ -683,6 +685,7 @@ DEPENDENCIES
   skylight (~> 4.3)
   spring
   spring-watcher-listen (~> 2.0.0)
+  strong_migrations (~> 0.7.8)
   uuidtools
   vcr (= 5.0)
   voight_kampff

--- a/config/initializers/strong_migrations.rb
+++ b/config/initializers/strong_migrations.rb
@@ -1,0 +1,26 @@
+# Mark existing migrations as safe
+StrongMigrations.start_after = 20211117160533
+
+# Set timeouts for migrations
+# If you use PgBouncer in transaction mode, delete these lines and set timeouts on the database user
+StrongMigrations.lock_timeout = 10.seconds
+StrongMigrations.statement_timeout = 1.hour
+
+# Analyze tables after indexes are added
+# Outdated statistics can sometimes hurt performance
+StrongMigrations.auto_analyze = true
+
+# Set the version of the production database
+# so the right checks are run in development
+# StrongMigrations.target_version = 10
+
+# Add custom checks
+# StrongMigrations.add_check do |method, args|
+#   if method == :add_index && args[0].to_s == "users"
+#     stop! "No more indexes on the users table"
+#   end
+# end
+
+# Make some operations safe by default
+# See https://github.com/ankane/strong_migrations#safe-by-default
+StrongMigrations.safe_by_default = true


### PR DESCRIPTION
## Context

When/if we move this application to the cloud we'll need to be especially careful about database migrations that cause downtime.  We're trying to move to a practice where deployments are easy and can be done multiple times a day.  During deployments we will have some traffic going to the old deployment and some to the new.  We will need to ensure that all changes are compatible with the code that is already running.

Related to #2621

## What's New

Use the `strong_migrations` gem:
  ✓  Detects potentially dangerous operations
  ✓  Prevents them from running by default
  ✓  Provides instructions on safer ways to do what you want

https://github.com/ankane/strong_migrations