### PR TITLE
Fix ci

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Setup stable Chrome
         uses: browser-actions/setup-chrome@v1
         with:
-          chrome-version: 133
+          chrome-version: 127
           install-chromedriver: true
           install-dependencies: true
 

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -61,6 +61,15 @@ jobs:
       - name: Run ERBLint
         run: bundle exec erb_lint .
 
+      - name: Remove image-bundled Chrome
+        run: sudo apt-get purge google-chrome-stable
+      - name: Setup stable Chrome
+        uses: browser-actions/setup-chrome@v1
+        with:
+          chrome-version: 133
+          install-chromedriver: true
+          install-dependencies: true
+
       - name: Run Tests
         env:
           RAILS_ENV: test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ New entries in this file should aim to provide a meaningful amount of informatio
 
 ## [Unreleased]
 
+### Changed
+* pin chrome so ci passes [3764](https://github.com/ualbertalib/jupiter/issues/3764)
+
 ## 2.10.3 - 2025-03-06
 
 ### Changed

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -14,13 +14,12 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   if ENV['CHROMIUM_CHROMEDRIVER_PATH']
     Selenium::WebDriver::Chrome::Service.driver_path = proc { ENV.fetch('CHROMIUM_CHROMEDRIVER_PATH', nil) }
   end
+  Selenium::WebDriver::Chrome.path = ENV.fetch('CHROME_BINARY_PATH', nil) if ENV['CHROME_BINARY_PATH']
   if ENV['CAPYBARA_NO_HEADLESS']
     driven_by :selenium, using: :chrome, screen_size: [1400, 1400]
   else
     driven_by :selenium, using: :headless_chrome, screen_size: [1400, 1400]
   end
-  puts page.driver.browser.capabilities[:browser_name]
-  puts page.driver.browser.capabilities[:browser_version]
 
   RANDOM_TITLE = ['Fancy', 'Nice'].freeze
 

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -19,6 +19,8 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   else
     driven_by :selenium, using: :headless_chrome, screen_size: [1400, 1400]
   end
+  puts page.driver.browser.capabilities[:browser_name]
+  puts page.driver.browser.capabilities[:browser_version]
 
   RANDOM_TITLE = ['Fancy', 'Nice'].freeze
 


### PR DESCRIPTION
## Context

On March 12, the CI tests started failing.  Pinning the chrome driver fixes this problem while we investigate. @aaronskiba offered https://github.com/teamcapybara/capybara/issues/2800#issuecomment-2731100953 which worked in DMP context.

Related to #3764 

## What's New

* GitHub actions uses: `browser-actions/setup-chrome@v1` to install a specific chrome version