### PR TITLE
Fixed markdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ New entries in this file should aim to provide a meaningful amount of informatio
 ### Fixed
 - Bring back illogical date range faceting flash message [#2030](https://github.com/ualbertalib/jupiter/issues/2030)
 - Thesis not being assigned a DOI [#2707](https://github.com/ualbertalib/jupiter/issues/2707)
+- Render markdown when viewing Collections as an administrator [#2708](https://github.com/ualbertalib/jupiter/issues/2708)
 
 ## [2.3.2] - 2022-01-10
 

--- a/app/controllers/admin/collections_controller.rb
+++ b/app/controllers/admin/collections_controller.rb
@@ -13,6 +13,7 @@ class Admin::CollectionsController < Admin::AdminController
 
     @results = search_query_index.results
     @search_models = search_query_index.search_models
+    @collection = @collection.decorate
 
     respond_to do |format|
       format.html { render template: 'collections/show' }

--- a/test/fixtures/collections.yml
+++ b/test/fixtures/collections.yml
@@ -24,6 +24,7 @@ collection_embargoed:
 collection_fancy:
   title: 'Fancy Collection'
   owner: user_admin
+  description: '[Linked markdown](http://example.com)'
   community: community_fancy
   record_created_at: <%= Time.zone.now - 1.hour %>
   date_ingested: <%= Time.zone.now - 1.hour %>

--- a/test/system/admin_communities_test.rb
+++ b/test/system/admin_communities_test.rb
@@ -2,9 +2,10 @@ require 'application_system_test_case'
 
 class AdminCommunitiesIndexTest < ApplicationSystemTestCase
 
-  test 'should be able to see rendered markdown of a description for a community' do
+  test 'should be able to see rendered markdown of a description for a community and collection' do
     admin = users(:user_admin)
     community = communities(:community_fancy)
+    collection = collections(:collection_fancy)
 
     login_user(admin)
 
@@ -21,6 +22,12 @@ class AdminCommunitiesIndexTest < ApplicationSystemTestCase
 
     # Check for description as markdown
     assert_link('Markdown link', href: 'http://example.com')
+
+    click_link collection.title
+    assert_selector 'h1', text: collection.title
+
+    # Check for description as markdown
+    assert_link('Linked markdown', href: 'http://example.com')
 
     logout_user
   end


### PR DESCRIPTION
## Context

Overlooked the admin view of the collections description.  
Related to #2708 

Before:
![image](https://user-images.githubusercontent.com/1220762/150194904-7f927dd3-6497-46f6-b73a-597b49be0c7e.png)

After:
![image](https://user-images.githubusercontent.com/1220762/150194680-80496dbc-e83f-4b6a-9ec0-f94aed3a2401.png)

## What's New

Fixed by decorating the Collection objects in the admin controller and tested.