### PR TITLE
Silence deprecation warnings when running tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ New entries in this file should aim to provide a meaningful amount of informatio
 
 ### Changed
 * skip brakeman Remove brakeman's ruby EOL check
+* silence deprecation warnings when running tests
 
 ### Chores
 * Bump bundler in Gemfile.lock to match production and build environments 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -44,7 +44,7 @@ Rails.application.configure do
   config.action_mailer.delivery_method = :test
 
   # Print deprecation notices to the stderr.
-  config.active_support.deprecation = :stderr
+  config.active_support.deprecation = :silence
 
   # Raise exceptions for disallowed deprecations.
   config.active_support.disallowed_deprecation = :raise


### PR DESCRIPTION
## Context

It was becoming difficult to see the signal in the noise.  Unfortunately, we know we won't fix deprecations as this project enters the end of its life.

Related to https://github.com/ualbertalib/jupiter/actions/runs/13292499330/job/37116459963?pr=3689

## What's New

Silence deprecation warnings when running tests.