### PR TITLE
Fixed nil error when viewing Collection drop down

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ New entries in this file should aim to provide a meaningful amount of informatio
 
 ## [Unreleased]
 
+### Fixed
+- nil Class error when viewing Collections drop down on Communities page [#2655](https://github.com/ualbertalib/jupiter/issues/2655)
+
 ## [2.3.1] - 2021-12-07
 
 - Fix Gemfile so that `strong_migrations` is usesd in all environments

--- a/app/controllers/communities_controller.rb
+++ b/app/controllers/communities_controller.rb
@@ -34,7 +34,7 @@ class CommunitiesController < ApplicationController
       end
       format.js do
         # Used for the collapsable dropdown to show member collections
-        @collections = @community.collections.order(Collection.sort_order(params))
+        @collections = community.collections.order(Collection.sort_order(params))
         @community = community.decorate
       end
 

--- a/test/controllers/communities_controller_test.rb
+++ b/test/controllers/communities_controller_test.rb
@@ -16,4 +16,14 @@ class CommunitiesControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  test 'should show community js' do
+    get community_url(@community, format: :js), xhr: true
+    assert_response :success
+  end
+
+  test 'should show community json' do
+    get community_url(@community, format: :json)
+    assert_response :success
+  end
+
 end


### PR DESCRIPTION
## Context

Missed change from `@community` to `community` in a refactor.  Began in 2.2.0.

Related to https://github.com/ualbertalib/jupiter/issues/2655

## What's New
Collections drop down on Communities page is fixed
![image](https://user-images.githubusercontent.com/1220762/145248318-2f3a243b-b244-4255-b6e1-a0fe74574dfb.png)
