### PR TITLE
Remove link to ERA A+V from homepage: #2765

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ New entries in this file should aim to provide a meaningful amount of informatio
 
 ## [Unreleased]
 
+### enhancement
+- remove link to ERA A+V [PR]()
+
 ## [2.3.6] - 2022-04-28
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@ New entries in this file should aim to provide a meaningful amount of informatio
 
 ## [Unreleased]
 
-### changed 
-- remove link to ERA A+V [PR2863](https://github.com/ualbertalib/jupiter/pull/2863)
+### Removed 
+- link to ERA A+V [#2765](https://github.com/ualbertalib/jupiter/issues/2765)
 
 ## [2.3.6] - 2022-04-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@ New entries in this file should aim to provide a meaningful amount of informatio
 
 ## [Unreleased]
 
-### enhancement
-- remove link to ERA A+V [PR]()
+### changed 
+- remove link to ERA A+V [PR2863](https://github.com/ualbertalib/jupiter/pull/2863)
 
 ## [2.3.6] - 2022-04-28
 

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -78,20 +78,4 @@
                 class: 'list-group-item list-group-item-action list-group-item-primary mb-3 text-dark' %>
   </div>
 
-  <div class="row mt-5">
-    <div class="col-md-6 offset-md-3">
-      <%= link_to 'https://era-av.library.ualberta.ca', target: :_blank, rel: 'noopener', class: 'media bg-light p-3 border border-primary rounded text-decoration-none' do %>
-        <%= icon('far', 'play-circle', class: 'fa-4x mr-3') %>
-        <div class="media-body text-dark">
-          <h3>
-            <%= t('.era_av_header') %>
-          </h3>
-          <p class="mb-0">
-            <%= t('.era_av_text') %>
-          </p>
-        </div>
-      <% end %>
-    </div>
-  </div>
-
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -615,8 +615,6 @@ en:
       images_of_research_attribution: 'Image: “Frozen Kaleidoscope” by Vincent McFarlane CC-BY 4.0'
       theses_collection: 'University of Alberta Theses and Dissertations'
       afns_collection: 'Department of Agriculture, Food and Nutritional Science Journal Articles'
-      era_av_header: 'Explore ERA Audio+Video'
-      era_av_text: "The University of Alberta Library's Media Streaming Service"
 
   items:
     index:


### PR DESCRIPTION
## Context

Remove ERA A+V link and associated i18n variables from the ERA homepage

Related to #2765 

## What's New

With the move to Aviary and removal of the ERA A+V public interface, remove the "Explore ERA Audio + Video" box/link on the ERA homepage.

-----

### After:

![Screenshot from 2022-06-01 16-53-52](https://user-images.githubusercontent.com/879785/171514748-8b771611-53a5-4ea4-b350-c6d5132344aa.png)

-----
### Before:
![Screenshot from 2022-06-01 16-54-51](https://user-images.githubusercontent.com/879785/171514855-4bc1278d-d1e8-41bf-a1b7-f2f267afaa6d.png)
