### PR TITLE
Revert "Bump redis from 4.7.1 to 4.8.0" due to seeding issues

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,7 @@ gem 'rdf-vocab', '~> 3.2.1' # this gem changed predicate names without warning, 
 # Database stuff
 gem 'connection_pool'
 gem 'pg', '~> 1.4.3'
-gem 'redis', '~> 4.8'
+gem 'redis', '~> 4.7'
 gem 'rsolr'
 gem 'strong_migrations', '~> 1.4.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -441,7 +441,7 @@ GEM
       rexml (~> 3.2)
     rdoc (6.3.3)
     redcarpet (3.5.1)
-    redis (4.8.0)
+    redis (4.7.1)
     regexp_parser (2.6.0)
     representable (3.1.1)
       declarative (< 0.1.0)
@@ -660,7 +660,7 @@ DEPENDENCIES
   rdf-n3 (~> 3.2.1)
   rdf-vocab (~> 3.2.1)
   redcarpet (~> 3.5, >= 3.5.1)
-  redis (~> 4.8)
+  redis (~> 4.7)
   rollbar
   rsolr
   rubocop (~> 1.36.0)


### PR DESCRIPTION
This reverts commit ef1bcff5feb19b86cec285c906537510cacb311d.

## Context

Bumped redis from 4.7.1 to 4.8.0 and saw that it caused some issues while seeding the db so I'm reverting it here

Related to # (issue)

https://github.com/ualbertalib/jupiter/pull/2962