### PR TITLE
Change the target community for theses ingestion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,10 @@ New entries in this file should aim to provide a meaningful amount of informatio
 ## [Unreleased]
 
 ### Chores
-- Bump rubocop-rails from 2.24.1 to 2.25.0 [PR#3475](https://github.com/ualbertalib/jupiter/pull/3475)
+* Bump rubocop-rails from 2.24.1 to 2.25.0 [PR#3475](https://github.com/ualbertalib/jupiter/pull/3475)
+
+### Changed
+* Modified the target destination for ingested theses [#3495](https://github.com/ualbertalib/jupiter/issues/3495) 
 
 ## [2.9.1] - 2024-05-16
 

--- a/lib/tasks/batch_ingest.rake
+++ b/lib/tasks/batch_ingest.rake
@@ -292,7 +292,7 @@ def generate_checksums(csv_directory)
 end
 
 def thesis_community_id
-  Community.where(title: 'Graduate Studies and Research, Faculty of').first.id
+  Community.where(title: 'Graduate and Postdoctoral Studies (GPS), Faculty of').first.id
 end
 
 def thesis_collection_id


### PR DESCRIPTION
The previous rake task required the target community to be called
"Graduate Studies and Research, Faculty of". This changes the target
community to "Graduate and Postdoctoral Studies (GPS), Faculty of" which is the current community that will receive the theses for ingestion.

## Context

A new community will recevie the ingested theses due to a change in name for the faculty. We need to change the target name in the code to complete this task.


Related to #3495

## What's New

Changed the string for checking community name in rake task.