### PR TITLE
Pin ubuntu to 22.04

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -3,7 +3,7 @@ on: [push, pull_request]
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     strategy:
       matrix:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ New entries in this file should aim to provide a meaningful amount of informatio
 
 ## [Unreleased]
 
+### Changed
+* Pin ubuntu to 22.04 for stability through the end of the project [#3676](https://github.com/ualbertalib/jupiter/issues/3676)
+
 ## 2.10.1 - 2024-10-30
 
 ### Added 


### PR DESCRIPTION
## Context

For stability through to the end of the project.  latest doesn't have ImageMagick.

Related to #3676 

## What's New

Pin GitHub actions to ubuntu 22.04