### PR TITLE
Draft PR Test/increase capybara wait for asynchronous process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ New entries in this file should aim to provide a meaningful amount of informatio
 ### Removed
 - references to EZID [#2671](https://github.com/ualbertalib/jupiter/issues/2671)
 
+### Changed
+- files attached to items and thesis are now sorted alphabetically in their views [#2946](https://github.com/ualbertalib/jupiter/issues/2946)
+
 ## [2.3.7] - 2022-07-13
 
 ### Removed 

--- a/app/models/draft_item.rb
+++ b/app/models/draft_item.rb
@@ -291,6 +291,10 @@ class DraftItem < ApplicationRecord
     visibility
   end
 
+  def ordered_files
+    files.joins(:blob).order('active_storage_blobs.filename ASC')
+  end
+
   private
 
   # Validations

--- a/app/models/draft_thesis.rb
+++ b/app/models/draft_thesis.rb
@@ -191,6 +191,10 @@ class DraftThesis < ApplicationRecord
     graduation_year.nil? || (graduation_year >= 2009)
   end
 
+  def ordered_files
+    files.joins(:blob).order('active_storage_blobs.filename ASC')
+  end
+
   private
 
   def parse_graduation_term_from_fedora(graduation_date)

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -88,6 +88,10 @@ class Item < JupiterCore::Doiable
     self.member_of_paths += ["#{community_id}/#{collection_id}"]
   end
 
+  def ordered_files
+    files.joins(:blob).order('active_storage_blobs.filename ASC')
+  end
+
   def self.from_draft(draft_item)
     item = Item.find(draft_item.uuid) if draft_item.uuid.present?
     item ||= Item.new(id: draft_item.uuid)

--- a/app/models/thesis.rb
+++ b/app/models/thesis.rb
@@ -55,6 +55,10 @@ class Thesis < JupiterCore::Doiable
     self.member_of_paths += ["#{community_id}/#{collection_id}"]
   end
 
+  def ordered_files
+    files.joins(:blob).order('active_storage_blobs.filename ASC')
+  end
+
   def self.from_draft(draft_thesis)
     thesis = Thesis.find(draft_thesis.uuid) if draft_thesis.uuid.present?
     thesis ||= Thesis.new

--- a/app/views/admin/theses/draft/_files_list.html.erb
+++ b/app/views/admin/theses/draft/_files_list.html.erb
@@ -15,7 +15,7 @@
     </div>
     <div class="col-md-8">
       <ul class="list-unstyled">
-        <% @draft.files.each do |file| %>
+        <% @draft.ordered_files.each do |file| %>
           <%= render partial: 'admin/theses/draft/file', locals: { file: file } %>
         <% end %>
       </ul>

--- a/app/views/admin/theses/draft/review_and_deposit_thesis.html.erb
+++ b/app/views/admin/theses/draft/review_and_deposit_thesis.html.erb
@@ -19,9 +19,9 @@
           </div>
           <div class="card-body">
             <%= render partial: 'feature_image', locals: { object: @draft } %>
-            <ul class="list-group mt-3">
+            <ul class="list-group mt-3 thesis-files">
               <% @draft.ordered_files.each do |file| %>
-                <li class="list-group-item">
+                <li class="list-group-item thesis-filename">
                   <%= icon('far', file_icon(file.content_type)) %>
                   <%= file.filename %>
                   <span class="badge badge-primary badge-pill float-right">

--- a/app/views/admin/theses/draft/review_and_deposit_thesis.html.erb
+++ b/app/views/admin/theses/draft/review_and_deposit_thesis.html.erb
@@ -20,7 +20,7 @@
           <div class="card-body">
             <%= render partial: 'feature_image', locals: { object: @draft } %>
             <ul class="list-group mt-3">
-              <% @draft.files.each do |file| %>
+              <% @draft.ordered_files.each do |file| %>
                 <li class="list-group-item">
                   <%= icon('far', file_icon(file.content_type)) %>
                   <%= file.filename %>

--- a/app/views/application/_files_section_sidebar.html.erb
+++ b/app/views/application/_files_section_sidebar.html.erb
@@ -32,7 +32,7 @@
         <div class="card-header"><%= t('.header') %></div>
         <div class="card-body p-2">
           <div class="list-group item-files">
-            <% item.files.each do |file| %>
+            <% item.ordered_files.each do |file| %>
               <div class="list-group-item list-group-item-action d-flex flex-column">
                 <div class="item-filename text-center pb-3"><%= file.filename %></div>
                 <% if file.fileset_uuid.present? %>
@@ -60,7 +60,7 @@
             <% end %>
           </div>
           <div class="pt-2">
-            <% unless item.files.any? {|file| file.fileset_uuid.blank?} %>
+            <% unless item.ordered_files.any? {|file| file.fileset_uuid.blank?} %>
               <button type="button" class="js-download-all btn btn-outline-primary float-right">
                 <%= t('.download_all') %>
               </button>

--- a/app/views/application/_item.html.erb
+++ b/app/views/application/_item.html.erb
@@ -7,7 +7,7 @@
     <div class="d-flex flex-wrap flex-lg-nowrap align-items-start">
       <h3 class="mt-0 h5 mr-auto"><%= link_to item.title, item_path(item) %></h3>
       <% if policy(item).download? %>
-        <% primary_file = item.files.first %>
+        <% primary_file = item.ordered_files.first %>
         <% if primary_file.present? && primary_file.fileset_uuid.present? %>
           <%= link_to file_download_item_url(id: primary_file.record.id,
                                              file_set_id: primary_file.fileset_uuid),

--- a/app/views/items/_google_scholar_metadata.html.erb
+++ b/app/views/items/_google_scholar_metadata.html.erb
@@ -6,7 +6,7 @@
 <% if @item.creation_date.present? %>
   <meta name="citation_publication_date" content="<%= humanize_date(@item.creation_date) %>">
 <% end %>
-<% citation_file = @item.files.first %>
+<% citation_file = @item.ordered_files.first %>
 <% if citation_file.present? && citation_file.fileset_uuid.present? %>
   <%# TODO: limit to pdf mime-type if/when that gets stored %>
   <meta name="citation_pdf_url" content="<%= file_view_item_url(id: citation_file.record.id,

--- a/app/views/items/draft/_files_list.html.erb
+++ b/app/views/items/draft/_files_list.html.erb
@@ -15,7 +15,7 @@
     </div>
     <div class="col-md-8">
       <ul class="list-unstyled">
-        <% @draft.files.each do |file| %>
+        <% @draft.ordered_files.each do |file| %>
           <%= render partial: 'items/draft/file', locals: { file: file } %>
         <% end %>
       </ul>

--- a/app/views/items/draft/review_and_deposit_item.html.erb
+++ b/app/views/items/draft/review_and_deposit_item.html.erb
@@ -19,9 +19,9 @@
           </div>
           <div class="card-body">
             <%= render partial: 'feature_image', locals: { object: @draft } %>
-            <ul class="list-group mt-3">
+            <ul class="list-group mt-3 item-files">
               <% @draft.ordered_files.each do |file| %>
-                <li class="list-group-item">
+                <li class="list-group-item item-filename">
                   <%= icon('far', file_icon(file.content_type)) %>
                   <%= file.filename %>
                   <span class="badge badge-primary badge-pill float-right">

--- a/app/views/items/draft/review_and_deposit_item.html.erb
+++ b/app/views/items/draft/review_and_deposit_item.html.erb
@@ -20,7 +20,7 @@
           <div class="card-body">
             <%= render partial: 'feature_image', locals: { object: @draft } %>
             <ul class="list-group mt-3">
-              <% @draft.files.each do |file| %>
+              <% @draft.ordered_files.each do |file| %>
                 <li class="list-group-item">
                   <%= icon('far', file_icon(file.content_type)) %>
                   <%= file.filename %>

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -3,7 +3,7 @@ require 'selenium-webdriver'
 
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
 
-  Capybara.default_max_wait_time = 5
+  Capybara.default_max_wait_time = 10
 
   setup do
     Capybara.app_host = Jupiter::TEST_URL

--- a/test/system/deposit_item_test.rb
+++ b/test/system/deposit_item_test.rb
@@ -184,8 +184,8 @@ class DepositItemTest < ApplicationSystemTestCase
     attach_file_in_dropzone(file_fixture('pdf-sample.pdf'))
     attach_file_in_dropzone(file_fixture('image-sample.jpeg'))
     attach_file_in_dropzone(file_fixture('text-sample.txt'))
-    has_css? '.j-thumbnail'
 
+    assert_selector '#js-files-list ul li', count: 3
     assert_selector '#js-files-list ul li:nth-child(1) h5', text: 'image-sample.jpeg'
     assert_selector '#js-files-list ul li:nth-child(2) h5', text: 'pdf-sample.pdf'
     assert_selector '#js-files-list ul li:nth-child(3) h5', text: 'text-sample.txt'
@@ -205,6 +205,7 @@ class DepositItemTest < ApplicationSystemTestCase
 
     # Success! Deposit Successful
 
+    assert_selector '.item-files > div', count: 3
     assert_selector '.item-files > div:nth-child(1) .item-filename', text: 'image-sample.jpeg'
     assert_selector '.item-files > div:nth-child(2) .item-filename', text: 'pdf-sample.pdf'
     assert_selector '.item-files > div:nth-child(3) .item-filename', text: 'text-sample.txt'

--- a/test/system/deposit_item_test.rb
+++ b/test/system/deposit_item_test.rb
@@ -134,7 +134,7 @@ class DepositItemTest < ApplicationSystemTestCase
   end
 
   # This test follows a very similar behaviour to the successfully deposit an
-  # item to make sure all required fields are present
+  # item making sure all required fields are present
   test 'files are alphabetically sorted when depositing an item' do
     user = users(:user_regular)
 

--- a/test/system/deposit_thesis_test.rb
+++ b/test/system/deposit_thesis_test.rb
@@ -128,6 +128,8 @@ class DepositThesisTest < ApplicationSystemTestCase
     logout_user
   end
 
+  # This test follows a very similar behaviour to the successfully deposit a
+  # thesis making sure all required fields are present
   test 'files are alphabetically sorted when depositing an thesis' do
     admin = users(:user_admin)
 

--- a/test/system/deposit_thesis_test.rb
+++ b/test/system/deposit_thesis_test.rb
@@ -129,6 +129,81 @@ class DepositThesisTest < ApplicationSystemTestCase
   end
 
   test 'files are alphabetically sorted when depositing an thesis' do
+    admin = users(:user_admin)
+
+    login_user(admin)
+
+    click_link admin.name
+    click_link I18n.t('application.navbar.links.admin')
+    click_link I18n.t('admin.items.index.header')
+    click_link I18n.t('admin.items.index.deposit_thesis')
+
+    # 1. Describe Thesis Form
+
+    fill_in I18n.t('admin.theses.draft.describe_thesis.title'),
+            # Need to narrow down by placeholder since capybara can't differentiate from title and alternate title labels
+            placeholder: I18n.t('admin.theses.draft.describe_thesis.title_placeholder'),
+            with: 'A Dance with Dragons'
+
+    fill_in I18n.t('admin.theses.draft.describe_thesis.creator'),
+            with: 'Jane Doe'
+
+    select '2018', from: I18n.t('admin.theses.draft.describe_thesis.graduation_year')
+    select '06 (Spring)', from: I18n.t('admin.theses.draft.describe_thesis.graduation_term')
+
+    fill_in I18n.t('admin.theses.draft.describe_thesis.description'),
+            with: 'A Dance with Dragons Description Goes Here!!!'
+
+    select communities(:community_thesis).title, from: 'draft_thesis[community_id][]'
+    select collections(:collection_thesis).title, from: 'draft_thesis[collection_id][]'
+
+    click_on I18n.t('admin.theses.draft.save_and_continue')
+
+    # 2. Choose License and Visibility Form
+
+    fill_in 'draft_thesis_rights',
+            with: 'Open for everyone!'
+
+    choose I18n.t('admin.theses.draft.choose_license_and_visibility.visibility.embargo')
+    select_date '2023/01/01', field_id: 'draft_thesis_embargo_end_date'
+
+    click_on I18n.t('admin.theses.draft.save_and_continue')
+
+    # 3. Upload File Form
+
+    assert_selector 'h2', text: I18n.t('admin.theses.draft.upload_files.header')
+
+    attach_file_in_dropzone(file_fixture('pdf-sample.pdf'))
+    attach_file_in_dropzone(file_fixture('image-sample.jpeg'))
+    attach_file_in_dropzone(file_fixture('text-sample.txt'))
+
+    # ASSERT ORDER OF UPLOAD
+
+    assert_selector '#js-files-list ul li', count: 3
+    assert_selector '#js-files-list ul li:nth-child(1) h5', text: 'image-sample.jpeg'
+    assert_selector '#js-files-list ul li:nth-child(2) h5', text: 'pdf-sample.pdf'
+    assert_selector '#js-files-list ul li:nth-child(3) h5', text: 'text-sample.txt'
+
+    click_on I18n.t('admin.theses.draft.save_and_continue'), wait: 5
+
+    assert_selector :xpath, "(.//li[contains(@class, 'thesis-filename')])", count: 3
+    # We are using regex in these assertions since the elements on the intreface
+    # include a badge with text showing the file size
+    assert_selector :xpath, "(.//li[contains(@class, 'thesis-filename')])[1]", text: /image-sample.jpeg/
+    assert_selector :xpath, "(.//li[contains(@class, 'thesis-filename')])[2]", text: /pdf-sample.pdf/
+    assert_selector :xpath, "(.//li[contains(@class, 'thesis-filename')])[3]", text: /text-sample.txt/
+
+    # 4. Review and Deposit Form
+    click_on I18n.t('admin.theses.draft.header')
+
+    # Success! Deposit Successful
+
+    assert_selector '.item-files > div', count: 3
+    assert_selector '.item-files > div:nth-child(1) .item-filename', text: 'image-sample.jpeg'
+    assert_selector '.item-files > div:nth-child(2) .item-filename', text: 'pdf-sample.pdf'
+    assert_selector '.item-files > div:nth-child(3) .item-filename', text: 'text-sample.txt'
+
+    logout_user
   end
 
   # Helper methods for javascript fields (dropzone)

--- a/test/system/deposit_thesis_test.rb
+++ b/test/system/deposit_thesis_test.rb
@@ -128,6 +128,9 @@ class DepositThesisTest < ApplicationSystemTestCase
     logout_user
   end
 
+  test 'files are alphabetically sorted when depositing an thesis' do
+  end
+
   # Helper methods for javascript fields (dropzone)
   # (could be moved and made as generic helpers if these are needed elsewhere)
   private

--- a/test/system/item_show_test.rb
+++ b/test/system/item_show_test.rb
@@ -26,7 +26,11 @@ class ItemShowTest < ApplicationSystemTestCase
       # Attach multiple files to the mondo-item
       File.open(file_fixture('image-sample.jpeg'), 'r') do |file1|
         File.open(file_fixture('pdf-sample.pdf'), 'r') do |file2|
-          @item.add_and_ingest_files([file1, file2])
+          File.open(file_fixture('text-sample.txt'), 'r') do |file3|
+            # Reversed file ingested order to test that ordered files are
+            # returned in alphabetical order
+            @item.add_and_ingest_files([file3, file2, file1])
+          end
         end
       end
     end
@@ -71,7 +75,7 @@ class ItemShowTest < ApplicationSystemTestCase
 
   test 'unauthed users should be able to download all files from a public item' do
     visit item_path @item
-    assert_selector '.js-download', count: 2
+    assert_selector '.js-download', count: 3
     assert_selector '.js-download-all'
     # TODO: test that the files are downloaded via js successfully without making the suite brittle
   end
@@ -80,6 +84,16 @@ class ItemShowTest < ApplicationSystemTestCase
     visit item_path @item
     click_link 'Joe Blow'
     assert_selector "a[href='/search?tab=item']", count: 1
+  end
+
+  test 'Check item files are listed alphabetically' do
+    visit item_path @item
+
+    assert_selector :xpath, "(.//div[contains(@class, 'item-filename')])", count: 3
+    # Item files have been sorted by its ordered_files method
+    assert_selector :xpath, "(.//div[contains(@class, 'item-filename')])[1]", text: 'image-sample.jpeg'
+    assert_selector :xpath, "(.//div[contains(@class, 'item-filename')])[2]", text: 'pdf-sample.pdf'
+    assert_selector :xpath, "(.//div[contains(@class, 'item-filename')])[3]", text: 'text-sample.txt'
   end
 
   test 'Visiting authenticated items as an unauthenticated user works' do


### PR DESCRIPTION
## Context

This is only a test PR to review the flapping errors coming up from uploading files.

Tests are failing due to items taking too long to upload and the test suite drops them after 5 seconds. By increasing the amount of time we wait for the change we should stop seeing these errors.

## What's New

This test PR should only increase the value `Capybara.default_max_wait_time` to see how it affects the tests results.

Remember to request a reviewer when you submit!