### PR TITLE
Fixed markdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ New entries in this file should aim to provide a meaningful amount of informatio
 
 ### Fixed
 - nil Class error when viewing Collections drop down on Communities page [#2655](https://github.com/ualbertalib/jupiter/issues/2655)
+- Render markdown when viewing Communities as an administrator [#1322](https://github.com/ualbertalib/jupiter/issues/1322)
 
 ## [2.3.1] - 2021-12-07
 

--- a/app/controllers/admin/communities_controller.rb
+++ b/app/controllers/admin/communities_controller.rb
@@ -5,7 +5,7 @@ class Admin::CommunitiesController < Admin::AdminController
   def index
     respond_to do |format|
       format.html do
-        @communities = Community.order(Community.sort_order(params)).page params[:page]
+        @communities = Community.order(Community.sort_order(params)).page(params[:page]).decorate
         @title = t('.header')
         render template: 'communities/index'
       end
@@ -26,6 +26,7 @@ class Admin::CommunitiesController < Admin::AdminController
   end
 
   def show
+    @community = @community.decorate
     respond_to do |format|
       format.js do
         # Used for the collapsable dropdown to show member collections

--- a/test/fixtures/communities.yml
+++ b/test/fixtures/communities.yml
@@ -14,6 +14,7 @@ community_thesis:
 
 community_fancy:
   title: "Fancy Community"
+  description: '[Markdown link](http://example.com)'
   owner: user_admin
   record_created_at: <%= Time.zone.now - 3.hour %>
   created_at: <%= Time.zone.now - 3.hour %>

--- a/test/system/admin_communities_test.rb
+++ b/test/system/admin_communities_test.rb
@@ -1,0 +1,28 @@
+require 'application_system_test_case'
+
+class AdminCommunitiesIndexTest < ApplicationSystemTestCase
+
+  test 'should be able to see rendered markdown of a description for a community' do
+    admin = users(:user_admin)
+    community = communities(:community_fancy)
+
+    login_user(admin)
+
+    click_link admin.name # opens user dropdown which has the admin link
+    click_link I18n.t('application.navbar.links.admin')
+    click_link I18n.t('admin.communities.index.header')
+    assert_selector 'h1', text: I18n.t('admin.communities.index.header')
+
+    # Check for description as markdown
+    assert_link('Markdown link', href: 'http://example.com')
+
+    click_link community.title
+    assert_selector 'h1', text: community.title
+
+    # Check for description as markdown
+    assert_link('Markdown link', href: 'http://example.com')
+
+    logout_user
+  end
+
+end


### PR DESCRIPTION
## Context

Overlooked the admin view of the communities description.  

Related to #1322

Before;
![image](https://user-images.githubusercontent.com/1220762/146619851-0859f8a2-631a-4450-b4d7-c97ed41ff86b.png)

After:
![image](https://user-images.githubusercontent.com/1220762/146619812-89a8f5fa-6f9a-474e-88ac-21a6a5b97621.png)

## What's New

Fixed by decorating the Community objects in the admin controller, added a description to a community fixture and tested.