### PR TITLE
Bump version of ffi to 1.16.3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -219,7 +219,7 @@ GEM
     faraday-http-cache (2.5.0)
       faraday (>= 0.8)
     faraday-net_http (3.0.2)
-    ffi (1.16.2)
+    ffi (1.16.3)
     flipper (1.0.0)
       brow (~> 0.4.1)
       concurrent-ruby (< 2)


### PR DESCRIPTION
Neil was having C compiling errors when bulding the release image which was due to FFI

Appears this is a known issue in FFI on centos: https://github.com/ffi/ffi/issues/1052

It is apparently fixed in v1.16.3
