### PR TITLE
Fixed rendering of markdown in collection browse view.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and releases in Jupiter project adheres to [Semantic Versioning](http://semver.o
 New entries in this file should aim to provide a meaningful amount of information in order to allow people to understand the change purely by reading this file, without relying on links to possibly-impermanent sources like Pull Request descriptions or issues.
 
 ## [Unreleased]
+
 ### Added
 - Add multi-file upload per item on batch ingest workflow [#2943](https://github.com/ualbertalib/jupiter/issues/2943)
 
@@ -17,6 +18,7 @@ New entries in this file should aim to provide a meaningful amount of informatio
 
 ### Changed
 - Column header names for batch ingestion spreadsheet [[#2941](https://github.com/ualbertalib/jupiter/issues/2941)]
+- Community links to exclude description [#2969](https://github.com/ualbertalib/jupiter/issues/2969)
 
 ## [2.3.7] - 2022-07-13
 

--- a/app/views/admin/communities/_community.html.erb
+++ b/app/views/admin/communities/_community.html.erb
@@ -1,13 +1,15 @@
 <li class="list-group-item list-group-item-action">
 
   <div class="d-flex justify-content-between align-items-start mb-3">
-    <%= link_to admin_community_path(community), class: 'media text-decoration-none' do %>
-      <%= render partial: 'thumbnail', locals: { object: community } %>
+      <%= link_to admin_community_path(community), class: 'media text-decoration-none' do %>
+        <%= render partial: 'thumbnail', locals: { object: community } %>
+      <% end %>
       <div class="media-body ml-3">
-        <h4 class="mt-0"><%= community.title %></h4>
+        <%= link_to admin_community_path(community), class: 'media text-decoration-none' do %>
+          <h4 class="mt-0"><%= community.title %></h4>
+        <% end %>
         <p class="text-muted"><%= community.description %></p>
       </div>
-    <% end %>
 
     <div class="btn-group" role="group" aria-label="Community Actions">
       <% if policy(community).update? %>

--- a/app/views/communities/_community.html.erb
+++ b/app/views/communities/_community.html.erb
@@ -4,11 +4,13 @@
 
   <%= link_to community_path(community), class: 'media text-decoration-none mb-3' do %>
     <%= render partial: 'thumbnail', locals: { object: community } %>
-    <div class="media-body ml-3">
-      <h3 class="mt-0"><%= community.title %></h3>
-      <p class="text-muted"><%= community.description %></p>
-    </div>
   <% end %>
+  <div class="media-body ml-3">
+      <%= link_to community_path(community), class: 'media text-decoration-none mb-3' do %>
+        <h3 class="mt-0"><%= community.title %></h3>
+      <% end %>
+    <p class="text-muted"><%= community.description %></p>
+  </div>
 
   <div class="btn-group mb-3" role="group" aria-label="Community Actions">
     <% if policy(community).update? %>


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/1220762/190496906-fcbc2586-8655-4b76-81e3-46f73992bfa1.png)

After:
![image](https://user-images.githubusercontent.com/1220762/190496258-52a31dfa-adfb-49ed-b92e-f58c2bfce7ec.png)


## Context
Markdown appears to be rendering differently in the [collection browse view](https://era.library.ualberta.ca/communities?page=2) from how it does on the [collection landing page](https://era.library.ualberta.ca/communities/8eecb737-9733-4319-bd57-f93665d7176d)

If the description also included a link this would cause problems. This was caused by wrapping the whole community block of content (thumbnail, title, description) in a link tag.

Related to #2969 

## What's New

No longer wrap community description in link tag.