### PR TITLE
Add healthcheck page for asserting health of application

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ New entries in this file should aim to provide a meaningful amount of informatio
 
 ## [Unreleased]
 
+### Added
+- Add readiness healthchecks for Rails and Sidekiq [PR#2657](https://github.com/ualbertalib/jupiter/pull/2657)
+
 ## [2.3.3] - 2022-01-19
 
 ### Fixed

--- a/app/controllers/healthcheck_controller.rb
+++ b/app/controllers/healthcheck_controller.rb
@@ -1,0 +1,9 @@
+class HealthcheckController < ApplicationController
+
+  skip_after_action :verify_authorized
+
+  def index
+    render json: { code: 200, status: 'OK' }, status: :ok
+  end
+
+end

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -2,4 +2,10 @@ class StaticPagesController < ApplicationController
 
   skip_after_action :verify_authorized
 
+  def about; end
+
+  def contact; end
+
+  def policies; end
+
 end

--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -2,4 +2,6 @@ class WelcomeController < ApplicationController
 
   skip_after_action :verify_authorized
 
+  def index; end
+
 end

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,4 +1,4 @@
-SIDEKIQ_WILL_PROCESSES_JOBS_FILE = Rails.root.join('tmp/sidekiq_process_has_started_and_will_begin_processing_jobs').freeze
+SIDEKIQ_HAS_STARTED_FILE = Rails.root.join('tmp/sidekiq_process_has_started').freeze
 
 Sidekiq.configure_server do |config|
   config.redis = { url: Rails.application.secrets.redis_url }
@@ -12,11 +12,11 @@ Sidekiq.configure_server do |config|
   # Doing this gives us a better sense of when a process is actually
   # alive and healthy, rather than just beginning the boot process.
   config.on(:startup) do
-    FileUtils.touch(SIDEKIQ_WILL_PROCESSES_JOBS_FILE)
+    FileUtils.touch(SIDEKIQ_HAS_STARTED_FILE)
   end
 
   config.on(:shutdown) do
-    FileUtils.rm_f(SIDEKIQ_WILL_PROCESSES_JOBS_FILE)
+    FileUtils.rm_f(SIDEKIQ_HAS_STARTED_FILE)
   end
 end
 

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,8 +1,23 @@
+SIDEKIQ_WILL_PROCESSES_JOBS_FILE = Rails.root.join('tmp/sidekiq_process_has_started_and_will_begin_processing_jobs').freeze
+
 Sidekiq.configure_server do |config|
   config.redis = { url: Rails.application.secrets.redis_url }
 
   schedule_file = 'config/schedule.yml'
   Sidekiq::Cron::Job.load_from_hash YAML.load_file(schedule_file) if File.exist?(schedule_file)
+
+  # We touch and destroy files in the Sidekiq lifecycle to provide a
+  # signal to Kubernetes that we are ready to process jobs or not.
+  #
+  # Doing this gives us a better sense of when a process is actually
+  # alive and healthy, rather than just beginning the boot process.
+  config.on(:startup) do
+    FileUtils.touch(SIDEKIQ_WILL_PROCESSES_JOBS_FILE)
+  end
+
+  config.on(:shutdown) do
+    FileUtils.rm_f(SIDEKIQ_WILL_PROCESSES_JOBS_FILE)
+  end
 end
 
 Sidekiq.configure_client do |config|

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -181,4 +181,6 @@ Rails.application.routes.draw do
       resources :books, :newspapers, :images, :maps, concerns: :downloadable
     end
   end
+
+  get 'healthcheck', to: 'healthcheck#index'
 end

--- a/test/controllers/healthcheck_controller_test.rb
+++ b/test/controllers/healthcheck_controller_test.rb
@@ -1,0 +1,14 @@
+require 'test_helper'
+
+class HealthcheckControllerTest < ActionDispatch::IntegrationTest
+
+  test 'should get healthcheck' do
+    get healthcheck_url
+
+    assert_response :success
+    response = JSON.parse(@response.body)
+    assert_equal 200, response['code']
+    assert_equal 'OK', response['status']
+  end
+
+end


### PR DESCRIPTION
https://cloud.google.com/blog/products/containers-kubernetes/kubernetes-best-practices-setting-up-health-checks-with-readiness-and-liveness-probes

Add readiness healthcheck for jupiter and sidekiq processes. This will be very useful for Operations team or for readiness checking within Kubernetes