### PR TITLE
docker compose command has changed, updated to newest command

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -19,7 +19,7 @@ jobs:
           node-version: 18
 
       - name: Build the docker-compose stack
-        run: docker-compose up -d
+        run: docker compose up -d
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1


### PR DESCRIPTION
Seeing some fails on recent pull requests for our CI pipeline due to:
![image](https://github.com/user-attachments/assets/2e9edc44-6863-4257-aa87-1465b281bdf2)

`docker-compose` command has been deprecated for a while, perhaps GitHub has updated their docker on their CI servers to a later version where this command no longer exists.

We should be using `docker compose` instead for now on.