### PR TITLE
Update dependabot.yml for npm updates to use correct `javascript` label

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,7 +32,7 @@ updates:
     target-branch: master
     labels:
       - "dependencies"
-      - "ruby"
+      - "javascript"
   - package-ecosystem: github-actions
     directory: "/"
     schedule:


### PR DESCRIPTION
## Context

![image](https://github.com/ualbertalib/jupiter/assets/1930474/12fe7f0a-e8ab-41a3-afe3-e249f39e64f5)

As the screenshot above shows, our javascript dependabot PRs are being opened with a `ruby` label, this isn't correct.

We have a `javascript` label already, let's use this instead of `ruby`
