### PR TITLE
Update Dockerfile.deployment

### DIFF
--- a/Dockerfile.deployment
+++ b/Dockerfile.deployment
@@ -1,4 +1,4 @@
-FROM ruby:3.0
+FROM ruby:3.1
 LABEL maintainer="University of Alberta Library"
 
 # Need to add jessie-backports repo so we can get FFMPEG, doesn't come with jessie debian by default


### PR DESCRIPTION
Failing in [Docker Hub](https://hub.docker.com/repository/registry-1.docker.io/ualbertalib/jupiter/builds/5dadf316-f813-468a-b87c-33012b57bcd6) builds

## Context

![image](https://github.com/ualbertalib/jupiter/assets/1220762/dd735753-2132-4093-90f8-941d9a9fb8f2)
![image](https://github.com/ualbertalib/jupiter/assets/1220762/5fbde3d1-9b62-41c4-8353-2624dac01452)

## What's New

Update the ruby version being used in the Dockerfile.deployment file.