### PR TITLE
Bumps flipper from 1.3.2 to 1.3.4.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,7 +54,7 @@ gem 'datacite-client', github: 'ualbertalib/datacite-client', tag: 'v0.1.0', req
 gem 'differ' # Used to diff two strings
 gem 'draper'
 gem 'edtf', '~> 3.2' # parsing Extended Date/Time Format
-gem 'flipper', '~> 1.3.2' # Feature flags for Ruby
+gem 'flipper', '~> 1.3.4' # Feature flags for Ruby
 gem 'flipper-active_record', '~> 1.3.4' # Store feature flags in ActiveRecord
 gem 'flipper-ui', '~> 1.3.4' # UI for feature flags
 gem 'jbuilder' # generate JSON objects

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -675,7 +675,7 @@ DEPENDENCIES
   edtf (~> 3.2)
   erb_lint (>= 0.0.35)
   faker
-  flipper (~> 1.3.2)
+  flipper (~> 1.3.4)
   flipper-active_record (~> 1.3.4)
   flipper-ui (~> 1.3.4)
   google-api-client


### PR DESCRIPTION
Dependabot was being difficult here (https://github.com/ualbertalib/jupiter/pull/3737) so I just updated this myself

Flipper works as expected given we currently do not have features behind features. Full test of ERA worked as expected. No breaking changes.

> Bumps [flipper](https://github.com/flippercloud/flipper) from 1.3.2 to 1.3.4.
> 
> Release notes
> _Sourced from [flipper's releases](https://github.com/flippercloud/flipper/releases)._
> 
> > ## v1.3.3
> > ## What's Changed
> > 
> > * Make redis and redis cache work with connection pool by [`@​jnunemaker`](https://github.com/jnunemaker) in [flippercloud/flipper#910](https://redirect.github.com/flippercloud/flipper/pull/910)
> > * Big pass on escaping and urls by [`@​jnunemaker`](https://github.com/jnunemaker) in [flippercloud/flipper#911](https://redirect.github.com/flippercloud/flipper/pull/911)
> > * Generate a default initializer by [`@​bkeepers`](https://github.com/bkeepers) in [flippercloud/flipper#815](https://redirect.github.com/flippercloud/flipper/pull/815)
> > * Add pstore gem for ruby 3.3.x by [`@​jnunemaker`](https://github.com/jnunemaker) in [flippercloud/flipper#898](https://redirect.github.com/flippercloud/flipper/pull/898)
> > * Relax sanitize version constraint by [`@​ur5us`](https://github.com/ur5us) in [flippercloud/flipper#903](https://redirect.github.com/flippercloud/flipper/pull/903)
> > * Use reject(&:nil?) in enabled? check by [`@​stevecrozz`](https://github.com/stevecrozz) in [flippercloud/flipper#887](https://redirect.github.com/flippercloud/flipper/pull/887)
> > 
> > ### cloud only
> > 
> > * Chill Out the Backoff Policy for Telemetry by [`@​jnunemaker`](https://github.com/jnunemaker) in [flippercloud/flipper#908](https://redirect.github.com/flippercloud/flipper/pull/908)
> > * Poll cold start fix by [`@​jnunemaker`](https://github.com/jnunemaker) in [flippercloud/flipper#795](https://redirect.github.com/flippercloud/flipper/pull/795)
> > 
> > ### flipper dev related only
> > 
> > * Add funding_uri to metadata.rb by [`@​andrew`](https://github.com/andrew) in [flippercloud/flipper#900](https://redirect.github.com/flippercloud/flipper/pull/900)
> > * Bump supercharge/mongodb-github-action from 1.11.0 to 1.12.0 by [`@​dependabot`](https://github.com/dependabot) in [flippercloud/flipper#902](https://redirect.github.com/flippercloud/flipper/pull/902)
> > * Fix all the warnings and turn them on for CI by [`@​jnunemaker`](https://github.com/jnunemaker) in [flippercloud/flipper#912](https://redirect.github.com/flippercloud/flipper/pull/912)
> > 
> > ## New Contributors
> > 
> > * [`@​ur5us`](https://github.com/ur5us) made their first contribution in [flippercloud/flipper#903](https://redirect.github.com/flippercloud/flipper/pull/903)
> > * [`@​andrew`](https://github.com/andrew) made their first contribution in [flippercloud/flipper#900](https://redirect.github.com/flippercloud/flipper/pull/900)
> > * [`@​stevecrozz`](https://github.com/stevecrozz) made their first contribution in [flippercloud/flipper#887](https://redirect.github.com/flippercloud/flipper/pull/887)
> > 
> > **Full Changelog**: [flippercloud/flipper@v1.3.2...v1.3.3](https://github.com/flippercloud/flipper/compare/v1.3.2...v1.3.3)