### PR TITLE
Use the latest Ruby version on UAT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ New entries in this file should aim to provide a meaningful amount of informatio
 - remove Ruby 2.6 [PR#2878](https://github.com/ualbertalib/jupiter/pull/2878)
 - bump rubocop and fix new nags [PR#2900](https://github.com/ualbertalib/jupiter/pull/2900)
 - bump ruboocp-rails and fix new nags [PR#2899](https://github.com/ualbertalib/jupiter/pull/2899)
+- bump Ruby from 2.6 to 2.7 for UAT [PR#2909](https://github.com/ualbertalib/jupiter/pull/2909)
 
 ### Security
 - bump rails 6.1.6 to 6.1.6.1

--- a/Dockerfile.deployment
+++ b/Dockerfile.deployment
@@ -1,4 +1,4 @@
-FROM ruby:2.6
+FROM ruby:2.7
 LABEL maintainer="University of Alberta Library"
 
 # Need to add jessie-backports repo so we can get FFMPEG, doesn't come with jessie debian by default


### PR DESCRIPTION
## Context

I went to test on UAT before cutting a release.  I noticed there that it was using the old Ruby version

![image](https://user-images.githubusercontent.com/1220762/178612653-e1e22117-7263-4d27-a78b-d809cac36f20.png)

I also noticed that the docker build failed because of mismatched ruby versions: https://hub.docker.com/repository/registry-1.docker.io/ualbertalib/jupiter/builds/82d262a8-7aca-4e2a-bd01-5f04b51713b4

Related to #2878 

## What's New

Bump Ruby from 2.6 to 2.7 for UAT. Missed this in  commit 7233eb9814bcfae5869a7a2a540ec5031f8a8d5