### PR TITLE
First draft of Newspapers show page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ New entries in this file should aim to provide a meaningful amount of informatio
 
 - Jupiter II work is continuing to incorporate Digitized materials into Jupiter in the digitalcollections namespace.
   - newspaper metadata for ACN digitization [#2645](https://github.com/ualbertalib/jupiter/issues/2645)
-
+  - newspaper show page [#2649](https://github.com/ualbertalib/jupiter/issues/2649)
+  
 ### Fixed
 - nil Class error when viewing Collections drop down on Communities page [#2655](https://github.com/ualbertalib/jupiter/issues/2655)
 - Render markdown when viewing Communities as an administrator [#1322](https://github.com/ualbertalib/jupiter/issues/1322)

--- a/app/controllers/digitization/newspapers_controller.rb
+++ b/app/controllers/digitization/newspapers_controller.rb
@@ -1,8 +1,9 @@
 class Digitization::NewspapersController < ApplicationController
 
   def show
-    @digitization_newspaper = Digitization::Newspaper.find(params[:id])
-    authorize @digitization_newspaper
+    digitization_newspaper = Digitization::Newspaper.find(params[:id])
+    authorize digitization_newspaper
+    @digitization_newspaper = digitization_newspaper.decorate
   end
 
 end

--- a/app/decorators/digitization/newspaper_decorator.rb
+++ b/app/decorators/digitization/newspaper_decorator.rb
@@ -1,0 +1,39 @@
+class Digitization::NewspaperDecorator < ApplicationDecorator
+
+  delegate_all
+
+  def all_subjects
+    object.geographic_subjects
+  end
+
+  def each_community_collection
+    # TODO: remove when Digitization collection is completed
+    []
+  end
+
+  def alternative_title
+    object.alternative_titles.join(' ') if object.alternative_titles.present?
+  end
+
+  def description
+    object.notes.join(' ') if object.notes.present?
+  end
+
+  def creation_date
+    object.dates_issued.first if object.dates_issued.present?
+  end
+
+  def sort_year
+    # TODO: remove when sort_year has been added
+    nil
+  end
+
+  def volume_label
+    "#{object.volume} #{object.issue}"
+  end
+
+  def languages
+    object.languages.map { |language| h.humanize_uri(:digitization, :language, language) }
+  end
+
+end

--- a/app/models/digitization/newspaper.rb
+++ b/app/models/digitization/newspaper.rb
@@ -4,6 +4,8 @@ class Digitization::Newspaper < JupiterCore::Depositable
 
   belongs_to :owner, class_name: 'User'
 
+  has_solr_exporter Exporters::Solr::Digitization::BookExporter
+
   validates :publication_code, uniqueness: { scope: [:year, :month, :day] }
   validates :year, :month, :day, presence: true, if: :publication_code?
 

--- a/app/views/digitization/newspapers/_item_more_information.html.erb
+++ b/app/views/digitization/newspapers/_item_more_information.html.erb
@@ -1,0 +1,79 @@
+<ul class="list-group">
+  <% if @digitization_newspaper.languages.present? %>
+    <li class="list-unstyled list-group-item-action">
+      <dl>
+        <dt><%= t('digitization.newspapers.newspaper.language') %></dt>
+        <dd>
+          <ul class="list-unstyled">
+            <% @digitization_newspaper.languages.each do |language| %>
+              <li><%= language_search_link(@digitization_newspaper, language) %></li>
+            <% end %>
+          </ul>
+        </dd>
+      </dl>
+    </li>
+  <% end %>
+
+  <% if @digitization_newspaper.genres.present? %>
+    <li class="list-unstyled list-group-item-action">
+      <dl>
+        <dt><%= t('digitization.newspapers.newspaper.genre') %></dt>
+        <dd>
+          <ul class="list-unstyled">
+            <% @digitization_newspaper.genres.each do |genre| %>
+              <li><%= genre_search_link(@digitization_newspaper, genre) %></li>
+            <% end %>
+          </ul>
+        </dd>
+      </dl>
+    </li>
+  <% end %>
+
+  <% if @digitization_newspaper.places_of_publication.present? %>
+    <li class="list-unstyled list-group-item-action">
+      <dl>
+        <dt><%= t('digitization.newspapers.newspaper.place_of_publication') %></dt>
+        <dd>
+          <ul class="list-unstyled">
+            <% @digitization_newspaper.places_of_publication.each do |place| %>
+              <li><%= place_of_publication_search_link(@digitization_newspaper, place) %></li>
+            <% end %>
+          </ul>
+        </dd>
+      </dl>
+    </li>
+  <% end %>
+
+  <% if @digitization_newspaper.extent.present? %>
+    <li class="list-unstyled list-group-item-action">
+      <dl>
+        <dt><%= t('digitization.newspapers.newspaper.extent') %></dt>
+        <dd><%= @digitization_newspaper.extent %></dd>
+      </dl>
+    </li>
+  <% end %>
+
+  <% if @digitization_newspaper.volume_label.present? %>
+    <li class="list-unstyled list-group-item-action">
+      <dl>
+        <dt><%= t('digitization.newspapers.newspaper.extent') %></dt>
+        <dd><%= @digitization_newspaper.volume_label %></dd>
+      </dl>
+    </li>
+  <% end %>
+
+  <% if @digitization_newspaper.editions.present? %>
+    <li class="list-unstyled list-group-item-action">
+      <dl>
+        <dt><%= t('digitization.newspapers.newspaper.place_of_publication') %></dt>
+        <dd>
+          <ul class="list-unstyled">
+            <% @digitization_newspaper.editions.each do |edition| %>
+              <li><%= edition %></li>
+            <% end %>
+          </ul>
+        </dd>
+      </dl>
+    </li>
+  <% end %>
+</ul>

--- a/app/views/digitization/newspapers/_newspaper.html.erb
+++ b/app/views/digitization/newspapers/_newspaper.html.erb
@@ -1,0 +1,94 @@
+<%# Be cautious of refactoring to decrease duplication with item and thesis.  Ordering attributes depending on context is highly desired. %>
+<ul class="list-group">
+  <% if @digitization_newspaper.alternative_title.present? %>
+    <li class="list-unstyled list-group-item-action">
+      <p title="<%= t('items.show.alternative_title') %>"><%= @digitization_newspaper.alternative_title %></p>
+    </li>
+  <% end %>
+
+  <% if @digitization_newspaper.description.present? %>
+    <li class="list-unstyled list-group-item-action">
+      <p title="<%= t('.description') %>"><%= @digitization_newspaper.description %></p>
+    </li>
+  <% end %>
+
+  <% if @digitization_newspaper.creation_date.present? %>
+    <li class="list-unstyled list-group-item-action">
+      <dl>
+        <dt><%= t('.created') %></dt>
+        <% if @digitization_newspaper.sort_year.present? %>
+          <%# Display the recorded date created, but link to searching on the facetable sort year if it is present %>
+          <dd><%= search_link_for(@digitization_newspaper, :sort_year, display: humanize_date(@digitization_newspaper.creation_date), facet: :range_facet) %></dd>
+        <% else %>
+          <dd><%= humanize_date(@digitization_newspaper.creation_date) %></dd>
+        <% end %>
+      </dl>
+    </li>
+  <% end %>
+
+  <% if @digitization_newspaper.volume_label.present? %>
+    <li class="list-unstyled list-group-item-action">
+      <dl>
+        <dt><%= t('.volume_label') %></dt>
+        <dd><%= @digitization_newspaper.volume_label %></dd>
+      </dl>
+    </li>
+  <% end %>
+
+  <% if @digitization_newspaper.all_subjects.present? %>
+    <li class="list-unstyled list-group-item-action">
+      <dl>
+        <dt><%= t('items.show.subject') %></dt>
+        <dd>
+          <ul class="list-unstyled">
+            <% @digitization_newspaper.all_subjects.each do |subject| %>
+              <li><%= subject_search_link(@digitization_newspaper, subject) %></li>
+            <% end %>
+          </ul>
+        </dd>
+      </dl>
+    </li>
+  <% end %>
+
+ <% if @digitization_newspaper.resource_type.present? %>
+    <li class="list-unstyled list-group-item-action">
+      <dl>
+        <dt><%= t('.item_type') %></dt>
+        <dd><%= type_search_link(@digitization_newspaper) %></dd>
+      </dl>
+    </li>
+  <% end %>
+
+  <li class="list-unstyled list-group-item-action">
+    <dl>
+      <dt><%= t('items.show.license') %></dt>
+      <% if @digitization_newspaper.rights.present? %>
+        <dd><%= rights_search_link(@digitization_newspaper) %></dd>
+      <% end %>
+    </dl>
+  </li>
+</ul>
+
+<%# ADDITIONAL INFORMATION %>
+<button type="button"
+        data-toggle="collapse"
+        data-target="#more-information-hidden"
+        aria-expanded="false"
+        aria-controls="more-information-hidden"
+        class="btn btn-outline-secondary mb-3 js-more-information-btn font-italic">
+    <span class="js-more-information-hidden">
+      <%= t(:more_information) %>
+      <%= icon('fas', 'chevron-down') %>
+    </span>
+
+    <span class="d-none js-more-information-shown">
+      <%= t(:show_less) %>
+      <%= icon('fas', 'chevron-up') %>
+    </span>
+</button>
+
+<div class="collapse" id='more-information-hidden'>
+  <%= render partial: 'item_more_information' %>
+</div>
+
+<%= render partial: 'edit_history', locals: { item: @digitization_newspaper } %>

--- a/app/views/digitization/newspapers/show.html.erb
+++ b/app/views/digitization/newspapers/show.html.erb
@@ -1,22 +1,85 @@
-<dl>
-<% if @digitization_newspaper.publication_code.present? %>
-  <dt><%= t('digitization.publication_code') %></dt>
-  <dd><%= @digitization_newspaper.publication_code %></dd>
+<%# TODO: Google Scholar Metadata %>
+
+<% content_for :extra_social_meta do %>
+
+  <% if @digitization_newspaper.copyright.present? %>
+    <meta name="twitter:label2" content="Rights">
+    <meta name="twitter:data2" content="<%= @digitization_newspaper.copyright %>">
+  <% end %>
 <% end %>
 
-<% if @digitization_newspaper.year.present? %>
-  <dt><%= t('digitization.year') %></dt>
-  <dd><%= @digitization_newspaper.year %></dd>
-<% end %>
+<% page_title(@digitization_newspaper.title) %>
+<% page_description(description(@digitization_newspaper)) %>
 
-<% if @digitization_newspaper.month.present? %>
-  <dt><%= t('digitization.month') %></dt>
-  <dd><%= @digitization_newspaper.month %></dd>
-<% end %>
+<div class="container mt-3">
 
-<% if @digitization_newspaper.day.present? %>
-  <dt><%= t('digitization.day') %></dt>
-  <dd><%= @digitization_newspaper.day %></dd>
-<% end %>
+  <%# Breadcrumbs here are for 'Home->Search->Item' %>
+  <%# Community/collection based links appear in own section below' %>
+  <div class="item-breadcrumb">
+    <ol class="breadcrumb mb-1">
+      <li class="breadcrumb-item">
+        <%= link_to(t(:home), root_path) %>
+      </li>
+      <li class="breadcrumb-item">
+        <%= link_to(t(:search_label), search_path) %>
+      </li>
+      <li class="breadcrumb-item active"><%= @digitization_newspaper.title %></li>
+    </ol>
+  </div>
 
-</dl>
+  <div class="row">
+    <%# LEFT SIDE %>
+    <div class="col-md-4 mt-5">
+      <%# FILES SIDEBAR %>
+
+      <%# COMMUNITY/COLLECTION PATHS %>
+      <div class="card">
+        <div class="card-header">
+          <%= t('digitization.collection.title') %>
+        </div>
+        <div class="card-body p-2">
+          <ul class="list-group">
+            <% @digitization_newspaper.each_community_collection do |community, collection| %>
+              <li class="list-group-item list-group-item-action">
+                <%= link_to(community.title, community_path(community)) %> /
+                <%= link_to(collection.title, community_collection_path(community, collection)) %>
+              </li>
+            <% end %>
+          </ul>
+        </div>
+      </div>
+
+      <div class="card mt-3">
+        <div class="card-header">
+          <%= t('.usage') %>
+        </div>
+        <div class="card-body p-2">
+          <ul class="list-group">
+            <li class="list-group-item"><%= t('.views', count: @views_count) %></li>
+            <li class="list-group-item"><%= t('.downloads', count: @downloads_count) %></li>
+          </ul>
+        </div>
+      </div>
+
+      <%# ADMIN SIDEBAR %>
+      <% if current_user&.admin? && display_admin_sidebar(@digitization_newspaper) %>
+        <%= render partial: 'admin_sidebar' %>
+      <% end %>
+    </div>
+
+    <%# MAIN CONTENT %>
+    <div class="col-md-8 pl-5 mt-5">
+      <% if policy(@digitization_newspaper).edit? %>
+        <%= link_to edit_item_path(@digitization_newspaper),
+                    class: 'btn btn-outline-secondary float-right' do %>
+            <%= icon('fas', 'edit') %>
+            <%= t('edit') %>
+        <% end %>
+      <% end %>
+
+      <h1 title="<%= t('items.show.title') %>"><%= @digitization_newspaper.title %></h1>
+
+      <%= render @digitization_newspaper %>
+    </div>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -557,6 +557,21 @@ en:
         language: 'Language'
         place_of_publication: 'Place of Publication'
         extent: 'Extent'
+    newspapers:
+      show:
+        usage: 'Usage'
+        views: 'Views'
+        downloads: 'Download'   
+      newspaper:
+        creators: 'Author / Creator'
+        description: 'Notes'
+        created: 'Date Created'
+        volume_label: 'Volume & Issue'
+        item_type: 'Type of Item'
+        genre: 'Genre'
+        language: 'Language'
+        place_of_publication: 'Place of Publication'
+        extent: 'Extent' 
     peel_image_id: 'Peel Image Id'
     peel_map_id: 'Peel Map Id'
     publication_code: 'Publication code'

--- a/test/models/digitization/newspaper_test.rb
+++ b/test/models/digitization/newspaper_test.rb
@@ -17,7 +17,6 @@ class Digitization::NewspaperTest < ActiveSupport::TestCase
                                                day: '29')
     assert_not newspaper.valid?
     assert_equal('has already been taken', newspaper.errors[:publication_code].first)
-    newspaper.destroy
   end
 
   test 'invalid Peel newspaper' do

--- a/test/system/digitization/newspaper_show_test.rb
+++ b/test/system/digitization/newspaper_show_test.rb
@@ -1,0 +1,16 @@
+require 'application_system_test_case'
+
+class Digitization::NewspaperShowTest < ApplicationSystemTestCase
+
+  setup do
+    Capybara.app_host = 'http://digitalcollections.ualberta.localhost'
+  end
+  test 'Newspapers are working correctly' do
+    visit digitization_newspaper_url(digitization_newspapers(:central_alberta_news))
+
+    assert_selector 'h1', text: 'The advertiser and central Alberta news', count: 1
+    assert_selector 'dt', text: 'Type of Item', count: 1
+    assert_selector 'dd a', text: 'Text', count: 1
+  end
+
+end


### PR DESCRIPTION
## Context

![image](https://user-images.githubusercontent.com/1220762/144920698-0be873eb-61ce-4134-90fc-105b68230564.png)

This may seem very similar to the book view/decorators and they are.  But we want the flexibility for each type to have different order and attributes.  For this flexibility we accept the duplication.

Related to #2649

## What's New

This is the first draft which basically copied the existing Item views, helper, exporter and decorator then used the decorator to map similar but differently named terms. Also added basic tests.
