### PR TITLE
Fixed file upload error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ New entries in this file should aim to provide a meaningful amount of informatio
 
 ## [Unreleased]
 
+### Fixed
+- File Upload error
+
 ## [2.3.4] - 2022-02-08
 ### Added
 - Add readiness healthchecks for Rails and Sidekiq [PR#2657](https://github.com/ualbertalib/jupiter/pull/2657)

--- a/app/models/concerns/draft_properties.rb
+++ b/app/models/concerns/draft_properties.rb
@@ -145,16 +145,11 @@ module DraftProperties
       # callbacks before save cannot access the file the regular way
       # `attachment_changes` is an undocumented api to gain access to the temp file
       # which will be a ActionDispatch::Http::UploadedFile
-      if attachment_changes['files'].present?
-        attachment_changes['files'].attachables.each do |file|
-          path = file_path_for(file)
-          errors.add(:files, :infected, filename: file.filename.to_s) unless Clamby.safe?(path)
-        end
-      else
-        files.each do |file|
-          path = file_path_for(file)
-          errors.add(:files, :infected, filename: file.filename.to_s) unless Clamby.safe?(path)
-        end
+      return unless attachment_changes['files']
+
+      attachment_changes['files'].attachables.each do |file|
+        path = file_path_for(file)
+        errors.add(:files, :infected, filename: File.basename(path)) unless Clamby.safe?(path)
       end
     end
   end

--- a/config/initializers/clamby.rb
+++ b/config/initializers/clamby.rb
@@ -1,5 +1,6 @@
 if defined?(Clamby)
   Clamby.configure(check: true,
                    daemonize: true,
+                   stream: true,
                    silence_output: false)
 end


### PR DESCRIPTION
## Context

https://rollbar.com/ualbertalib/jupiter/items/1365/ is the same error as I'm experiencing with File uploads in the staging environment (era.test.library.ualberta.ca).  In production it only happens to select users.  I continue to have no issues with file upload in the production environment but I get 500 errors in staging when the files_are_virus_free code runs.

When I was working on Digitization content ingestion I observed that ActiveStorage files would not be available during some callbacks for things like validation.  Basically before save.  So maybe that's at play here too, but can't account for the occassional failure in production.

## What's New

Use undocumented `attachment_changes` api to access the `ActionDispatch::Http::UploadedFile` tempfile path for virus checking.