### PR TITLE
Updates the freeze collection rake task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ New entries in this file should aim to provide a meaningful amount of informatio
 
 ## [Unreleased]
 
+### Changed
+* fixed freeze collection rake tasks [#3758](https://github.com/ualbertalib/jupiter/issues/3758)
+
 ## 2.11.0 - 2025-03-25
 
 ### Changed

--- a/lib/tasks/freeze_collection.rake
+++ b/lib/tasks/freeze_collection.rake
@@ -28,11 +28,14 @@ namespace :jupiter do
 
   desc 'unfreeze all collections'
   task :unfreeze_all, [] => :environment do |_t, _args|
+    # specifically use update_columns to skip validations and avoid performance issues
+    # rubocop:disable Rails/SkipsModelValidations
     Collection.where(read_only: true).find_each do |collection|
       collection.update_columns(read_only: false)
     end
     Item.where(read_only: true).find_each do |item|
       item.update_columns(read_only: false)
     end
+    # rubocop:enable Rails/SkipsModelValidations
   end
 end

--- a/lib/tasks/freeze_collection.rake
+++ b/lib/tasks/freeze_collection.rake
@@ -3,14 +3,19 @@ namespace :jupiter do
   task :freeze_collection, [:collection] => :environment do |_t, args|
     puts 'started freezing collection'
     collection = Collection.find(args[:collection])
+    collection.transaction do
       collection.read_only = true
       collection.save!
       puts 'finished freezing collection'
+    rescue StandardError
+      puts "failed to freeze collection #{args[:collection]}"
+    end
   end
 
   desc 'freeze a set of collections from a file by setting read_only to true'
   task :freeze_collections, [:filename] => :environment do |_t, args|
     puts 'started freezing collections'
+    Collection.transaction do
       File.open(args[:filename]).each do |collection_id|
         collection = Collection.find(collection_id.strip)
         collection.read_only = true
@@ -18,6 +23,9 @@ namespace :jupiter do
         print '.'
       end
       puts 'finished freezing collections'
+    rescue StandardError
+      puts "failed to freeze collection #{collection_id.strip}"
+    end
   end
 
   desc 'freeze an item by setting read_only to true'
@@ -38,6 +46,7 @@ namespace :jupiter do
     # specifically use update_columns to skip validations and avoid performance issues
     # rubocop:disable Rails/SkipsModelValidations
     puts 'started unfreezing collections'
+    Collection.transaction do
       Collection.where(read_only: true).find_each do |collection|
         collection.update_columns(read_only: false)
         print '.'
@@ -49,6 +58,9 @@ namespace :jupiter do
         print '.'
       end
       puts 'finished unfreezing items'
+    rescue StandardError
+      puts 'failed to unfreeze all'
+    end
     # rubocop:enable Rails/SkipsModelValidations
   end
 end

--- a/lib/tasks/freeze_collection.rake
+++ b/lib/tasks/freeze_collection.rake
@@ -17,15 +17,22 @@ namespace :jupiter do
 
   desc 'freeze an item by setting read_only to true'
   task :freeze_item, [:item] => :environment do |_t, args|
-    item = Item.find(args[:item])
+    item = begin
+      Item.find(args[:item])
+    rescue ActiveRecord::RecordNotFound
+      Thesis.find(args[:item])
+    end
     item.read_only = true
     item.save!
   end
 
   desc 'unfreeze all collections'
   task :unfreeze_all, [] => :environment do |_t, _args|
-    Collection.find_each do |collection|
-      collection.update!(read_only: false)
+    Collection.where(read_only: true).find_each do |collection|
+      collection.update_columns(read_only: false)
+    end
+    Item.where(read_only: true).find_each do |item|
+      item.update_columns(read_only: false)
     end
   end
 end

--- a/lib/tasks/freeze_collection.rake
+++ b/lib/tasks/freeze_collection.rake
@@ -1,22 +1,28 @@
 namespace :jupiter do
   desc 'freeze a collection by setting read_only to true'
   task :freeze_collection, [:collection] => :environment do |_t, args|
+    puts 'started freezing collection'
     collection = Collection.find(args[:collection])
-    collection.read_only = true
-    collection.save!
+      collection.read_only = true
+      collection.save!
+      puts 'finished freezing collection'
   end
 
   desc 'freeze a set of collections from a file by setting read_only to true'
   task :freeze_collections, [:filename] => :environment do |_t, args|
-    File.open(args[:filename]).each do |collection_id|
-      collection = Collection.find(collection_id.strip)
-      collection.read_only = true
-      collection.save!
-    end
+    puts 'started freezing collections'
+      File.open(args[:filename]).each do |collection_id|
+        collection = Collection.find(collection_id.strip)
+        collection.read_only = true
+        collection.save!
+        print '.'
+      end
+      puts 'finished freezing collections'
   end
 
   desc 'freeze an item by setting read_only to true'
   task :freeze_item, [:item] => :environment do |_t, args|
+    puts 'started freezing item'
     item = begin
       Item.find(args[:item])
     rescue ActiveRecord::RecordNotFound
@@ -24,18 +30,25 @@ namespace :jupiter do
     end
     item.read_only = true
     item.save!
+    puts 'finished freezing item'
   end
 
   desc 'unfreeze all collections'
   task :unfreeze_all, [] => :environment do |_t, _args|
     # specifically use update_columns to skip validations and avoid performance issues
     # rubocop:disable Rails/SkipsModelValidations
-    Collection.where(read_only: true).find_each do |collection|
-      collection.update_columns(read_only: false)
-    end
-    Item.where(read_only: true).find_each do |item|
-      item.update_columns(read_only: false)
-    end
+    puts 'started unfreezing collections'
+      Collection.where(read_only: true).find_each do |collection|
+        collection.update_columns(read_only: false)
+        print '.'
+      end
+      puts 'finished unfreezing collections'
+      puts 'started unfreezing items'
+      Item.where(read_only: true).find_each do |item|
+        item.update_columns(read_only: false)
+        print '.'
+      end
+      puts 'finished unfreezing items'
     # rubocop:enable Rails/SkipsModelValidations
   end
 end


### PR DESCRIPTION


## Context
@ConnorSheremeta noticed deficiencies when testing the 2.11.0 deployment in the staging environment.

Related to # (issue)

## What's New
* Ability to freeze individual theses.
* More performant unfreeze all by focusing on only the objects that are set to read_only and skipping callbacks.