### PR TITLE
Change depositable's behaviour to attach files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and releases in Jupiter project adheres to [Semantic Versioning](http://semver.o
 
 New entries in this file should aim to provide a meaningful amount of information in order to allow people to understand the change purely by reading this file, without relying on links to possibly-impermanent sources like Pull Request descriptions or issues.
 
+## Unreleased
+
+### Fix
+- Make sure all files are copied when items are ingested with multiple files each [#2990](https://github.com/ualbertalib/jupiter/issues/2990)
+
 ## [2.4.1] - 2022-10-19
 
 ### Fix

--- a/app/jobs/batch_ingestion_job.rb
+++ b/app/jobs/batch_ingestion_job.rb
@@ -132,11 +132,11 @@ class BatchIngestionJob < ApplicationJob
   end
 
   def files_ingest(item, item_files, google_credentials)
-    item_files.each do |item_file|
-      file = google_credentials.download_file(item_file.google_file_id, item_file.google_file_name)
-      item.add_and_ingest_files([file])
+    files = item_files.map do |item_file|
+      google_credentials.download_file(item_file.google_file_id, item_file.google_file_name)
     end
 
+    item.add_and_ingest_files(files)
     item.set_thumbnail(item.files.first) if item.files.first.present?
   end
 

--- a/test/jobs/batch_ingestion_job_test.rb
+++ b/test/jobs/batch_ingestion_job_test.rb
@@ -126,6 +126,10 @@ class BatchIngestionJobTest < ActiveJob::TestCase
     assert_equal(2, Item.find_by(title: 'Test Resource Title 1').files.count)
     assert_equal(3, Item.find_by(title: 'Test Resource Title 2').files.count)
     assert_equal(1, Item.find_by(title: 'Test Resource Title 3').files.count)
+
+    item = Item.find_by(title: 'Test Resource Title 1')
+    assert(File.file?(ActiveStorage::Blob.service.path_for(item.files[0].blob.key)))
+    assert(File.file?(ActiveStorage::Blob.service.path_for(item.files[1].blob.key)))
   end
 
 end


### PR DESCRIPTION
This change allows having a multi-file attachment even inside a base transaction block.

Before, the behaviour for attaching files in the depositable model allowed attaching a single file at a time. Now we make sure all of the copy callbacks are run inside a transaction block, actually copying the files, and not just the last one.

## Context

Multifile batch ingest was correctly adding the files' metadata but the file itself was not being copied to the storage area.

Related to #2990

## What's New

We changed the attaching method to attach multiple files at the same time, to allow their copy callbacks to be run after a transaction block.
