### PR TITLE
Remove brakeman's ruby EOL check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ New entries in this file should aim to provide a meaningful amount of informatio
 
 ## [Unreleased]
 
+### Changed
+* skip brakeman Remove brakeman's ruby EOL check
+
 ### Chores
 * Bump bundler in Gemfile.lock to match production and build environments 
 

--- a/config/brakeman.yml
+++ b/config/brakeman.yml
@@ -2,4 +2,5 @@
 :run_all_checks: true
 :skip_checks:
         - CheckUnscopedFind
+        - CheckEOLRuby
 :github_repo: ualbertalib/jupiter


### PR DESCRIPTION
## Context

Temporary so that CI passes in case we need security release.  Also working on bump to Ruby 3.4

Related to #3697 

## What's New

Instruct brakeman to skip CheckEOLRuby