### PR TITLE
Bump sidekiq 6.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ New entries in this file should aim to provide a meaningful amount of informatio
 
 ### Security
 - Bump Sidekiq from 5.2.9 to 6.4.1 [#2189](https://github.com/ualbertalib/jupiter/issues/2189)
+- Bump follow-redirects
+- Bump puma
+- Bump actionpack 
 
 ## [2.3.3] - 2022-01-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,12 @@ New entries in this file should aim to provide a meaningful amount of informatio
 
 ## [Unreleased]
 
+## [2.3.4] - 2022-02-08
 ### Added
 - Add readiness healthchecks for Rails and Sidekiq [PR#2657](https://github.com/ualbertalib/jupiter/pull/2657)
+
+### Security
+- Bump Sidekiq from 5.2.9 to 6.4.1 [#2189](https://github.com/ualbertalib/jupiter/issues/2189)
 
 ## [2.3.3] - 2022-01-19
 

--- a/Gemfile
+++ b/Gemfile
@@ -41,7 +41,7 @@ gem 'omniauth-saml', '~> 2.0'
 gem 'pundit', '1.1.0'
 
 # Background tasks
-gem 'sidekiq', '~> 6.2.0'
+gem 'sidekiq', '~> 6.3.0'
 gem 'sidekiq-cron'
 gem 'sidekiq-unique-jobs', '~> 7.1'
 

--- a/Gemfile
+++ b/Gemfile
@@ -41,7 +41,7 @@ gem 'omniauth-saml', '~> 2.0'
 gem 'pundit', '1.1.0'
 
 # Background tasks
-gem 'sidekiq', '~> 5.2'
+gem 'sidekiq', '~> 6.0'
 gem 'sidekiq-cron'
 gem 'sidekiq-unique-jobs', '~> 7.1'
 

--- a/Gemfile
+++ b/Gemfile
@@ -41,7 +41,7 @@ gem 'omniauth-saml', '~> 2.0'
 gem 'pundit', '1.1.0'
 
 # Background tasks
-gem 'sidekiq', '~> 6.0'
+gem 'sidekiq', '6.1'
 gem 'sidekiq-cron'
 gem 'sidekiq-unique-jobs', '~> 7.1'
 

--- a/Gemfile
+++ b/Gemfile
@@ -42,10 +42,8 @@ gem 'pundit', '1.1.0'
 
 # Background tasks
 gem 'sidekiq', '~> 5.2'
-gem 'sidekiq-unique-jobs', '~> 7.1'
-gem 'sinatra', '~> 2.1.0' # used by sidekiq/web
-# Sidekiq cron jobs
 gem 'sidekiq-cron'
+gem 'sidekiq-unique-jobs', '~> 7.1'
 
 # Misc Utilities
 gem 'aasm' # state-machine management

--- a/Gemfile
+++ b/Gemfile
@@ -41,7 +41,7 @@ gem 'omniauth-saml', '~> 2.0'
 gem 'pundit', '1.1.0'
 
 # Background tasks
-gem 'sidekiq', '6.1'
+gem 'sidekiq', '~> 6.2.0'
 gem 'sidekiq-cron'
 gem 'sidekiq-unique-jobs', '~> 7.1'
 

--- a/Gemfile
+++ b/Gemfile
@@ -41,7 +41,7 @@ gem 'omniauth-saml', '~> 2.0'
 gem 'pundit', '1.1.0'
 
 # Background tasks
-gem 'sidekiq', '~> 6.3.0'
+gem 'sidekiq', '~> 6.4'
 gem 'sidekiq-cron'
 gem 'sidekiq-unique-jobs', '~> 7.1'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -507,11 +507,11 @@ GEM
     semantic_range (3.0.0)
     shoulda-matchers (5.1.0)
       activesupport (>= 5.2.0)
-    sidekiq (5.2.9)
-      connection_pool (~> 2.2, >= 2.2.2)
+    sidekiq (6.0.7)
+      connection_pool (>= 2.2.2)
       rack (~> 2.0)
-      rack-protection (>= 1.5.0)
-      redis (>= 3.3.5, < 4.2)
+      rack-protection (>= 2.0.0)
+      redis (>= 4.1.0)
     sidekiq-cron (1.2.0)
       fugit (~> 1.1)
       sidekiq (>= 4.2.1)
@@ -674,7 +674,7 @@ DEPENDENCIES
   sdoc
   selenium-webdriver
   shoulda-matchers (~> 5.1)
-  sidekiq (~> 5.2)
+  sidekiq (~> 6.0)
   sidekiq-cron
   sidekiq-unique-jobs (~> 7.1)
   simple_form
@@ -696,4 +696,4 @@ RUBY VERSION
    ruby 2.7.3p183
 
 BUNDLED WITH
-   2.1.4
+   2.3.6

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -205,7 +205,7 @@ GEM
       rubocop
       smart_properties
     erubi (1.10.0)
-    et-orbi (1.2.4)
+    et-orbi (1.2.6)
       tzinfo
     ezid-client (1.8.0)
       hashie (~> 3.4, >= 3.4.3)
@@ -248,7 +248,7 @@ GEM
       rack (>= 1.4, < 3)
       rack-protection (>= 1.5.3, < 2.2.0)
       sanitize (< 7)
-    fugit (1.4.5)
+    fugit (1.5.2)
       et-orbi (~> 1.1, >= 1.1.8)
       raabro (~> 1.4)
     gems (1.2.0)
@@ -507,7 +507,7 @@ GEM
     semantic_range (3.0.0)
     shoulda-matchers (5.1.0)
       activesupport (>= 5.2.0)
-    sidekiq (6.3.1)
+    sidekiq (6.4.1)
       connection_pool (>= 2.2.2)
       rack (~> 2.0)
       redis (>= 4.2.0)
@@ -673,7 +673,7 @@ DEPENDENCIES
   sdoc
   selenium-webdriver
   shoulda-matchers (~> 5.1)
-  sidekiq (~> 6.3.0)
+  sidekiq (~> 6.4)
   sidekiq-cron
   sidekiq-unique-jobs (~> 7.1)
   simple_form

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -446,7 +446,7 @@ GEM
       rexml (~> 3.2)
     rdoc (6.3.3)
     redcarpet (3.5.1)
-    redis (4.1.4)
+    redis (4.6.0)
     regexp_parser (2.2.1)
     representable (3.1.1)
       declarative (< 0.1.0)
@@ -507,11 +507,10 @@ GEM
     semantic_range (3.0.0)
     shoulda-matchers (5.1.0)
       activesupport (>= 5.2.0)
-    sidekiq (6.0.7)
+    sidekiq (6.1.0)
       connection_pool (>= 2.2.2)
       rack (~> 2.0)
-      rack-protection (>= 2.0.0)
-      redis (>= 4.1.0)
+      redis (>= 4.2.0)
     sidekiq-cron (1.2.0)
       fugit (~> 1.1)
       sidekiq (>= 4.2.1)
@@ -674,7 +673,7 @@ DEPENDENCIES
   sdoc
   selenium-webdriver
   shoulda-matchers (~> 5.1)
-  sidekiq (~> 6.0)
+  sidekiq (= 6.1)
   sidekiq-cron
   sidekiq-unique-jobs (~> 7.1)
   simple_form

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -339,8 +339,6 @@ GEM
     msgpack (1.4.4)
     multi_json (1.15.0)
     multipart-post (2.1.1)
-    mustermann (1.1.1)
-      ruby2_keywords (~> 0.0.1)
     nanoid (2.0.0)
     nap (1.1.0)
     net-http-persistent (4.0.1)
@@ -536,11 +534,6 @@ GEM
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.3)
-    sinatra (2.1.0)
-      mustermann (~> 1.0)
-      rack (~> 2.2)
-      rack-protection (= 2.1.0)
-      tilt (~> 2.0)
     skylight (4.3.2)
       skylight-core (= 4.3.2)
     skylight-core (4.3.2)
@@ -577,7 +570,6 @@ GEM
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
     thor (1.2.1)
-    tilt (2.0.10)
     trailblazer-option (0.1.1)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
@@ -687,7 +679,6 @@ DEPENDENCIES
   sidekiq-unique-jobs (~> 7.1)
   simple_form
   simplecov
-  sinatra (~> 2.1.0)
   skylight (~> 4.3)
   spring
   spring-watcher-listen (~> 2.0.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -507,7 +507,7 @@ GEM
     semantic_range (3.0.0)
     shoulda-matchers (5.1.0)
       activesupport (>= 5.2.0)
-    sidekiq (6.1.0)
+    sidekiq (6.2.2)
       connection_pool (>= 2.2.2)
       rack (~> 2.0)
       redis (>= 4.2.0)
@@ -673,7 +673,7 @@ DEPENDENCIES
   sdoc
   selenium-webdriver
   shoulda-matchers (~> 5.1)
-  sidekiq (= 6.1)
+  sidekiq (~> 6.2.0)
   sidekiq-cron
   sidekiq-unique-jobs (~> 7.1)
   simple_form

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -507,7 +507,7 @@ GEM
     semantic_range (3.0.0)
     shoulda-matchers (5.1.0)
       activesupport (>= 5.2.0)
-    sidekiq (6.2.2)
+    sidekiq (6.3.1)
       connection_pool (>= 2.2.2)
       rack (~> 2.0)
       redis (>= 4.2.0)
@@ -673,7 +673,7 @@ DEPENDENCIES
   sdoc
   selenium-webdriver
   shoulda-matchers (~> 5.1)
-  sidekiq (~> 6.2.0)
+  sidekiq (~> 6.3.0)
   sidekiq-cron
   sidekiq-unique-jobs (~> 7.1)
   simple_form

--- a/app/models/jupiter_core/depositable.rb
+++ b/app/models/jupiter_core/depositable.rb
@@ -160,7 +160,7 @@ class JupiterCore::Depositable < ApplicationRecord
   def push_entity_for_preservation
     queue_name = Rails.application.secrets.preservation_queue_name
 
-    $queue ||= ConnectionPool.new(size: 1, timeout: 5) { Cache.redis }
+    $queue ||= ConnectionPool.new(size: 1, timeout: 5) { RedisClient.current }
 
     $queue.with do |connection|
       # pushmi_pullyu requires both the id and type of the depositable

--- a/app/models/jupiter_core/depositable.rb
+++ b/app/models/jupiter_core/depositable.rb
@@ -160,7 +160,7 @@ class JupiterCore::Depositable < ApplicationRecord
   def push_entity_for_preservation
     queue_name = Rails.application.secrets.preservation_queue_name
 
-    $queue ||= ConnectionPool.new(size: 1, timeout: 5) { Redis.current }
+    $queue ||= ConnectionPool.new(size: 1, timeout: 5) { Cache.redis }
 
     $queue.with do |connection|
       # pushmi_pullyu requires both the id and type of the depositable

--- a/app/services/statistics.rb
+++ b/app/services/statistics.rb
@@ -9,11 +9,11 @@ class Statistics
   end
 
   def self.views_for(item_id:)
-    Cache.redis.get(counter_key_for(:view, item_id)).to_i || 0
+    RedisClient.current.get(counter_key_for(:view, item_id)).to_i || 0
   end
 
   def self.downloads_for(item_id:)
-    Cache.redis.get(counter_key_for(:download, item_id)).to_i || 0
+    RedisClient.current.get(counter_key_for(:download, item_id)).to_i || 0
   end
 
   # Conveinience method for fetching all counts for a given item. The expectation is that you probably want to
@@ -35,13 +35,13 @@ class Statistics
       # based on some experimentation, key sizes for pfadd seems slightly more space and time efficient
       # than a scored set approach, but if imprecision becomes an issue we could revisit that as an alternative
       # at the cost of some space if items get "hot"
-      is_new_visit = Cache.redis.pfadd(uniques_filter_key, ip)
+      is_new_visit = RedisClient.current.pfadd(uniques_filter_key, ip)
 
       # ip filters reset at the top of the hour, so if the key was freshly (re-)created we need to set its TTL
-      Cache.redis.expireat(uniques_filter_key, Time.current.end_of_hour.to_i)
+      RedisClient.current.expireat(uniques_filter_key, Time.current.end_of_hour.to_i)
       return unless is_new_visit
 
-      Cache.redis.incr(counter_key)
+      RedisClient.current.incr(counter_key)
     end
 
     def uniques_key_for(action, id)

--- a/config/initializers/redis.rb
+++ b/config/initializers/redis.rb
@@ -1,1 +1,9 @@
-Redis.current = Redis.new(url: Rails.application.secrets.redis_url)
+module Cache
+  class << self
+
+    def redis
+      @redis ||= Redis.new(url: Rails.application.secrets.redis_url)
+    end
+
+  end
+end

--- a/config/initializers/redis.rb
+++ b/config/initializers/redis.rb
@@ -1,8 +1,14 @@
-module Cache
+module RedisClient
   class << self
 
-    def redis
-      @redis ||= Redis.new(url: Rails.application.secrets.redis_url)
+    # Starting with version 4.6.0 Redis.current has been deprecated.
+    # The author notes that typical multi-threaded applications will find a lot of locking around a shared redis client.
+    # They recommend to define an own place to get a redis client, but also suggest to use a connection pool.
+    # The accepted answer is therefore the simplest solution to achieve something comparable to Redis.current, but may
+    # not perform optimal in multi-threaded environments.
+    # https://stackoverflow.com/a/34673035
+    def current
+      @current ||= Redis.new(url: Rails.application.secrets.redis_url)
     end
 
   end

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -3,6 +3,16 @@ SIDEKIQ_HAS_STARTED_FILE = Rails.root.join('tmp/sidekiq_process_has_started').fr
 Sidekiq.configure_server do |config|
   config.redis = { url: Rails.application.secrets.redis_url }
 
+  config.client_middleware do |chain|
+    chain.add SidekiqUniqueJobs::Middleware::Client
+  end
+
+  config.server_middleware do |chain|
+    chain.add SidekiqUniqueJobs::Middleware::Server
+  end
+
+  SidekiqUniqueJobs::Server.configure(config)
+
   schedule_file = 'config/schedule.yml'
   if File.exist?(schedule_file) && Sidekiq.server?
     # use the after_initialze block to avoid deprecation warning triggered
@@ -29,6 +39,10 @@ end
 
 Sidekiq.configure_client do |config|
   config.redis = { url: Rails.application.secrets.redis_url }
+
+  config.client_middleware do |chain|
+    chain.add SidekiqUniqueJobs::Middleware::Client
+  end
 end
 
 require 'sidekiq/web'

--- a/lib/jupiter/version.rb
+++ b/lib/jupiter/version.rb
@@ -1,3 +1,3 @@
 module Jupiter
-  VERSION = '2.3.3'.freeze
+  VERSION = '2.3.4'.freeze
 end

--- a/lib/tasks/jupiter.rake
+++ b/lib/tasks/jupiter.rake
@@ -88,7 +88,7 @@ namespace :jupiter do
   task clear_preservation_queue: :environment do
     queue_name = Rails.application.secrets.preservation_queue_name
 
-    queue = ConnectionPool.new(size: 1, timeout: 5) { Cache.redis }
+    queue = ConnectionPool.new(size: 1, timeout: 5) { RedisClient.current }
     success = queue.with { |connection| connection.del queue_name }
     puts case success
          when 1

--- a/lib/tasks/jupiter.rake
+++ b/lib/tasks/jupiter.rake
@@ -88,7 +88,7 @@ namespace :jupiter do
   task clear_preservation_queue: :environment do
     queue_name = Rails.application.secrets.preservation_queue_name
 
-    queue = ConnectionPool.new(size: 1, timeout: 5) { Redis.current }
+    queue = ConnectionPool.new(size: 1, timeout: 5) { Cache.redis }
     success = queue.with { |connection| connection.del queue_name }
     puts case success
          when 1

--- a/test/models/item_test.rb
+++ b/test/models/item_test.rb
@@ -314,7 +314,7 @@ class ItemTest < ActiveSupport::TestCase
 
   # Preservation queue handling
   test 'should add id and type with the correct score for a new item to preservation queue' do
-    Redis.current.del Rails.application.secrets.preservation_queue_name
+    Cache.redis.del Rails.application.secrets.preservation_queue_name
 
     # Setup an item...
     community = communities(:community_books)
@@ -336,10 +336,10 @@ class ItemTest < ActiveSupport::TestCase
         unlocked_item.save
       end
 
-      item_output, score = Redis.current.zrange(Rails.application.secrets.preservation_queue_name,
-                                                0,
-                                                -1,
-                                                with_scores: true)[0]
+      item_output, score = Cache.redis.zrange(Rails.application.secrets.preservation_queue_name,
+                                              0,
+                                              -1,
+                                              with_scores: true)[0]
       item_output = JSON.parse(item_output)
 
       assert_equal item.id, item_output['uuid']
@@ -347,11 +347,11 @@ class ItemTest < ActiveSupport::TestCase
       assert_in_delta 0.5, score, Time.now.to_f
     end
 
-    Redis.current.del Rails.application.secrets.preservation_queue_name
+    Cache.redis.del Rails.application.secrets.preservation_queue_name
   end
 
   test 'should end up with the queue only having an item id once after multiple saves of the same item' do
-    Redis.current.del Rails.application.secrets.preservation_queue_name
+    Cache.redis.del Rails.application.secrets.preservation_queue_name
 
     # Setup an item...
     community = communities(:community_books)
@@ -381,22 +381,22 @@ class ItemTest < ActiveSupport::TestCase
         unlocked_item.save
       end
 
-      assert_equal 1, Redis.current.zcard(Rails.application.secrets.preservation_queue_name)
+      assert_equal 1, Cache.redis.zcard(Rails.application.secrets.preservation_queue_name)
 
-      item_output, score = Redis.current.zrange(Rails.application.secrets.preservation_queue_name,
-                                                0,
-                                                -1,
-                                                with_scores: true)[0]
+      item_output, score = Cache.redis.zrange(Rails.application.secrets.preservation_queue_name,
+                                              0,
+                                              -1,
+                                              with_scores: true)[0]
       item_output = JSON.parse(item_output)
       assert_equal item.id, item_output['uuid']
       assert_in_delta 0.5, score, 3.minutes.from_now.to_f
     end
 
-    Redis.current.del Rails.application.secrets.preservation_queue_name
+    Cache.redis.del Rails.application.secrets.preservation_queue_name
   end
 
   test 'should end up with item ids in the queue in the correct temporal order' do
-    Redis.current.del Rails.application.secrets.preservation_queue_name
+    Cache.redis.del Rails.application.secrets.preservation_queue_name
 
     # Setup some items...
     community = communities(:community_books)
@@ -440,11 +440,11 @@ class ItemTest < ActiveSupport::TestCase
     end
 
     save_order = [items[1], items[0], items[2]]
-    queue = Redis.current.zrange(Rails.application.secrets.preservation_queue_name, 0, -1, with_scores: false)
+    queue = Cache.redis.zrange(Rails.application.secrets.preservation_queue_name, 0, -1, with_scores: false)
 
     assert_equal save_order.map(&:id), (queue.map { |x| JSON.parse(x)['uuid'] })
 
-    Redis.current.del Rails.application.secrets.preservation_queue_name
+    Cache.redis.del Rails.application.secrets.preservation_queue_name
   end
 
 end

--- a/test/models/item_test.rb
+++ b/test/models/item_test.rb
@@ -314,7 +314,7 @@ class ItemTest < ActiveSupport::TestCase
 
   # Preservation queue handling
   test 'should add id and type with the correct score for a new item to preservation queue' do
-    Cache.redis.del Rails.application.secrets.preservation_queue_name
+    RedisClient.current.del Rails.application.secrets.preservation_queue_name
 
     # Setup an item...
     community = communities(:community_books)
@@ -336,10 +336,10 @@ class ItemTest < ActiveSupport::TestCase
         unlocked_item.save
       end
 
-      item_output, score = Cache.redis.zrange(Rails.application.secrets.preservation_queue_name,
-                                              0,
-                                              -1,
-                                              with_scores: true)[0]
+      item_output, score = RedisClient.current.zrange(Rails.application.secrets.preservation_queue_name,
+                                                      0,
+                                                      -1,
+                                                      with_scores: true)[0]
       item_output = JSON.parse(item_output)
 
       assert_equal item.id, item_output['uuid']
@@ -347,11 +347,11 @@ class ItemTest < ActiveSupport::TestCase
       assert_in_delta 0.5, score, Time.now.to_f
     end
 
-    Cache.redis.del Rails.application.secrets.preservation_queue_name
+    RedisClient.current.del Rails.application.secrets.preservation_queue_name
   end
 
   test 'should end up with the queue only having an item id once after multiple saves of the same item' do
-    Cache.redis.del Rails.application.secrets.preservation_queue_name
+    RedisClient.current.del Rails.application.secrets.preservation_queue_name
 
     # Setup an item...
     community = communities(:community_books)
@@ -381,22 +381,22 @@ class ItemTest < ActiveSupport::TestCase
         unlocked_item.save
       end
 
-      assert_equal 1, Cache.redis.zcard(Rails.application.secrets.preservation_queue_name)
+      assert_equal 1, RedisClient.current.zcard(Rails.application.secrets.preservation_queue_name)
 
-      item_output, score = Cache.redis.zrange(Rails.application.secrets.preservation_queue_name,
-                                              0,
-                                              -1,
-                                              with_scores: true)[0]
+      item_output, score = RedisClient.current.zrange(Rails.application.secrets.preservation_queue_name,
+                                                      0,
+                                                      -1,
+                                                      with_scores: true)[0]
       item_output = JSON.parse(item_output)
       assert_equal item.id, item_output['uuid']
       assert_in_delta 0.5, score, 3.minutes.from_now.to_f
     end
 
-    Cache.redis.del Rails.application.secrets.preservation_queue_name
+    RedisClient.current.del Rails.application.secrets.preservation_queue_name
   end
 
   test 'should end up with item ids in the queue in the correct temporal order' do
-    Cache.redis.del Rails.application.secrets.preservation_queue_name
+    RedisClient.current.del Rails.application.secrets.preservation_queue_name
 
     # Setup some items...
     community = communities(:community_books)
@@ -440,11 +440,11 @@ class ItemTest < ActiveSupport::TestCase
     end
 
     save_order = [items[1], items[0], items[2]]
-    queue = Cache.redis.zrange(Rails.application.secrets.preservation_queue_name, 0, -1, with_scores: false)
+    queue = RedisClient.current.zrange(Rails.application.secrets.preservation_queue_name, 0, -1, with_scores: false)
 
     assert_equal save_order.map(&:id), (queue.map { |x| JSON.parse(x)['uuid'] })
 
-    Cache.redis.del Rails.application.secrets.preservation_queue_name
+    RedisClient.current.del Rails.application.secrets.preservation_queue_name
   end
 
 end

--- a/test/models/thesis_test.rb
+++ b/test/models/thesis_test.rb
@@ -193,7 +193,7 @@ class ThesisTest < ActiveSupport::TestCase
 
   # Preservation queue handling
   test 'should add id and type with the correct score for a new thesis to preservation queue' do
-    Redis.current.del Rails.application.secrets.preservation_queue_name
+    Cache.redis.del Rails.application.secrets.preservation_queue_name
 
     # Setup a thesis...
     admin = users(:user_admin)
@@ -214,10 +214,10 @@ class ThesisTest < ActiveSupport::TestCase
         unlocked_thesis.save
       end
 
-      thesis_output, score = Redis.current.zrange(Rails.application.secrets.preservation_queue_name,
-                                                  0,
-                                                  -1,
-                                                  with_scores: true)[0]
+      thesis_output, score = Cache.redis.zrange(Rails.application.secrets.preservation_queue_name,
+                                                0,
+                                                -1,
+                                                with_scores: true)[0]
       thesis_output = JSON.parse(thesis_output)
 
       assert_equal thesis.id, thesis_output['uuid']
@@ -225,7 +225,7 @@ class ThesisTest < ActiveSupport::TestCase
       assert_in_delta 0.5, score, Time.now.to_f
     end
 
-    Redis.current.del Rails.application.secrets.preservation_queue_name
+    Cache.redis.del Rails.application.secrets.preservation_queue_name
   end
 
 end

--- a/test/models/thesis_test.rb
+++ b/test/models/thesis_test.rb
@@ -193,7 +193,7 @@ class ThesisTest < ActiveSupport::TestCase
 
   # Preservation queue handling
   test 'should add id and type with the correct score for a new thesis to preservation queue' do
-    Cache.redis.del Rails.application.secrets.preservation_queue_name
+    RedisClient.current.del Rails.application.secrets.preservation_queue_name
 
     # Setup a thesis...
     admin = users(:user_admin)
@@ -214,10 +214,10 @@ class ThesisTest < ActiveSupport::TestCase
         unlocked_thesis.save
       end
 
-      thesis_output, score = Cache.redis.zrange(Rails.application.secrets.preservation_queue_name,
-                                                0,
-                                                -1,
-                                                with_scores: true)[0]
+      thesis_output, score = RedisClient.current.zrange(Rails.application.secrets.preservation_queue_name,
+                                                        0,
+                                                        -1,
+                                                        with_scores: true)[0]
       thesis_output = JSON.parse(thesis_output)
 
       assert_equal thesis.id, thesis_output['uuid']
@@ -225,7 +225,7 @@ class ThesisTest < ActiveSupport::TestCase
       assert_in_delta 0.5, score, Time.now.to_f
     end
 
-    Cache.redis.del Rails.application.secrets.preservation_queue_name
+    RedisClient.current.del Rails.application.secrets.preservation_queue_name
   end
 
 end

--- a/test/services/statistics_test.rb
+++ b/test/services/statistics_test.rb
@@ -40,11 +40,11 @@ class StatisticsTest < ActiveSupport::TestCase
       views_key = Statistics.send(:uniques_key_for, :view, obj_id)
       downloads_key = Statistics.send(:uniques_key_for, :download, obj_id)
       # clear current timeout
-      Cache.redis.persist views_key
-      Cache.redis.persist downloads_key
+      RedisClient.current.persist views_key
+      RedisClient.current.persist downloads_key
       # expire immediately
-      Cache.redis.pexpire views_key, -1
-      Cache.redis.pexpire downloads_key, -1
+      RedisClient.current.pexpire views_key, -1
+      RedisClient.current.pexpire downloads_key, -1
 
       # Susequent viewings outside the ip filter expiry period should now count
       Statistics.increment_view_count_for(item_id: obj_id, ip: test_ip)

--- a/test/services/statistics_test.rb
+++ b/test/services/statistics_test.rb
@@ -40,11 +40,11 @@ class StatisticsTest < ActiveSupport::TestCase
       views_key = Statistics.send(:uniques_key_for, :view, obj_id)
       downloads_key = Statistics.send(:uniques_key_for, :download, obj_id)
       # clear current timeout
-      Redis.current.persist views_key
-      Redis.current.persist downloads_key
+      Cache.redis.persist views_key
+      Cache.redis.persist downloads_key
       # expire immediately
-      Redis.current.pexpire views_key, -1
-      Redis.current.pexpire downloads_key, -1
+      Cache.redis.pexpire views_key, -1
+      Cache.redis.pexpire downloads_key, -1
 
       # Susequent viewings outside the ip filter expiry period should now count
       Statistics.increment_view_count_for(item_id: obj_id, ip: test_ip)


### PR DESCRIPTION
## Context

Address potential security vulnerabilities in dependency.  This upgrade has been in our backlog for awhile because of the major version bump required more careful checking.

Related to https://github.com/ualbertalib/jupiter/issues/2189

## What's New
- removed sinatra because it wasn't being used
- use the after_initialze block to avoid deprecation warning triggered by zeitwerk for these Sidekiq::Cron
- Automatic configuration of the sidekiq middleware is no longer done so made it explicit
- `Redis.current=` is deprecated and will be removed in 5.0 https://github.com/redis/redis-rb/issues/1064 so added our own accessor
- prepare for next release