### PR TITLE
Strong Migrations should be in all envs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ New entries in this file should aim to provide a meaningful amount of informatio
 
 ## [Unreleased]
 
+## [2.3.1] - 2021-12-07
+
+- Fix Gemfile so that `strong_migrations` is usesd in all environments
+
 ## [2.3.0] - 2021-12-01
 
 - The EZID Compatibility API is sunsetting at the end of this year, per https://blog.datacite.org/sunsetting-of-the-ez-api/.  [datacite-client](https://github.com/pgwillia/datacite-client) is a ruby gem that wraps the [Datacite API](https://support.datacite.org/reference/introduction) for our use.  The main changes are the DOI's no longer have the `doi:` prefix, the format of metadata attributes, and the event mechanism for publishing/hiding the metadata from the public. Requires `datacite_api` feature flag and new secrets for our datacite credentials. [#2268](https://github.com/ualbertalib/jupiter/issues/2268)

--- a/Gemfile
+++ b/Gemfile
@@ -29,6 +29,7 @@ gem 'connection_pool'
 gem 'pg', '~> 1.2.3'
 gem 'redis', '~> 4.1'
 gem 'rsolr'
+gem 'strong_migrations', '~> 0.7.8'
 
 # Authentication
 gem 'bcrypt', '>= 3.1.13'
@@ -101,8 +102,6 @@ group :development, :test do
   gem 'rubocop-minitest', require: false
   gem 'rubocop-performance', require: false
   gem 'rubocop-rails', require: false
-
-  gem 'strong_migrations', '~> 0.7.8'
 end
 
 group :development do

--- a/lib/jupiter/version.rb
+++ b/lib/jupiter/version.rb
@@ -1,3 +1,3 @@
 module Jupiter
-  VERSION = '2.3.0'.freeze
+  VERSION = '2.3.1'.freeze
 end


### PR DESCRIPTION
## Context
Deploying 2.3.0 to staging was unsuccessful at the precompile assets stage
> I got an error message while precompile:assets. It is about strong_migrations

> uninitialized constant StrongMigrations (NameError)

I had put the `strong_migration` gem in the development and test group but the initializer is for all environments.  I realized my mistake and have moved the gem in the Gemfile.

## What's New

`strong_migration` gem used in all environments

Also bumped the version in preparation for a bug fix release.