### PR TITLE
Fixed AIP api collections with nil descriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ New entries in this file should aim to provide a meaningful amount of informatio
 
 ### Fixed 
 - Resolved new rubocop offenses [PR#3109](https://github.com/ualbertalib/jupiter/pull/3109)
+- AIP api collections with nil descriptions [#3117](https://github.com/ualbertalib/jupiter/issues/3117)
 
 ## [2.5.0] - 2023-04-05
 

--- a/app/controllers/aip/v1/collections_controller.rb
+++ b/app/controllers/aip/v1/collections_controller.rb
@@ -17,7 +17,6 @@ class Aip::V1::CollectionsController < ApplicationController
       RDF::Statement(subject: self_subject, predicate: RDF.type, object: RDF::Vocab::PCDM.Collection),
       RDF::Statement(subject: self_subject, predicate: RDF::Vocab::PCDM.memberOf, object: @collection.community_id),
       RDF::Statement(subject: self_subject, predicate: RDF::Vocab::DC.title, object: @collection.title),
-      RDF::Statement(subject: self_subject, predicate: RDF::Vocab::DC.description, object: @collection.description),
       RDF::Statement(subject: self_subject, predicate: RDF::Vocab::DC.accessRights, object: @collection.visibility),
       RDF::Statement(subject: self_subject, predicate: TERMS[:ual].restricted_collection,
                      object: @collection.restricted),
@@ -25,6 +24,10 @@ class Aip::V1::CollectionsController < ApplicationController
       RDF::Statement(subject: self_subject, predicate: TERMS[:ual].record_created_in_jupiter,
                      object: @collection.record_created_at)
     ]
+    if @collection.description.present?
+      statements << RDF::Statement(subject: self_subject, predicate: RDF::Vocab::DC.description,
+                                   object: @collection.description)
+    end
 
     rdf_graph_creator.graph.insert(*statements)
 

--- a/test/controllers/aip/v1/aip_collections_controller_test.rb
+++ b/test/controllers/aip/v1/aip_collections_controller_test.rb
@@ -67,4 +67,22 @@ class Aip::V1::CollectionsControllerTest < ActionDispatch::IntegrationTest
     assert_equal rendered_graph, graph
   end
 
+  test 'should get collection metadata graph with n3 serialization even when description is markdown' do
+    # specifically we want to make sure that any URLs are preserved
+    @collection.assign_attributes(description: '[Collection description](https://example.com)')
+    @collection.save!
+    sign_in_as_system_user
+    get aip_v1_collection_url(
+      id: @collection
+    )
+    assert_response :success
+
+    graph = generate_graph_from_n3(response.body)
+    rendered_graph = load_n3_graph(
+      file_fixture('n3/collections/a93cbb63-4bb2-4deb-a952-c96c4c851c8c_markdown_description.n3')
+    )
+
+    assert_equal rendered_graph, graph
+  end
+
 end

--- a/test/controllers/aip/v1/aip_collections_controller_test.rb
+++ b/test/controllers/aip/v1/aip_collections_controller_test.rb
@@ -50,4 +50,21 @@ class Aip::V1::CollectionsControllerTest < ActionDispatch::IntegrationTest
     assert_equal rendered_graph, graph
   end
 
+  test 'should get collection metadata graph with n3 serialization even when description is nil' do
+    @collection.assign_attributes(description: nil)
+    @collection.save!
+    sign_in_as_system_user
+    get aip_v1_collection_url(
+      id: @collection
+    )
+    assert_response :success
+
+    graph = generate_graph_from_n3(response.body)
+    rendered_graph = load_n3_graph(
+      file_fixture('n3/collections/a93cbb63-4bb2-4deb-a952-c96c4c851c8c_nil_description.n3')
+    )
+
+    assert_equal rendered_graph, graph
+  end
+
 end

--- a/test/fixtures/files/n3/collections/a93cbb63-4bb2-4deb-a952-c96c4c851c8c_markdown_description.n3
+++ b/test/fixtures/files/n3/collections/a93cbb63-4bb2-4deb-a952-c96c4c851c8c_markdown_description.n3
@@ -1,0 +1,13 @@
+@prefix dc: <http://purl.org/dc/terms/> .
+@prefix pcdm: <http://pcdm.org/models#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<http://era.ualberta.localhost/aip/v1/collections/a93cbb63-4bb2-4deb-a952-c96c4c851c8c> a pcdm:Collection;
+    dc:title "AIP Collection";
+    dc:description "[Collection description](https://example.com)";
+    pcdm:memberOf "b644bf7f-d950-56bb-ba68-c4271a175491";
+    dc:accessRights "http://terms.library.ualberta.ca/public";
+    dc:created "2015-12-12T00:00:00Z"^^xsd:dateTime;
+    <http://terms.library.ualberta.ca/recordCreatedInJupiter> "2015-12-12T00:00:00Z"^^xsd:dateTime;
+    <http://terms.library.ualberta.ca/restrictedCollection> false .

--- a/test/fixtures/files/n3/collections/a93cbb63-4bb2-4deb-a952-c96c4c851c8c_nil_description.n3
+++ b/test/fixtures/files/n3/collections/a93cbb63-4bb2-4deb-a952-c96c4c851c8c_nil_description.n3
@@ -1,0 +1,12 @@
+@prefix dc: <http://purl.org/dc/terms/> .
+@prefix pcdm: <http://pcdm.org/models#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<http://era.ualberta.localhost/aip/v1/collections/a93cbb63-4bb2-4deb-a952-c96c4c851c8c> a pcdm:Collection;
+    dc:title "AIP Collection";
+    pcdm:memberOf "b644bf7f-d950-56bb-ba68-c4271a175491";
+    dc:accessRights "http://terms.library.ualberta.ca/public";
+    dc:created "2015-12-12T00:00:00Z"^^xsd:dateTime;
+    <http://terms.library.ualberta.ca/recordCreatedInJupiter> "2015-12-12T00:00:00Z"^^xsd:dateTime;
+    <http://terms.library.ualberta.ca/restrictedCollection> false .


### PR DESCRIPTION
## Context

After running the rake task to enqueue all the collections and communities we received many errors like: `ArgumentError: Statement #<RDF::Statement:0x9808(<http://era.ualberta.localhost/aip/v1/collections/a93cbb63-4bb2-4deb-a952-c96c4c851c8c> <http://purl.org/dc/terms/description> nil .)> is incomplete`

274 of our collections have no description.
Related to #3117

## What's New
If there is no description than we can leave out the statement about description.

Also added a test that demonstrates that markdown will not be stripped or rendered by the AIP api.
