### PR TITLE
Make Collection and its member objects read-only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ New entries in this file should aim to provide a meaningful amount of informatio
 * pin chrome so ci passes [3764](https://github.com/ualbertalib/jupiter/issues/3764)
 
 ### Added
-* read_only behavior to items, thesis and collection [[#3758](https://github.com/ualbertalib/jupiter/issues/3758)]
+* read_only behavior to items, thesis and collection [#3758](https://github.com/ualbertalib/jupiter/issues/3758)
 
 ## 2.10.3 - 2025-03-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ New entries in this file should aim to provide a meaningful amount of informatio
 ### Changed
 * pin chrome so ci passes [3764](https://github.com/ualbertalib/jupiter/issues/3764)
 
+### Added
+* read_only behavior to items and thesis [[#3758](https://github.com/ualbertalib/jupiter/issues/3758)]
+
 ## 2.10.3 - 2025-03-06
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ New entries in this file should aim to provide a meaningful amount of informatio
 
 ### Added
 * read_only behavior to items, thesis and collection [#3758](https://github.com/ualbertalib/jupiter/issues/3758)
+* rake task to freeze collection, item or collections [#3758](https://github.com/ualbertalib/jupiter/issues/3758)
 
 ## 2.10.3 - 2025-03-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ New entries in this file should aim to provide a meaningful amount of informatio
 
 ### Added
 * read_only behavior to items, thesis and collection [#3758](https://github.com/ualbertalib/jupiter/issues/3758)
-* rake task to freeze collection, item or collections [#3758](https://github.com/ualbertalib/jupiter/issues/3758)
+* rake task to freeze collection, item or collections, or to unfreeze everything [#3758](https://github.com/ualbertalib/jupiter/issues/3758)
 
 ## 2.10.3 - 2025-03-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ New entries in this file should aim to provide a meaningful amount of informatio
 * pin chrome so ci passes [3764](https://github.com/ualbertalib/jupiter/issues/3764)
 
 ### Added
-* read_only behavior to items and thesis [[#3758](https://github.com/ualbertalib/jupiter/issues/3758)]
+* read_only behavior to items, thesis and collection [[#3758](https://github.com/ualbertalib/jupiter/issues/3758)]
 
 ## 2.10.3 - 2025-03-06
 

--- a/README.md
+++ b/README.md
@@ -280,3 +280,20 @@ Jupiter comes with a handy rake task for batch ingesting items/theses.
 Batch ingest for items can now also be done via the admin dashboard. There is a new tab called "Batch ingest" where you can create a new batch ingest by providing a manifest file and files from Google Drive.
 
 For more info about this admin batch ingest screen and how to configure it, [please see the documentation in DI internal](https://github.com/ualbertalib/di_internal/blob/main/Applications/Jupiter/Batch_Ingest/README.md)
+
+## Freeze Collections
+
+To freeze a single collection
+```shell
+rails jupiter:freeze_collection['5de1de5f-8905-4dad-b509-16a469119c0a']
+```
+
+To freeze a list of collections from a file called collections.txt
+```shell
+rails jupiter:freeze_collections['collections.txt']
+```
+
+To freeze a single item
+```shell
+rails jupiter:freeze_item['5ff7ea1a-6883-4981-a1fc-bf1da720b93e']
+```

--- a/README.md
+++ b/README.md
@@ -297,3 +297,8 @@ To freeze a single item
 ```shell
 rails jupiter:freeze_item['5ff7ea1a-6883-4981-a1fc-bf1da720b93e']
 ```
+
+To unfreeze all collections
+```shell
+rails jupiter:unfreeze_all
+```

--- a/app/controllers/admin/collections_controller.rb
+++ b/app/controllers/admin/collections_controller.rb
@@ -27,8 +27,8 @@ class Admin::CollectionsController < Admin::AdminController
   def edit
     return unless @collection.read_only?
 
-    redirect_to admin_community_collection_path(@community, @collection),
-                alert: 'This item is frozen and cannot be edited.'
+    flash[:alert] = t('.read_only')
+    redirect_to admin_community_collection_path(@community, @collection)
   end
 
   def create

--- a/app/controllers/admin/collections_controller.rb
+++ b/app/controllers/admin/collections_controller.rb
@@ -24,7 +24,12 @@ class Admin::CollectionsController < Admin::AdminController
     @collection = Collection.new(community_id: @community.id)
   end
 
-  def edit; end
+  def edit
+    return unless @collection.read_only?
+
+    redirect_to admin_community_collection_path(@community, @collection),
+                alert: 'This item is frozen and cannot be edited.'
+  end
 
   def create
     @collection =

--- a/app/controllers/admin/items_controller.rb
+++ b/app/controllers/admin/items_controller.rb
@@ -14,6 +14,8 @@ class Admin::ItemsController < Admin::AdminController
       Thesis.find(params[:id])
     end
 
+    return redirect_to item_path @item, alert: 'This item is frozen and cannot be edited.' if @item.read_only?
+
     begin
       @item.destroy!
       flash[:notice] = t('.deleted')

--- a/app/controllers/admin/items_controller.rb
+++ b/app/controllers/admin/items_controller.rb
@@ -14,7 +14,10 @@ class Admin::ItemsController < Admin::AdminController
       Thesis.find(params[:id])
     end
 
-    return redirect_to item_path @item, alert: 'This item is frozen and cannot be edited.' if @item.read_only?
+    if @item.read_only?
+      flash[:alert] = t('items.edit.read_only')
+      return redirect_to item_path @item
+    end
 
     begin
       @item.destroy!

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -12,7 +12,9 @@ class ItemsController < ApplicationController
   def edit
     authorize @item
 
-    if @item.is_a? Thesis
+    if @item.read_only?
+      redirect_to item_path @item, alert: 'This item is frozen and cannot be edited.'
+    elsif @item.is_a? Thesis
       draft_thesis = DraftThesis.from_thesis(@item, for_user: current_user)
 
       redirect_to admin_thesis_draft_path(id: Wicked::FIRST_STEP, thesis_id: draft_thesis.id)

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -13,7 +13,8 @@ class ItemsController < ApplicationController
     authorize @item
 
     if @item.read_only?
-      redirect_to item_path @item, alert: 'This item is frozen and cannot be edited.'
+      flash[:alert] = t('.read_only')
+      redirect_to item_path @item
     elsif @item.is_a? Thesis
       draft_thesis = DraftThesis.from_thesis(@item, for_user: current_user)
 

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -17,6 +17,7 @@ class Collection < JupiterCore::Depositable
   end
 
   after_save :push_entity_for_preservation
+  after_save :update_member_objects_read_only
 
   # We have no attachments, so the scope is just the class itself.
   def self.eager_attachment_scope; self; end
@@ -52,6 +53,12 @@ class Collection < JupiterCore::Depositable
     errors.add(:member_objects, :must_be_empty,
                list_of_objects: member_objects.map(&:title).join(', '))
     throw(:abort)
+  end
+
+  def update_member_objects_read_only
+    member_objects.each do |member_object|
+      member_object.update(read_only: read_only)
+    end
   end
 
 end

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -57,7 +57,13 @@ class Collection < JupiterCore::Depositable
 
   def update_member_objects_read_only
     member_objects.each do |member_object|
-      member_object.update(read_only: read_only)
+      # Check if the object belongs to any other collections marked as read_only
+      other_read_only_collections = []
+      member_object.each_community_collection do |_, collection|
+        other_read_only_collections << collection if collection.read_only? && collection != self
+      end
+      # Only update read_only to false if no other collections are read_only
+      member_object.update(read_only: read_only) if read_only || other_read_only_collections.empty?
     end
   end
 

--- a/app/models/concerns/draft_properties.rb
+++ b/app/models/concerns/draft_properties.rb
@@ -116,6 +116,8 @@ module DraftProperties
           errors.add(:member_of_paths, :collection_not_found)
         elsif collection.community_id != community.id
           errors.add(:member_of_paths, :collection_not_in_community)
+        elsif collection.read_only?
+          errors.add(:member_of_paths, :collection_read_only)
         end
       end
     end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -308,6 +308,7 @@ en:
         created: 'Collection was successfully created!'
       edit:
         header: 'Edit %{title}'
+        read_only: 'This collection is frozen and cannot be edited.'
       update:
         updated: 'Collection was successfully updated!'
       destroy:
@@ -625,6 +626,7 @@ en:
       header: 'Items'
     edit:
       header: 'Edit Item'
+      read_only: 'This item is frozen and cannot be edited.'
     update:
       updated: 'Item was successfully updated!'
     show:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -151,6 +151,7 @@ en:
               community_not_found: "Community can't be found"
               collection_not_found: "Collection can't be found"
               collection_not_in_community: "Collection not in community"
+              collection_read_only: "Collection is frozen and not available for deposit"
               collection_restricted: "Deposit is restricted for this collection"
             files:
               infected: '%{filename} is infected with a virus'
@@ -162,6 +163,7 @@ en:
               community_not_found: "Community can't be found"
               collection_not_found: "Collection can't be found"
               collection_not_in_community: "Collection not in community"
+              collection_read_only: "Collection is frozen and not available for deposit"
               collection_restricted: "Deposit is restricted for this collection"
             files:
               infected: '%{filename} is infected with a virus'

--- a/db/migrate/20250312221142_add_read_only_to_items_theses_and_collections.rb
+++ b/db/migrate/20250312221142_add_read_only_to_items_theses_and_collections.rb
@@ -1,0 +1,7 @@
+class AddReadOnlyToItemsThesesAndCollections < ActiveRecord::Migration[7.1]
+  def change
+    add_column :items, :read_only, :boolean, default: false
+    add_column :theses, :read_only, :boolean, default: false
+    add_column :collections, :read_only, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_03_27_203605) do
+ActiveRecord::Schema[7.1].define(version: 2025_03_12_221142) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -103,6 +103,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_27_203605) do
     t.boolean "restricted", default: false, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "read_only", default: false
     t.index ["owner_id"], name: "index_collections_on_owner_id"
   end
 
@@ -385,6 +386,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_27_203605) do
     t.datetime "updated_at", null: false
     t.json "subject", array: true
     t.bigint "batch_ingest_id"
+    t.boolean "read_only", default: false
     t.index ["batch_ingest_id"], name: "index_items_on_batch_ingest_id"
     t.index ["logo_id"], name: "index_items_on_logo_id"
     t.index ["owner_id"], name: "index_items_on_owner_id"
@@ -450,6 +452,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_27_203605) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.json "subject", array: true
+    t.boolean "read_only", default: false
     t.index ["logo_id"], name: "index_theses_on_logo_id"
     t.index ["owner_id"], name: "index_theses_on_owner_id"
   end

--- a/lib/tasks/freeze_collection.rake
+++ b/lib/tasks/freeze_collection.rake
@@ -1,0 +1,24 @@
+namespace :jupiter do
+  desc 'freeze a collection by setting read_only to true'
+  task :freeze_collection, [:collection] => :environment do |_t, args|
+    collection = Collection.find(args[:collection])
+    collection.read_only = true
+    collection.save!
+  end
+
+  desc 'freeze a set of collections from a file by setting read_only to true'
+  task :freeze_collections, [:filename] => :environment do |_t, args|
+    File.open(args[:filename]).each do |collection_id|
+      collection = Collection.find(collection_id.strip)
+      collection.read_only = true
+      collection.save!
+    end
+  end
+
+  desc 'freeze a item by setting read_only to true'
+  task :freeze_item, [:item] => :environment do |_t, args|
+    item = Item.find(args[:item])
+    item.read_only = true
+    item.save!
+  end
+end

--- a/lib/tasks/freeze_collection.rake
+++ b/lib/tasks/freeze_collection.rake
@@ -15,10 +15,17 @@ namespace :jupiter do
     end
   end
 
-  desc 'freeze a item by setting read_only to true'
+  desc 'freeze an item by setting read_only to true'
   task :freeze_item, [:item] => :environment do |_t, args|
     item = Item.find(args[:item])
     item.read_only = true
     item.save!
+  end
+
+  desc 'unfreeze all collections'
+  task :unfreeze_all, [] => :environment do |_t, args|
+    Collection.find_each do |collection|
+      collection.update!(read_only: false)
+    end
   end
 end

--- a/lib/tasks/freeze_collection.rake
+++ b/lib/tasks/freeze_collection.rake
@@ -23,7 +23,7 @@ namespace :jupiter do
   end
 
   desc 'unfreeze all collections'
-  task :unfreeze_all, [] => :environment do |_t, args|
+  task :unfreeze_all, [] => :environment do |_t, _args|
     Collection.find_each do |collection|
       collection.update!(read_only: false)
     end

--- a/test/controllers/admin/collections_controller_test.rb
+++ b/test/controllers/admin/collections_controller_test.rb
@@ -53,7 +53,7 @@ class Admin::CollectionsControllerTest < ActionDispatch::IntegrationTest
     get edit_admin_community_collection_url(@community, @collection)
 
     assert_redirected_to admin_community_collection_url(@community, @collection)
-    assert_equal 'This item is frozen and cannot be edited.', flash[:alert]
+    assert_equal 'This collection is frozen and cannot be edited.', flash[:alert]
 
     @collection.read_only = false
     @collection.save!

--- a/test/controllers/admin/collections_controller_test.rb
+++ b/test/controllers/admin/collections_controller_test.rb
@@ -46,6 +46,19 @@ class Admin::CollectionsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  test 'shouldnt edit read_only collection' do
+    @collection.read_only = true
+    @collection.save!
+
+    get edit_admin_community_collection_url(@community, @collection)
+
+    assert_redirected_to admin_community_collection_url(@community, @collection)
+    assert_equal 'This item is frozen and cannot be edited.', flash[:alert]
+
+    @collection.read_only = false
+    @collection.save!
+  end
+
   test 'update collection when given valid information' do
     patch admin_community_collection_url(@community, @collection),
           params: { collection: { title: 'Updated collection' } }

--- a/test/controllers/admin/collections_controller_test.rb
+++ b/test/controllers/admin/collections_controller_test.rb
@@ -53,7 +53,7 @@ class Admin::CollectionsControllerTest < ActionDispatch::IntegrationTest
     get edit_admin_community_collection_url(@community, @collection)
 
     assert_redirected_to admin_community_collection_url(@community, @collection)
-    assert_equal 'This collection is frozen and cannot be edited.', flash[:alert]
+    assert_equal I18n.t('admin.collections.edit.read_only'), flash[:alert]
 
     @collection.read_only = false
     @collection.save!

--- a/test/controllers/admin/items_controller_test.rb
+++ b/test/controllers/admin/items_controller_test.rb
@@ -34,7 +34,7 @@ class Admin::ItemsControllerTest < ActionDispatch::IntegrationTest
     delete admin_item_url(@item)
 
     assert_redirected_to item_path @item
-    assert_equal 'This item is frozen and cannot be edited.', flash[:alert]
+    assert_equal I18n.t('items.edit.read_only'), flash[:alert]
 
     @item.read_only = false
     @item.save!

--- a/test/controllers/admin/items_controller_test.rb
+++ b/test/controllers/admin/items_controller_test.rb
@@ -33,7 +33,8 @@ class Admin::ItemsControllerTest < ActionDispatch::IntegrationTest
 
     delete admin_item_url(@item)
 
-    assert_redirected_to item_path @item, alert: 'This item is frozen and cannot be edited.'
+    assert_redirected_to item_path @item
+    assert_equal 'This item is frozen and cannot be edited.', flash[:alert]
 
     @item.read_only = false
     @item.save!

--- a/test/controllers/admin/items_controller_test.rb
+++ b/test/controllers/admin/items_controller_test.rb
@@ -27,6 +27,18 @@ class Admin::ItemsControllerTest < ActionDispatch::IntegrationTest
     assert_equal I18n.t('admin.items.destroy.deleted'), flash[:notice]
   end
 
+  test 'shouldnt destroy read_only item' do
+    @item.read_only = true
+    @item.save!
+
+    delete admin_item_url(@item)
+
+    assert_redirected_to item_path @item, alert: 'This item is frozen and cannot be edited.'
+
+    @item.read_only = false
+    @item.save!
+  end
+
   test 'reset DOI should queue job' do
     assert_no_enqueued_jobs only: DOIRemoveJob
     Rails.application.secrets.doi_minting_enabled = true

--- a/test/controllers/items_controller_test.rb
+++ b/test/controllers/items_controller_test.rb
@@ -91,7 +91,7 @@ class ItemsControllerTest < ActionDispatch::IntegrationTest
     get edit_item_url(@item)
 
     assert_redirected_to item_path @item
-    assert_equal 'This item is frozen and cannot be edited.', flash[:alert]
+    assert_equal I18n.t('items.edit.read_only'), flash[:alert]
 
     @item.read_only = false
     @item.save!

--- a/test/controllers/items_controller_test.rb
+++ b/test/controllers/items_controller_test.rb
@@ -90,7 +90,8 @@ class ItemsControllerTest < ActionDispatch::IntegrationTest
     sign_in_as @admin
     get edit_item_url(@item)
 
-    assert_redirected_to item_path @item, alert: 'This item is frozen and cannot be edited.'
+    assert_redirected_to item_path @item
+    assert_equal 'This item is frozen and cannot be edited.', flash[:alert]
 
     @item.read_only = false
     @item.save!

--- a/test/controllers/items_controller_test.rb
+++ b/test/controllers/items_controller_test.rb
@@ -83,4 +83,17 @@ class ItemsControllerTest < ActionDispatch::IntegrationTest
     assert_equal [1, 0], Statistics.for(item_id: @item.id)
   end
 
+  test 'shouldnt be able to edit an item if its read_only' do
+    @item.read_only = true
+    @item.save!
+
+    sign_in_as @admin
+    get edit_item_url(@item)
+
+    assert_redirected_to item_path @item, alert: 'This item is frozen and cannot be edited.'
+
+    @item.read_only = false
+    @item.save!
+  end
+
 end

--- a/test/fixtures/collections.yml
+++ b/test/fixtures/collections.yml
@@ -35,3 +35,19 @@ collection_fancier:
   community: community_fancy
   record_created_at: <%= Time.zone.now - 1.hour %>
   date_ingested: <%= Time.zone.now - 1.hour %>
+
+collection_read_only:
+  title: 'Read Only Collection'
+  owner: user_admin
+  community: community_books
+  record_created_at: <%= Time.zone.now - 1.hour %>
+  date_ingested: <%= Time.zone.now - 1.hour %>
+  read_only: true
+
+collection_another_read_only:
+  title: 'Another Read Only Collection'
+  owner: user_admin
+  community: community_books
+  record_created_at: <%= Time.zone.now - 1.hour %>
+  date_ingested: <%= Time.zone.now - 1.hour %>
+  read_only: true

--- a/test/integration/add_to_preservation_queue_task_test.rb
+++ b/test/integration/add_to_preservation_queue_task_test.rb
@@ -29,7 +29,7 @@ class AddToPreservationQueueTaskTest < ActionDispatch::IntegrationTest
         Community.first.save!
         Rake::Task['jupiter:preserve_all_collections_and_communities'].execute(after_date_arguments)
 
-        # the communiy, collection and four items all have save actions that trigger the preservation step
+        # the community, collection and four items all have save actions that trigger the preservation step
         assert_equal 6, Jupiter::Redis.current.zcard(Rails.application.secrets.preservation_queue_name)
       end
     end

--- a/test/integration/add_to_preservation_queue_task_test.rb
+++ b/test/integration/add_to_preservation_queue_task_test.rb
@@ -29,7 +29,8 @@ class AddToPreservationQueueTaskTest < ActionDispatch::IntegrationTest
         Community.first.save!
         Rake::Task['jupiter:preserve_all_collections_and_communities'].execute(after_date_arguments)
 
-        assert_equal 2, Jupiter::Redis.current.zcard(Rails.application.secrets.preservation_queue_name)
+        # the communiy, collection and four items all have save actions that trigger the preservation step
+        assert_equal 6, Jupiter::Redis.current.zcard(Rails.application.secrets.preservation_queue_name)
       end
     end
   end

--- a/test/models/collection_test.rb
+++ b/test/models/collection_test.rb
@@ -58,4 +58,22 @@ class CollectionTest < ActiveSupport::TestCase
     assert_predicate item, :read_only?
   end
 
+  test 'should not set read only to false if object belongs to other read_only collections' do
+    collection1 = collections(:collection_read_only)
+    collection2 = collections(:collection_another_read_only)
+    item = items(:item_fancy)
+
+    # Add the item to both collections
+    item.add_to_path(collection1.community_id, collection1.id)
+    item.add_to_path(collection2.community_id, collection2.id)
+    item.read_only = true
+    item.save!
+
+    # Attempt to set read_only to false in one collection
+    collection1.update(read_only: false)
+
+    # Ensure the item's read_only remains true because of the other collection
+    assert item.reload.read_only
+  end
+
 end

--- a/test/models/collection_test.rb
+++ b/test/models/collection_test.rb
@@ -44,4 +44,18 @@ class CollectionTest < ActiveSupport::TestCase
                            id: community_id)
   end
 
+  test 'after_save read_only callback' do
+    collection = collections(:collection_fancy)
+    item = items(:item_fancy)
+
+    assert_not item.read_only?
+
+    collection.read_only = true
+    collection.save!
+
+    item.reload
+
+    assert_predicate item, :read_only?
+  end
+
 end

--- a/test/models/draft_item_test.rb
+++ b/test/models/draft_item_test.rb
@@ -212,13 +212,6 @@ class DraftItemTest < ActiveSupport::TestCase
 
     @collection.read_only = true
     @collection.save!
-    Collection.create!(title: 'Risque fantasy Books',
-                       owner_id: user.id,
-                       restricted: true,
-                       community_id: @community.id)
-    draft_item.assign_attributes(
-      member_of_paths: { community_id: [@community.id], collection_id: [@collection.id] }
-    )
 
     assert_not draft_item.valid?
     assert_equal ['Collection is frozen and not available for deposit'], draft_item.errors.messages[:member_of_paths]

--- a/test/models/draft_item_test.rb
+++ b/test/models/draft_item_test.rb
@@ -210,6 +210,21 @@ class DraftItemTest < ActiveSupport::TestCase
 
     assert_predicate draft_item, :valid?
 
+    @collection.read_only = true
+    @collection.save!
+    frozen_collection = Collection.create!(title: 'Risque fantasy Books',
+                                           owner_id: user.id,
+                                           restricted: true,
+                                           community_id: @community.id)
+    draft_item.assign_attributes(
+      member_of_paths: { community_id: [@community.id], collection_id: [@collection.id] }
+    )
+
+    assert_not draft_item.valid?
+    assert_equal ['Collection is frozen and not available for deposit'], draft_item.errors.messages[:member_of_paths]
+    @collection.read_only = false
+    @collection.save!
+
     # Regular user can't deposit to a restricted collection
     restricted_collection = Collection.create!(title: 'Risque fantasy Books',
                                                owner_id: user.id,

--- a/test/models/draft_item_test.rb
+++ b/test/models/draft_item_test.rb
@@ -212,10 +212,10 @@ class DraftItemTest < ActiveSupport::TestCase
 
     @collection.read_only = true
     @collection.save!
-    frozen_collection = Collection.create!(title: 'Risque fantasy Books',
-                                           owner_id: user.id,
-                                           restricted: true,
-                                           community_id: @community.id)
+    Collection.create!(title: 'Risque fantasy Books',
+                       owner_id: user.id,
+                       restricted: true,
+                       community_id: @community.id)
     draft_item.assign_attributes(
       member_of_paths: { community_id: [@community.id], collection_id: [@collection.id] }
     )


### PR DESCRIPTION
## Context

As we work through the Scholaris migration, we want the ability to freeze one collection, or batches of collections at a time.

Related to #3758 

## What's New

* Database migrations to add `read_only` column
* Change controller to redirect to show page from edit page when `read_only` is set
* Test of the behavior
* CHANGELOG