### PR TITLE
bump bundler to match lastest in production and build environments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ New entries in this file should aim to provide a meaningful amount of informatio
 
 ## [Unreleased]
 
+### Chores
+* Bump bundler in Gemfile.lock to match production and build environments 
+
 ## 2.10.2 - 2025-01-15
 
 ### Changed

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -719,4 +719,4 @@ RUBY VERSION
    ruby 3.1.4p223
 
 BUNDLED WITH
-   2.5.6
+   2.6.3


### PR DESCRIPTION
## Context

[Gemfile.lock](https://github.com/ualbertalib/jupiter/blob/d1b96d89bcb2553d53eb8f8be62f269f485206bb/Gemfile.lock#L722) is bundled with 2.5.6.  Historically it's updated when there's a problem with bundler in production.

[The RPM build process](https://monitor.library.ualberta.ca/unixDoc/Change/2025/Q1/CR00001229_build2.txt) has a different bundler version installed and is used to `bundle install` gems.  This would change Gemfile.lock bundled with, but the version we package is from the git repo.  Later in the install script the latest version of bundler, 2.6.3, is installed but not immediately used.

Install RPM on era-app-prd-4.  When `bundle exec rake assets:precompile` is run it fails with "Could not find mini_portile2-2.8.8 in locally installed gems (Bundler::GemNotFound)"
Running `bundle install` on era-app-prd-4 fixes the problem and the playbook runs to completion.

## What's New

Bump bundler in Gemfile.lock to match latest in production and build environments