### PR TITLE
Fix warning about already initialized constants in rake tests within tests

### DIFF
--- a/test/integration/add_to_preservation_queue_task_test.rb
+++ b/test/integration/add_to_preservation_queue_task_test.rb
@@ -2,11 +2,11 @@ require 'test_helper'
 require 'rake'
 require 'application_system_test_case'
 
-Rails.application.load_tasks
-
 class AddToPreservationQueueTaskTest < ApplicationSystemTestCase
 
   setup do
+    Jupiter::Application.load_tasks if Rake::Task.tasks.empty?
+
     @admin = users(:user_admin)
     login_user(@admin)
 

--- a/test/integration/read_only_mode_integration_test.rb
+++ b/test/integration/read_only_mode_integration_test.rb
@@ -1,10 +1,11 @@
 require 'test_helper'
 require 'rake'
-Rails.application.load_tasks
 
 class ReadOnlyModeIntegrationTest < ActionDispatch::IntegrationTest
 
   setup do
+    Jupiter::Application.load_tasks if Rake::Task.tasks.empty?
+
     Announcement.destroy_all
   end
 


### PR DESCRIPTION

## Context

Our test output was polluting the console with the following warnings:
```
/jupiter/lib/tasks/batch_ingest.rake:1: warning: already initialized constant INGEST_REPORTS_LOCATION
/jupiter/lib/tasks/batch_ingest.rake:1: warning: previous definition of INGEST_REPORTS_LOCATION was here
/jupiter/lib/tasks/batch_ingest.rake:2: warning: already initialized constant INDEX_OFFSET
/jupiter/lib/tasks/batch_ingest.rake:2: warning: previous definition of INDEX_OFFSET was here
```

Appears we were loading the same rake tasks multiple times, which attempts to redefine the CONSTANTS in batch_ingest.rake file.

We can simply just load our rake tasks in our tests in a smarter fashion. Load them once, and don't load them again if they are already loaded.
