### PR TITLE
Remove skylight

### DIFF
--- a/.env_deployment_sample
+++ b/.env_deployment_sample
@@ -27,4 +27,3 @@ POSTGRES_USER=jupiter
 
 # Nginx environment variables
 HOSTNAME=localhost
-SKYLIGHT_AUTHENTICATION=secretauthenticationtoken

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ New entries in this file should aim to provide a meaningful amount of informatio
 - Push collections and communities to preservation on save along with a rake task to do so [#255](https://github.com/ualbertalib/pushmi_pullyu/issues/255)
 - Added minitest-retry gem to retry flapping tests that are able to pass through retries [#3044](https://github.com/ualbertalib/jupiter/pull/3044)
 ### Removed
-- Skylight performance monitoring.  Will need to remove this secret from ansible playbook secrets as well.
+- Skylight performance monitoring.  Will need to remove this secret from ansible playbook secrets as well. [#3023](https://github.com/ualbertalib/jupiter/issues/3023)
 
 ## [2.4.3] - 2022-12-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ New entries in this file should aim to provide a meaningful amount of informatio
 ### Added
 - Push collections and communities to preservation on save along with a rake task to do so [#255](https://github.com/ualbertalib/pushmi_pullyu/issues/255)
 - Added minitest-retry gem to retry flapping tests that are able to pass through retries [#3044](https://github.com/ualbertalib/jupiter/pull/3044)
+### Removed
+- Skylight performance monitoring.  Will need to remove this secret from ansible playbook secrets as well.
+
 ## [2.4.3] - 2022-12-14
 
 ### Security

--- a/Gemfile
+++ b/Gemfile
@@ -64,8 +64,6 @@ gem 'uuidtools'
 gem 'voight_kampff' # bot detection
 gem 'wicked' # Multi-step wizard
 
-# Performance monitoring
-gem 'skylight', '~> 4.3'
 # resolve production errors in minutes
 gem 'rollbar'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -532,10 +532,6 @@ GEM
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.3)
-    skylight (4.3.2)
-      skylight-core (= 4.3.2)
-    skylight-core (4.3.2)
-      activesupport (>= 4.2.0)
     smart_properties (1.17.0)
     sparql (3.2.1)
       builder (~> 3.2)
@@ -678,7 +674,6 @@ DEPENDENCIES
   sidekiq-unique-jobs (~> 7.1)
   simple_form
   simplecov
-  skylight (~> 4.3)
   spring
   spring-watcher-listen (~> 2.1.0)
   strong_migrations (~> 1.4.0)

--- a/app/models/jupiter_core/search.rb
+++ b/app/models/jupiter_core/search.rb
@@ -86,7 +86,7 @@ class JupiterCore::Search
                                 restrict_to_model: restrict_to_model, rows: rows,
                                 start: start, sort: sort, fulltext_fields: fulltext_fields)
 
-    response = ActiveSupport::Notifications.instrument(JUPITER_SOLR_NOTIFICATION,
+    response = ActiveSupport::Notifications.instrument('jupiter.solr.query',
                                                        name: 'solr select',
                                                        query: params) do
       JupiterCore::SolrServices::Client.instance.connection.get('select', params: params)

--- a/app/models/jupiter_core/search.rb
+++ b/app/models/jupiter_core/search.rb
@@ -86,14 +86,12 @@ class JupiterCore::Search
                                 restrict_to_model: restrict_to_model, rows: rows,
                                 start: start, sort: sort, fulltext_fields: fulltext_fields)
 
-    response = ActiveSupport::Notifications.instrument('jupiter.solr.query',
-                                                       name: 'solr select',
-                                                       query: params) do
+    response = begin
       JupiterCore::SolrServices::Client.instance.connection.get('select', params: params)
-      rescue RSolr::Error::Http => e
-        raise JupiterCore::SolrBadRequestError if e.response[:status] == 400
+    rescue RSolr::Error::Http => e
+      raise JupiterCore::SolrBadRequestError if e.response[:status] == 400
 
-        raise
+      raise
     end
 
     raise SearchFailed unless response['responseHeader']['status'] == 0

--- a/config/application.rb
+++ b/config/application.rb
@@ -39,9 +39,6 @@ module Jupiter
     # Set ActiveJob adapter
     config.active_job.queue_adapter = :sidekiq
 
-    # Run skylight in Staging for performance metric monitoring pre-launch
-    config.skylight.environments << 'staging'
-
     config.redis_key_prefix = "jupiter.#{Rails.env}."
 
     config.action_dispatch.tld_length = Rails.application.secrets.tld_length.to_i

--- a/config/initializers/solr_normalizer.rb
+++ b/config/initializers/solr_normalizer.rb
@@ -1,14 +1,3 @@
-require 'skylight'
-
 SOLR_NORMALIZER = 'solr.query'.freeze
 JUPITER_SOLR_NOTIFICATION = "jupiter.#{SOLR_NORMALIZER}".freeze
 
-class Skylight::Core::Normalizers::SolrNormalizer < Skylight::Core::Normalizers::Normalizer
-
-  register JUPITER_SOLR_NOTIFICATION
-
-  def normalize(_trace, _name, payload)
-    [SOLR_NORMALIZER, payload[:name], payload[:query].to_s]
-  end
-
-end

--- a/config/initializers/solr_normalizer.rb
+++ b/config/initializers/solr_normalizer.rb
@@ -1,3 +1,0 @@
-SOLR_NORMALIZER = 'solr.query'.freeze
-JUPITER_SOLR_NOTIFICATION = "jupiter.#{SOLR_NORMALIZER}".freeze
-

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -150,5 +150,3 @@ production:
   fcrepo_url: <%= ENV['FCREPO_URL'] %>
   fcrepo_base_path: /prod
   solr_url: <%= ENV['SOLR_URL'] %>
-
-  skylight_authentication: <%= ENV['SKYLIGHT_AUTHENTICATION'] %>

--- a/config/skylight.yml
+++ b/config/skylight.yml
@@ -1,3 +1,0 @@
----
-# The authentication token for the application.
-authentication: <%= Rails.application.secrets.skylight_authentication %>


### PR DESCRIPTION
## Context

We installed this to get more observability about jupiter performance.  I've been getting these weekly emails for years without acting on them.  We now have netdata for some performance statistics.

I've left in ActiveSupport::Notifications instrument (https://edgeguides.rubyonrails.org/active_support_instrumentation.html) in case it comes in handy in the future.  I have removed the normalizer for Skylight.

Related to #3023 

## What's New

Remove Skylight.io