### PR TITLE
Prepare for 2.10.0 minor release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@ New entries in this file should aim to provide a meaningful amount of informatio
 
 ## [Unreleased]
 
-## [2.9.3] - 2024-06-13
+## [2.10.0] - Unreleased
+
+:warning: Updated requirement **Node.js** 18.15.0+
 
 ### CVE fixes
 * Bump ruby-saml from 1.15.0 to 1.17.0 - [CVE-2024-45409](https://github.com/advisories/GHSA-jw9c-mfg7-9rx2) [PR#3565](https://github.com/ualbertalib/jupiter/pull/3564)
@@ -65,6 +67,15 @@ New entries in this file should aim to provide a meaningful amount of informatio
 * Bump pundit from 2.3.2 to 2.4.0 by @dependabot in https://github.com/ualbertalib/jupiter/pull/3549
 * Bump selenium-webdriver from 4.23.0 to 4.24.0 by @dependabot in https://github.com/ualbertalib/jupiter/pull/3550
 * Update CHANGELOG.md by @pgwillia in https://github.com/ualbertalib/jupiter/pull/3501
+
+## [2.9.3] - 2024-09-11
+
+:warning: this tag based off the nodejs_16 branch as main was not compatible with the hosting infrastructure and a timely release was required.
+
+### CVE fixes
+* Bump ruby-saml from 1.15.0 to 1.17.0 - [CVE-2024-45409](https://github.com/advisories/GHSA-jw9c-mfg7-9rx2) [PR#3565](https://github.com/ualbertalib/jupiter/pull/3564)
+
+
 
 ## [2.9.2] - 2024-06-13
 

--- a/lib/jupiter/version.rb
+++ b/lib/jupiter/version.rb
@@ -1,5 +1,5 @@
 module Jupiter::Version
   def self.version_info
-    '2.9.3'.freeze
+    '2.10.0'.freeze
   end
 end


### PR DESCRIPTION
Prepare for 2.10.0 minor release that requires NodeJS 18

Edit changelog to document the rollback of the 2.9.3 release (refactor the changelog). The main branch required NodeJS 18 while the infrastructure required NodeJS 16 therefore release 2.9.3 was pulled back and based off tag 2.9.2 instead of the main branch to facilitate the security patch requiring the 2.9.3 release.  
