### PR TITLE
`Digitization:Newspaper` model from ACN triples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ New entries in this file should aim to provide a meaningful amount of informatio
 
 ## [Unreleased]
 
+- Jupiter II work is continuing to incorporate Digitized materials into Jupiter in the digitalcollections namespace.
+  - newspaper metadata for ACN digitization [#2645](https://github.com/ualbertalib/jupiter/issues/2645)
+
 ### Fixed
 - nil Class error when viewing Collections drop down on Communities page [#2655](https://github.com/ualbertalib/jupiter/issues/2655)
 - Render markdown when viewing Communities as an administrator [#1322](https://github.com/ualbertalib/jupiter/issues/1322)
@@ -20,7 +23,7 @@ New entries in this file should aim to provide a meaningful amount of informatio
 ## [2.3.1] - 2021-12-07
 
 - Fix Gemfile so that `strong_migrations` is usesd in all environments
-
+  
 ## [2.3.0] - 2021-12-01
 
 - The EZID Compatibility API is sunsetting at the end of this year, per https://blog.datacite.org/sunsetting-of-the-ez-api/.  [datacite-client](https://github.com/pgwillia/datacite-client) is a ruby gem that wraps the [Datacite API](https://support.datacite.org/reference/introduction) for our use.  The main changes are the DOI's no longer have the `doi:` prefix, the format of metadata attributes, and the event mechanism for publishing/hiding the metadata from the public. Requires `datacite_api` feature flag and new secrets for our datacite credentials. [#2268](https://github.com/ualbertalib/jupiter/issues/2268)

--- a/app/models/digitization/book.rb
+++ b/app/models/digitization/book.rb
@@ -23,7 +23,6 @@ class Digitization::Book < JupiterCore::Depositable
   validates :geographic_subjects, presence: true, unless: :temporal_subjects? || :topical_subjects?
   validates :topical_subjects, presence: true, unless: :temporal_subjects? || :geographic_subjects?
 
-  validates :title, presence: true
   validates :resource_type, presence: true, uri: { namespace: :digitization, in_vocabulary: :resource_type }
   validates :genres, presence: true, uri: { namespace: :digitization, in_vocabulary: :genre }
   validates :languages, presence: true, uri: { namespace: :digitization, in_vocabulary: :language }

--- a/app/models/digitization/newspaper.rb
+++ b/app/models/digitization/newspaper.rb
@@ -1,5 +1,7 @@
 class Digitization::Newspaper < JupiterCore::Depositable
 
+  acts_as_rdfable
+
   belongs_to :owner, class_name: 'User'
 
   validates :publication_code, uniqueness: { scope: [:year, :month, :day] }

--- a/app/models/digitization/newspaper.rb
+++ b/app/models/digitization/newspaper.rb
@@ -6,7 +6,6 @@ class Digitization::Newspaper < JupiterCore::Depositable
   validates :year, :month, :day, presence: true, if: :publication_code?
 
   validates :geographic_subjects, presence: true
-  validates :title, presence: true
   validates :resource_type, presence: true, uri: { namespace: :digitization, in_vocabulary: :resource_type }
   validates :genres, presence: true, uri: { namespace: :digitization, in_vocabulary: :genre }
   validates :languages, presence: true, uri: { namespace: :digitization, in_vocabulary: :language }

--- a/app/models/digitization/newspaper.rb
+++ b/app/models/digitization/newspaper.rb
@@ -5,4 +5,13 @@ class Digitization::Newspaper < JupiterCore::Depositable
   validates :publication_code, uniqueness: { scope: [:year, :month, :day] }
   validates :year, :month, :day, presence: true, if: :publication_code?
 
+  validates :geographic_subjects, presence: true
+  validates :title, presence: true
+  validates :resource_type, presence: true, uri: { namespace: :digitization, in_vocabulary: :resource_type }
+  validates :genres, presence: true, uri: { namespace: :digitization, in_vocabulary: :genre }
+  validates :languages, presence: true, uri: { namespace: :digitization, in_vocabulary: :language }
+  validates :rights, presence: true, uri: { namespace: :digitization, in_vocabulary: :rights }
+
+  validates :dates_issued, edtf: true
+
 end

--- a/config/controlled_vocabularies/digitization/genre.raw.yml
+++ b/config/controlled_vocabularies/digitization/genre.raw.yml
@@ -1,2 +1,3 @@
 genre:
   'Programs (Publications)': http://id.loc.gov/authorities/genreForms/gf2014026156
+  'Newspapers': http://id.loc.gov/authorities/genreForms/gf2014026132

--- a/config/controlled_vocabularies/digitization/rights.raw.yml
+++ b/config/controlled_vocabularies/digitization/rights.raw.yml
@@ -1,2 +1,3 @@
 rights:
   'In Copyright': https://rightsstatements.org/page/InC/1.0/?language=en
+  'No Known Copyright': https://creativecommons.org/share-your-work/public-domain/pdm/

--- a/config/controlled_vocabularies/digitization/subject.raw.yml
+++ b/config/controlled_vocabularies/digitization/subject.raw.yml
@@ -2,3 +2,4 @@ subject:
   "Edmonton Folk Music Festival": http://viaf.org/viaf/148861489
   "Folk music festivals": http://id.loc.gov/authorities/subjects/sh2008004058
   "Edmonton (Alta.)": http://id.loc.gov/authorities/names/n79007225
+  "Lacombe (Alta.)": http://id.loc.gov/authorities/names/n2002124886

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -175,6 +175,16 @@ en:
                 not_recognized: 'is not recognized'
               rights:
                 not_recognized: 'is not recognized'
+        digitization/newspaper:
+            attributes:
+              resource_type:
+                not_recognized: 'is not recognized'
+              genres:
+                not_recognized: 'is not recognized'
+              languages:
+                not_recognized: 'is not recognized'
+              rights:
+                not_recognized: 'is not recognized'
         user:
           attributes:
             api_key_digest:

--- a/db/migrate/20211203185004_add_acn_attributes_to_digitzation_newspaper.rb
+++ b/db/migrate/20211203185004_add_acn_attributes_to_digitzation_newspaper.rb
@@ -12,7 +12,8 @@ class AddAcnAttributesToDigitzationNewspaper < ActiveRecord::Migration[6.1]
         t.text :notes, array: true
         t.string :geographic_subjects, array: true
         t.string :rights
-        t.string :volume_label
+        t.string :volume
+        t.string :issue
         t.string :editions, array: true
       end
     }
@@ -29,7 +30,8 @@ class AddAcnAttributesToDigitzationNewspaper < ActiveRecord::Migration[6.1]
       t.notes has_predicate: ::RDF::Vocab::SKOS.note
       t.geographic_subjects has_predicate: ::RDF::Vocab::DC11.coverage
       t.rights has_predicate: ::RDF::Vocab::EDM.rights
-      t.volume_label has_predicate: ::TERMS[:rdfs].ch_label
+      t.volume has_predicate: ::RDF::Vocab::BIBO.volume
+      t.issue has_predicate: ::RDF::Vocab::BIBO.issue
       t.editions has_predicate: ::RDF::Vocab::Bibframe.editionStatement
     end
   end

--- a/db/migrate/20211203185004_add_acn_attributes_to_digitzation_newspaper.rb
+++ b/db/migrate/20211203185004_add_acn_attributes_to_digitzation_newspaper.rb
@@ -1,0 +1,36 @@
+class AddAcnAttributesToDigitzationNewspaper < ActiveRecord::Migration[6.1]
+  def change
+    safety_assured { # this migration is a bunch of add_columns which are safe
+      change_table :digitization_newspapers do |t|
+        t.string :dates_issued, array:true
+        t.text :alternative_titles, array: true
+        t.string :resource_type, null: false
+        t.string :genres, null: false, array: true
+        t.string :languages, null: false, array: true
+        t.string :places_of_publication, array:true
+        t.string :extent
+        t.text :notes, array: true
+        t.string :geographic_subjects, array: true
+        t.string :rights
+        t.string :volume_label
+        t.string :editions, array: true
+      end
+    }
+
+    add_rdf_table_annotations for_table: :digitization_newspapers do |t|
+      t.dates_issued has_predicate: ::RDF::Vocab::DC.issued
+      t.title has_predicate: ::RDF::Vocab::DC.title
+      t.alternative_titles has_predicate: ::RDF::Vocab::DC.alternative
+      t.resource_type has_predicate: ::RDF::Vocab::DC.type
+      t.genres has_predicate: ::RDF::Vocab::EDM.hasType
+      t.languages has_predicate: ::RDF::Vocab::DC.language
+      t.places_of_publication has_predicate: ::RDF::Vocab::MARCRelators.pup
+      t.extent has_predicate: ::TERMS[:rdau].extent
+      t.notes has_predicate: ::RDF::Vocab::SKOS.note
+      t.geographic_subjects has_predicate: ::RDF::Vocab::DC11.coverage
+      t.rights has_predicate: ::RDF::Vocab::EDM.rights
+      t.volume_label has_predicate: ::TERMS[:rdfs].ch_label
+      t.editions has_predicate: ::RDF::Vocab::Bibframe.editionStatement
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -221,7 +221,8 @@ ActiveRecord::Schema.define(version: 2021_12_03_185004) do
     t.text "notes", array: true
     t.string "geographic_subjects", array: true
     t.string "rights"
-    t.string "volume_label"
+    t.string "volume"
+    t.string "issue"
     t.string "editions", array: true
     t.index ["owner_id"], name: "index_digitization_newspapers_on_owner_id"
     t.index ["publication_code", "year", "month", "day"], name: "unique_peel_newspaper", unique: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_10_162254) do
+ActiveRecord::Schema.define(version: 2021_12_03_185004) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -211,6 +211,18 @@ ActiveRecord::Schema.define(version: 2021_11_10_162254) do
     t.string "visibility"
     t.bigint "owner_id", null: false
     t.string "title", null: false
+    t.string "dates_issued", array: true
+    t.text "alternative_titles", array: true
+    t.string "resource_type", null: false
+    t.string "genres", null: false, array: true
+    t.string "languages", null: false, array: true
+    t.string "places_of_publication", array: true
+    t.string "extent"
+    t.text "notes", array: true
+    t.string "geographic_subjects", array: true
+    t.string "rights"
+    t.string "volume_label"
+    t.string "editions", array: true
     t.index ["owner_id"], name: "index_digitization_newspapers_on_owner_id"
     t.index ["publication_code", "year", "month", "day"], name: "unique_peel_newspaper", unique: true
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -729,6 +729,29 @@ if Rails.env.development? || Rails.env.uat?
     book.create_fulltext!(text: Faker::Lorem.sentence(word_count: 250, supplemental: false, random_words_to_add: 0))
   end
 
+  11.times do |_i|
+    date = Faker::Date.between(from: '1900-01-01', to: Date.today)
+    place = [ControlledVocabulary.digitization.subject.from_value('Edmonton (Alta.)'), ControlledVocabulary.digitization.subject.from_value('Lacombe (Alta.)')].sample
+    newspaper = Digitization::Newspaper.create!(publication_code: ['ACN', 'LSV', 'SDN'].sample, 
+                              year: date.year,
+                              month: date.month.to_s.rjust(2, "0"),
+                              day: date.mday.to_s.rjust(2, "0"),
+                              owner_id: admin.id,
+                              dates_issued: [date.edtf],
+                              date_ingested: '2016-12-08T06:00:00.000Z',
+                              title: "#{Faker::Address.city} #{Faker::Subscription.subscription_term}",
+                              alternative_titles: [Faker::Hipster.sentence.to_s],
+                              resource_type: ControlledVocabulary.digitization.resource_type.from_value('Text'),
+                              genres: [ControlledVocabulary.digitization.genre.from_value('Newspapers')],
+                              languages: [ControlledVocabulary.digitization.language.from_value('English')],
+                              places_of_publication: [place],
+                              extent: 'v. : ill.',
+                              notes: [Faker::Hipster.sentence.to_s],
+                              geographic_subjects: [place],
+                              rights: ControlledVocabulary.digitization.rights.from_value('No Known Copyright')
+    )
+  end
+
   Digitization::Book.create(peel_id: '4062') # monograph
   Digitization::Book.create(peel_id: '10571', part_number: '2') # Government Document
   Digitization::Book.create(peel_id: '3178', run: '2', part_number: '12') # Henderson

--- a/db/seeds/rdf_annotations.rb
+++ b/db/seeds/rdf_annotations.rb
@@ -127,6 +127,7 @@ RdfAnnotation.create!([
   {table: "digitization_newspapers", column: "notes", predicate: "http://www.w3.org/2004/02/skos/core#note"},
   {table: "digitization_newspapers", column: "geographic_subjects", predicate: "http://purl.org/dc/elements/1.1/coverage"},
   {table: "digitization_newspapers", column: "rights", predicate: "http://www.europeana.eu/schemas/edm/rights"},
-  {table: "digitization_newspapers", column: "volume_label", predicate: "https://www.w3.org/TR/rdf-schema/#ch_label"},
+  {table: "digitization_newspapers", column: "volume", predicate: "http://purl.org/ontology/bibo/volume"},
+  {table: "digitization_newspapers", column: "issue", predicate: "http://purl.org/ontology/bibo/issue"},
   {table: "digitization_newspapers", column: "editions", predicate: "http://id.loc.gov/ontologies/bibframe/editionStatement"}
 ])

--- a/db/seeds/rdf_annotations.rb
+++ b/db/seeds/rdf_annotations.rb
@@ -115,5 +115,18 @@ RdfAnnotation.create!([
   {table: "digitization_maps", column: "date_ingested", predicate: "http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#dateIngested"},
   {table: "digitization_maps", column: "record_created_at", predicate: "http://terms.library.ualberta.ca/recordCreatedInJupiter"},
   {table: "digitization_books", column: "alternative_titles", predicate: "http://purl.org/dc/terms/alternative"},
-  {table: "digitization_books", column: "rights", predicate: "http://www.europeana.eu/schemas/edm/rights"}
+  {table: "digitization_books", column: "rights", predicate: "http://www.europeana.eu/schemas/edm/rights"},
+  {table: "digitization_newspapers", column: "dates_issued", predicate: "http://purl.org/dc/terms/issued"},
+  {table: "digitization_newspapers", column: "title", predicate: "http://purl.org/dc/terms/title"},
+  {table: "digitization_newspapers", column: "alternative_titles", predicate: "http://purl.org/dc/terms/alternative"},
+  {table: "digitization_newspapers", column: "resource_type", predicate: "http://purl.org/dc/terms/type"},
+  {table: "digitization_newspapers", column: "genres", predicate: "http://www.europeana.eu/schemas/edm/hasType"},
+  {table: "digitization_newspapers", column: "languages", predicate: "http://purl.org/dc/terms/language"},
+  {table: "digitization_newspapers", column: "places_of_publication", predicate: "http://id.loc.gov/vocabulary/relators/pup"},
+  {table: "digitization_newspapers", column: "extent", predicate: "http://rdaregistry.info/Elements/u/P60550"},
+  {table: "digitization_newspapers", column: "notes", predicate: "http://www.w3.org/2004/02/skos/core#note"},
+  {table: "digitization_newspapers", column: "geographic_subjects", predicate: "http://purl.org/dc/elements/1.1/coverage"},
+  {table: "digitization_newspapers", column: "rights", predicate: "http://www.europeana.eu/schemas/edm/rights"},
+  {table: "digitization_newspapers", column: "volume_label", predicate: "https://www.w3.org/TR/rdf-schema/#ch_label"},
+  {table: "digitization_newspapers", column: "editions", predicate: "http://id.loc.gov/ontologies/bibframe/editionStatement"}
 ])

--- a/test/controllers/digitization/newspapers_controller_test.rb
+++ b/test/controllers/digitization/newspapers_controller_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 class Digitization::NewspapersControllerTest < ActionDispatch::IntegrationTest
 
   setup do
-    @digitization_newspaper = digitization_newspapers(:la_survivance)
+    @digitization_newspaper = digitization_newspapers(:central_alberta_news)
   end
 
   test 'should show digitization_newspaper' do

--- a/test/controllers/digitization/redirect_controller_test.rb
+++ b/test/controllers/digitization/redirect_controller_test.rb
@@ -75,16 +75,16 @@ class Digitization::RedirectControllerTest < ActionDispatch::IntegrationTest
 
   test 'should redirect Peel newspaper' do
     # Action: redirect#peel_newspaper
-    get '/newspapers/LSV/1967/03/29'
+    get '/newspapers/ACN/1907/08/29'
     assert_response :moved_permanently
-    assert_redirected_to digitization_newspaper_url(digitization_newspapers(:la_survivance))
+    assert_redirected_to digitization_newspaper_url(digitization_newspapers(:central_alberta_news))
   end
 
   test 'should redirect Peel newspaper article level to the issue level' do
     # Action: redirect#peel_newspaper
-    get '/newspapers/LSV/1967/03/29/5/Ar00501.html'
+    get '/newspapers/ACN/1907/08/29/5/Ad00501_14.html'
     assert_response :moved_permanently
-    assert_redirected_to digitization_newspaper_url(digitization_newspapers(:la_survivance))
+    assert_redirected_to digitization_newspaper_url(digitization_newspapers(:central_alberta_news))
   end
 
   test 'should redirect Peel Magee photograph' do

--- a/test/fixtures/digitization/newspapers.yml
+++ b/test/fixtures/digitization/newspapers.yml
@@ -1,11 +1,23 @@
 # Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
-la_survivance:
-  publication_code: "LSV"
-  title: "La Survivance March 29, 1967"
-  year: "1967"
-  month: "03"
+central_alberta_news:
+  publication_code: "ACN"
+  title: "The advertiser and central Alberta news"
+  year: "1907"
+  month: "08"
   day: "29"
+  alternative_titles: ['Central Alberta news']
+  dates_issued: ['1907-08-29']
+  resource_type: <%= ControlledVocabulary.digitization.resource_type.from_value("Text") %>
+  genres: ['http://id.loc.gov/authorities/genreForms/gf2014026132']
+  languages: <%= [ControlledVocabulary.digitization.language.from_value("English")] %>
+  places_of_publication: ['http://id.loc.gov/authorities/names/n2002124886']
+  extent: 'v. : ill.'
+  notes: ['Weekly. Imprint varies. Published 1898 to 18 June 1908.']
+  geographic_subjects: ['http://id.loc.gov/authorities/names/n2002124886']
+  rights: 'https://creativecommons.org/share-your-work/public-domain/pdm/'
+  editions: ['1']
+  volume_label: 'v. 9 no. 10'
   date_ingested: "2000-01-01T00:00:00.007Z"
   record_created_at: "2000-01-01T00:00:00.007Z"
   owner: user_admin

--- a/test/fixtures/digitization/newspapers.yml
+++ b/test/fixtures/digitization/newspapers.yml
@@ -9,13 +9,13 @@ central_alberta_news:
   alternative_titles: ['Central Alberta news']
   dates_issued: ['1907-08-29']
   resource_type: <%= ControlledVocabulary.digitization.resource_type.from_value("Text") %>
-  genres: ['http://id.loc.gov/authorities/genreForms/gf2014026132']
+  genres: <%= [ControlledVocabulary.digitization.genre.from_value("Newspapers")] %>
   languages: <%= [ControlledVocabulary.digitization.language.from_value("English")] %>
-  places_of_publication: ['http://id.loc.gov/authorities/names/n2002124886']
+  places_of_publication: <%= [ControlledVocabulary.digitization.subject.from_value("Lacombe (Alta.)")] %>
   extent: 'v. : ill.'
   notes: ['Weekly. Imprint varies. Published 1898 to 18 June 1908.']
-  geographic_subjects: ['http://id.loc.gov/authorities/names/n2002124886']
-  rights: 'https://creativecommons.org/share-your-work/public-domain/pdm/'
+  geographic_subjects: <%= [ControlledVocabulary.digitization.subject.from_value("Lacombe (Alta.)")] %>
+  rights: <%= ControlledVocabulary.digitization.rights.from_value("No Known Copyright") %>
   editions: ['1']
   volume_label: 'v. 9 no. 10'
   date_ingested: "2000-01-01T00:00:00.007Z"

--- a/test/fixtures/digitization/newspapers.yml
+++ b/test/fixtures/digitization/newspapers.yml
@@ -17,7 +17,8 @@ central_alberta_news:
   geographic_subjects: <%= [ControlledVocabulary.digitization.subject.from_value("Lacombe (Alta.)")] %>
   rights: <%= ControlledVocabulary.digitization.rights.from_value("No Known Copyright") %>
   editions: ['1']
-  volume_label: 'v. 9 no. 10'
+  volume: 'v. 9'
+  issue: 'no. 10'
   date_ingested: "2000-01-01T00:00:00.007Z"
   record_created_at: "2000-01-01T00:00:00.007Z"
   owner: user_admin

--- a/test/models/digitization/newspaper_test.rb
+++ b/test/models/digitization/newspaper_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 class Digitization::NewspaperTest < ActiveSupport::TestCase
 
   setup do
-    @newspaper = digitization_newspapers(:la_survivance)
+    @newspaper = digitization_newspapers(:central_alberta_news)
   end
 
   test 'valid Peel newspaper' do
@@ -11,9 +11,9 @@ class Digitization::NewspaperTest < ActiveSupport::TestCase
   end
 
   test 'unique Peel newspaper' do
-    newspaper = Digitization::Newspaper.create(publication_code: 'LSV',
-                                               year: '1967',
-                                               month: '03',
+    newspaper = Digitization::Newspaper.create(publication_code: 'ACN',
+                                               year: '1907',
+                                               month: '08',
                                                day: '29')
     assert_not newspaper.valid?
     assert_equal('has already been taken', newspaper.errors[:publication_code].first)
@@ -26,6 +26,44 @@ class Digitization::NewspaperTest < ActiveSupport::TestCase
     assert_equal("can't be blank", @newspaper.errors[:year].first)
     assert_equal("can't be blank", @newspaper.errors[:month].first)
     assert_equal("can't be blank", @newspaper.errors[:day].first)
+  end
+
+  test 'should have required attributes' do
+    @newspaper.assign_attributes(title: nil, genres: nil, languages: nil)
+    assert_not @newspaper.valid?
+    assert_equal("can't be blank", @newspaper.errors[:title].first)
+    assert_equal("can't be blank", @newspaper.errors[:genres].first)
+    assert_equal("can't be blank", @newspaper.errors[:languages].first)
+  end
+
+  test 'unknown resource types are not valid' do
+    @newspaper.assign_attributes(resource_type: 'some_fake_resource_type')
+    assert_not @newspaper.valid?
+    assert_includes @newspaper.errors[:resource_type], 'is not recognized'
+  end
+
+  test 'unknown genres are not valid' do
+    @newspaper.assign_attributes(genres: ['some_fake_genre'])
+    assert_not @newspaper.valid?
+    assert_includes @newspaper.errors[:genres], 'is not recognized'
+  end
+
+  test 'unknown languages are not valid' do
+    @newspaper.assign_attributes(languages: ['some_fake_language'])
+    assert_not @newspaper.valid?
+    assert_includes @newspaper.errors[:languages], 'is not recognized'
+  end
+
+  test 'unknown rights are not valid' do
+    @newspaper.assign_attributes(rights: 'some_fake_right')
+    assert_not @newspaper.valid?
+    assert_includes @newspaper.errors[:rights], 'is not recognized'
+  end
+
+  test 'dates must conform to EDTF format' do
+    @newspaper.assign_attributes(dates_issued: ['INVALID DATE'])
+    assert_not @newspaper.valid?
+    assert_equal('does not conform to the Extended Date/Time Format standard', @newspaper.errors[:dates_issued].first)
   end
 
 end


### PR DESCRIPTION
## Context

The second set of digitization content will be the The advertiser and central Alberta news. This set was chosen because it is relatively small (there are 47) and well described. Before we can ingest them we need to do some modelling.

Related to #2645

## What's New

- added attributes to `Digitization::Newspaper` model and their rdf annotations
- added validations for the attributes
- added several controlled vocabularies and relevant ACN values

